### PR TITLE
RSE-492: Create award type option group.

### DIFF
--- a/CRM/CiviAwards/Setup/CreateAwardTypeOptionGroup.php
+++ b/CRM/CiviAwards/Setup/CreateAwardTypeOptionGroup.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup.
+ */
+class CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup {
+
+  /**
+   * Award option group name.
+   *
+   * @var string
+   */
+  private $awardOptionGroupName = 'civiawards_award_type';
+
+  /**
+   * Creates the Awards Type option group with default values.
+   */
+  public function apply() {
+    $this->createOptionGroupForAwardType();
+    $this->createOptionValuesForAwardType();
+  }
+
+  /**
+   * Creates the award type option group.
+   */
+  private function createOptionGroupForAwardType() {
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => $this->awardOptionGroupName,
+      'title' => ts('Award Types'),
+      'is_reserved' => 1,
+    ]);
+  }
+
+  /**
+   * Creates default option values for award type option group.
+   */
+  private function createOptionValuesForAwardType() {
+    $optionValues = [
+      'medal',
+      'prize',
+      'programme',
+      'scholarship',
+      'award',
+      'grant',
+    ];
+
+    foreach ($optionValues as $optionValue) {
+      CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+        'option_group_id' => $this->awardOptionGroupName,
+        'name' => $optionValues,
+        'label' => ucfirst($optionValue),
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+      ]);
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -4,6 +4,7 @@ use CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption as CreateAwardsCaseCateg
 use CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue as AddAwardsCgExtendsOptionValue;
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption as DeleteAwardsCgExtendsOption;
+use CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup as CreateAwardTypeOptionGroup;
 
 /**
  * Collection of upgrade steps.
@@ -17,6 +18,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     $steps = [
       new CreateAwardsCaseCategoryOption(),
       new AddAwardsCgExtendsOptionValue(),
+      new CreateAwardTypeOptionGroup(),
     ];
 
     foreach ($steps as $step) {


### PR DESCRIPTION
## Overview
This PR adds the Award Type option group with default option values.

## Before
This option group does not exist.

## After
The option group is created

<img width="1227" alt="Option Groups  case-prospect 2019-10-25 14-38-29" src="https://user-images.githubusercontent.com/6951813/67576145-efcc9400-f735-11e9-8001-ac8ec3d07c13.png">
