### PR TITLE
RSE-297: Add the Awards Category to the CG extends Option Group

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class CRM_CiviAwards_Helper_CaseTypeCategory.
+ */
+class CRM_CiviAwards_Helper_CaseTypeCategory {
+
+  const AWARDS_CASE_TYPE_CATEGORY_NAME = 'awards';
+
+  /**
+   * Returns the case types for the awards category.
+   *
+   * @return array
+   *   Array of Case Types indexed by Id.
+   */
+  public static function getAwardCaseTypes() {
+    $result = civicrm_api3('CaseType', 'get', [
+      'return' => ['title', 'id'],
+      'case_type_category' => self::AWARDS_CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    return array_column($result['values'], 'title', 'id');
+  }
+
+}

--- a/CRM/CiviAwards/Setup/AddAwardsCgExtendsOptionValue.php
+++ b/CRM/CiviAwards/Setup/AddAwardsCgExtendsOptionValue.php
@@ -1,0 +1,36 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Class CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue.
+ */
+class CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue {
+
+  const AWARDS_CATEGORY_CG_LABEL = 'Case (Awards)';
+
+  /**
+   * Add Awards as a valid Entity that a custom group can extend.
+   */
+  public function apply() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => self::AWARDS_CATEGORY_CG_LABEL,
+    ]);
+
+    if ($result['count'] > 0) {
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_case',
+      'label' => self::AWARDS_CATEGORY_CG_LABEL,
+      'value' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      'description' => 'CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes;',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Setup/CreateAwardsCaseCategoryOption.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsCaseCategoryOption.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
 /**
  * Class CreateAwardsCategoryOptionValue.
  */
@@ -11,7 +13,7 @@ class CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption {
   public function apply() {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'case_type_categories',
-      'name' => 'Awards',
+      'name' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
       'label' => 'Awards',
       'is_default' => 1,
       'is_active' => TRUE,

--- a/CRM/CiviAwards/Setup/DeleteAwardsCgExtendsOption.php
+++ b/CRM/CiviAwards/Setup/DeleteAwardsCgExtendsOption.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue as AddAwardsCgExtendsOptionValue;
+
+/**
+ * Class CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOptionValue.
+ */
+class CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption {
+
+  /**
+   * Deletes the Awards option from the CG Extends option values.
+   */
+  public function apply() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'label' => AddAwardsCgExtendsOptionValue::AWARDS_CATEGORY_CG_LABEL,
+      'option_group_id' => 'cg_extend_objects',
+    ]);
+
+    if ($result['count'] == 0) {
+      return;
+    }
+
+    CRM_Core_BAO_OptionValue::del($result['values'][0]['id']);
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -1,7 +1,9 @@
 <?php
 
 use CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption as CreateAwardsCaseCategoryOption;
+use CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue as AddAwardsCgExtendsOptionValue;
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
+use CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption as DeleteAwardsCgExtendsOption;
 
 /**
  * Collection of upgrade steps.
@@ -14,6 +16,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
   public function install() {
     $steps = [
       new CreateAwardsCaseCategoryOption(),
+      new AddAwardsCgExtendsOptionValue(),
     ];
 
     foreach ($steps as $step) {
@@ -27,6 +30,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
   public function uninstall() {
     $steps = [
       new DeleteAwardsCaseCategoryOption(),
+      new DeleteAwardsCgExtendsOption(),
     ];
 
     foreach ($steps as $step) {


### PR DESCRIPTION
## Overview
This PR adds the Awards Case type category to the Core `cg_extend_objects` option group. This will enable us to add custom fields that extend case types for this category.

## Before
This functionality was not present.

## After
- Custom groups can now be added for the Award Case type category.

<img width="1219" alt="New Custom Field Set  case-prospect 2019-09-02 18-43-16" src="https://user-images.githubusercontent.com/6951813/64129046-9be6a400-cdb1-11e9-850e-5ca7941cd47e.png">
