### PR TITLE
RSE-351: Implement Awards Word Replacement

### DIFF
--- a/CRM/CiviAwards/Setup/AddAwardsCategoryWordReplacement.php
+++ b/CRM/CiviAwards/Setup/AddAwardsCategoryWordReplacement.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Class CRM_CiviAwards_Setup_AddAwardsCategoryWordReplacement.
+ */
+class CRM_CiviAwards_Setup_AddAwardsCategoryWordReplacement {
+
+  /**
+   * Creates the Awards word replacement option value.
+   */
+  public function apply() {
+    $optionName = CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME . "_word_replacement";
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'case_type_category_word_replacement_class',
+      'name' => $optionName,
+      'label' => $optionName,
+      'value' => 'CRM_CiviAwards_WordReplacement_AwardsCategory',
+      'is_default' => 1,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -7,6 +7,7 @@ use CRM_CiviAwards_Setup_DeleteAwardsCgExtendsOption as DeleteAwardsCgExtendsOpt
 use CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup as CreateAwardTypeOptionGroup;
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 use CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField as DeleteApplicantReviewCustomField;
+use CRM_CiviAwards_Setup_AddAwardsCategoryWordReplacement as AddAwardsCategoryWordReplacement;
 
 /**
  * Collection of upgrade steps.
@@ -29,6 +30,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new AddAwardsCgExtendsOptionValue(),
       new CreateAwardTypeOptionGroup(),
       new CreateApplicantReviewActivityType(),
+      new AddAwardsCategoryWordReplacement(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/WordReplacement/AwardsCategory.php
+++ b/CRM/CiviAwards/WordReplacement/AwardsCategory.php
@@ -1,0 +1,18 @@
+<?php
+use CRM_CiviAwards_ExtensionUtil as ExtensionUtil;
+/**
+ * Class AwardsCategory.
+ */
+class CRM_CiviAwards_WordReplacement_AwardsCategory implements CRM_Civicase_WordReplacement_BaseInterface {
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   *   Returns the word replacements
+   */
+  public function get() {
+    $configFile = CRM_Core_Resources::singleton()
+      ->getPath(ExtensionUtil::LONG_NAME, 'config/word_replacement/awards_category.php');
+    return include $configFile;
+  }
+}

--- a/config/word_replacement/awards_category.php
+++ b/config/word_replacement/awards_category.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Returns the words to be replaced and the replacement words.
+ */
+return [
+  'Case' => 'Award',
+  'Cases' => 'Awards',
+  'case' => 'award',
+  'cases' => 'awards',
+];


### PR DESCRIPTION
## Overview
We need to add the word replacement config file for awards so that on dashboard and manage cases page word replacements are done.

## Before
Function did not exists before
![RSE-351-Before](https://user-images.githubusercontent.com/6951813/64013962-e8fc1900-cb18-11e9-9fbd-03a6e58d122a.png)

## After
![RSE-351-After](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-351-after.png)

## Technical Details
Implemented a class `CRM_CiviAwards_WordReplacement_AwardsCategory` that implements the CRM_Civicase_WordReplacement_BaseInterface and provides a method that returns the word replacements array.
```php
return [
  'Case' => 'Award',
  'Cases' => 'Awards',
  'case' => 'award',
  'cases' => 'awards',
];
```
This `CRM_CiviAwards_WordReplacement_AwardsCategory` is added via an option value to the `case_type_category_word_replacement_class` option group so that Civicase knows the class to call for word replacements for prospect category related pages.