### PR TITLE
RSE-349: Install "Applicant Review" Activity type and custom field set

### DIFF
--- a/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Class CreateApplicantReviewActivityType.
+ */
+class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
+
+  /**
+   * Adds the Applicant review activity type and category.
+   */
+  public function apply() {
+    $this->addApplicantReviewCategory();
+    $this->addApplicantReviewActivityType();
+  }
+
+  /**
+   * Adds the applicant review activity category.
+   */
+  private function addApplicantReviewCategory() {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_category',
+      'name' => 'Applicant Review',
+      'label' => 'Applicant Review',
+      'is_default' => 1,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * Adds the applicant review activity type.
+   */
+  private function addApplicantReviewActivityType() {
+    $civicaseComponent = CRM_Core_Component::get('CiviCase');
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_type',
+      'name' => 'Applicant Review',
+      'label' => 'Applicant Review',
+      'grouping' => 'Applicant Review',
+      'icon' => 'fa-user',
+      'component_id' => !empty($civicaseComponent->componentID) ? $civicaseComponent->componentID : '',
+      'is_default' => 1,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Setup/DeleteApplicantReviewCustomField.php
+++ b/CRM/CiviAwards/Setup/DeleteApplicantReviewCustomField.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class DeleteApplicantReviewCustomField.
+ */
+class CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField {
+
+  /**
+   * Deletes the Applicant review custom group set.
+   */
+  public function apply() {
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'name' => 'Applicant_Review',
+    ]);
+
+    if (empty($result['id'])) {
+      return;
+    }
+
+    civicrm_api3('CustomGroup', 'delete', [
+      'id' => $result['id'],
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -5,11 +5,19 @@ use CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue as AddAwardsCgExtendsOpti
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption as DeleteAwardsCgExtendsOption;
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
+use CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField as DeleteApplicantReviewCustomField;
 
 /**
  * Collection of upgrade steps.
  */
 class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
+
+  /**
+   * A list of directories to be scanned for XML installation files.
+   *
+   * @var array
+   */
+  private $xmlDirectories = ['custom_fields'];
 
   /**
    * Custom extension installation logic.
@@ -24,6 +32,24 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     foreach ($steps as $step) {
       $step->apply();
     }
+
+    $this->processXmlInstallationFiles();
+  }
+
+  /**
+   * Scans all the directories in $xmlDirectories for installation files.
+   *
+   * (xml files ending with _install.xml) and processes them.
+   */
+  private function processXmlInstallationFiles() {
+    foreach ($this->xmlDirectories as $directory) {
+      $files = glob($this->extensionDir . "/xml/{$directory}/*_install.xml");
+      if (is_array($files)) {
+        foreach ($files as $file) {
+          $this->executeCustomDataFileByAbsPath($file);
+        }
+      }
+    }
   }
 
   /**
@@ -33,6 +59,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     $steps = [
       new DeleteAwardsCaseCategoryOption(),
       new DeleteAwardsCgExtendsOption(),
+      new DeleteApplicantReviewCustomField(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -4,6 +4,7 @@ use CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption as CreateAwardsCaseCateg
 use CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue as AddAwardsCgExtendsOptionValue;
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption as DeleteAwardsCgExtendsOption;
+use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 
 /**
  * Collection of upgrade steps.
@@ -17,6 +18,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     $steps = [
       new CreateAwardsCaseCategoryOption(),
       new AddAwardsCgExtendsOptionValue(),
+      new CreateApplicantReviewActivityType(),
     ];
 
     foreach ($steps as $step) {

--- a/xml/custom_fields/applicant_review_install.xml
+++ b/xml/custom_fields/applicant_review_install.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+  <CustomGroups>
+    <CustomGroup>
+      <name>Applicant_Review</name>
+      <title>Applicant Review</title>
+      <extends>Activity</extends>
+      <extends_entity_column_value_option_group>activity_type</extends_entity_column_value_option_group>
+      <extends_entity_column_value>Applicant Review</extends_entity_column_value>
+      <style>Inline</style>
+      <collapse_display>1</collapse_display>
+      <help_pre></help_pre>
+      <help_post></help_post>
+      <weight>4</weight>
+      <is_active>1</is_active>
+      <table_name>civicrm_value_applicant_rev_6</table_name>
+      <is_multiple>0</is_multiple>
+      <collapse_adv_display>0</collapse_adv_display>
+      <created_date>2019-10-17 17:23:12</created_date>
+      <is_reserved>0</is_reserved>
+      <is_public>1</is_public>
+    </CustomGroup>
+  </CustomGroups>
+</CustomData>


### PR DESCRIPTION
## Overview
This PR adds the Applicant review activity category, Applicant review activity type and the applicant review custom field.

## Before
The Applicant review activity category, activity type and custom field does not exist.

## After
This PR installs the Applicant Custom field which extends the Activity Entity for the Applicant Review activity type. The Applicant review activity type itself is of the Applicant review category

The Custom field set is installed empty as the Site administrator will add custom fields later.