### PR TITLE
RSE-299: Create Awards Permissions.

### DIFF
--- a/civiawards.php
+++ b/civiawards.php
@@ -152,8 +152,8 @@ function civiawards_civicrm_themes(&$themes) {
  * Implements hook_civicrm_permission().
  */
 function civiawards_civicrm_permission(&$permissions) {
-  $permissionService = new CaseCategoryPermission(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
-  $caseCategoryPermissions = $permissionService->get();
+  $permissionService = new CaseCategoryPermission();
+  $caseCategoryPermissions = $permissionService->get(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
 
   // Add basic permissions set from civicase extension.
   foreach ($caseCategoryPermissions as $caseCategoryPermission) {

--- a/civiawards.php
+++ b/civiawards.php
@@ -5,9 +5,6 @@
  * Extension file.
  */
 
-use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
-use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryhelper;
-
 require_once 'civiawards.civix.php';
 
 /**
@@ -152,17 +149,6 @@ function civiawards_civicrm_themes(&$themes) {
  * Implements hook_civicrm_permission().
  */
 function civiawards_civicrm_permission(&$permissions) {
-  $permissionService = new CaseCategoryPermission();
-  $caseCategoryPermissions = $permissionService->get(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
-
-  // Add basic permissions set from civicase extension.
-  foreach ($caseCategoryPermissions as $caseCategoryPermission) {
-    $permissions[$caseCategoryPermission['name']] = [
-      $caseCategoryPermission['label'],
-      ts($caseCategoryPermission['description']),
-    ];
-  }
-
   // Add permission defined by this extension.
   $permissions['access awards panel portal'] = [
     'CiviAwards: Access awards panel portal',

--- a/civiawards.php
+++ b/civiawards.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @file
+ * Extension file.
+ */
+
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryhelper;
+
 require_once 'civiawards.civix.php';
 
 /**
@@ -140,30 +148,29 @@ function civiawards_civicrm_themes(&$themes) {
   _civiawards_civix_civicrm_themes($themes);
 }
 
-// --- Functions below this ship commented out. Uncomment as required. ---
-
 /**
- * Implements hook_civicrm_preProcess().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
- *
- * function civiawards_civicrm_preProcess($formName, &$form) {
- *
- * } // */
+ * Implements hook_civicrm_permission().
+ */
+function civiawards_civicrm_permission(&$permissions) {
+  $permissionService = new CaseCategoryPermission(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
+  $caseCategoryPermissions = $permissionService->get();
 
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
- *
- * function civiawards_civicrm_navigationMenu(&$menu) {
- * _civiawards_civix_insert_navigation_menu($menu, 'Mailings', array(
- * 'label' => E::ts('New subliminal message'),
- * 'name' => 'mailing_subliminal_message',
- * 'url' => 'civicrm/mailing/subliminal',
- * 'permission' => 'access CiviMail',
- * 'operator' => 'OR',
- * 'separator' => 0,
- * ));
- * _civiawards_civix_navigationMenu($menu);
- * } // */
+  // Add basic permissions set from civicase extension.
+  foreach ($caseCategoryPermissions as $caseCategoryPermission) {
+    $permissions[$caseCategoryPermission['name']] = [
+      $caseCategoryPermission['label'],
+      ts($caseCategoryPermission['description']),
+    ];
+  }
+
+  // Add permission defined by this extension.
+  $permissions['access awards panel portal'] = [
+    'CiviAwards: Access awards panel portal',
+    ts('Allows a user to access the awards panel portal'),
+  ];
+
+  $permissions['access applicant portal'] = [
+    'CiviAwards: Access applicant portal',
+    ts('Allows a user to access the awards applicant portal'),
+  ];
+}


### PR DESCRIPTION
## Overview
This PR adds the permissions defined by the Civi Awards extensions.

## Before
- These permissions were not present.

## After
- The permissions added are:

1. CiviAwards: Access awards panel portal
2. CiviAwards: Access applicant portal