### PR TITLE
CPS-25: Fix error after disabling extension

### DIFF
--- a/CRM/CiviAwards/Setup/AddAwardsCgExtendsOptionValue.php
+++ b/CRM/CiviAwards/Setup/AddAwardsCgExtendsOptionValue.php
@@ -11,6 +11,9 @@ class CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue {
 
   /**
    * Add Awards as a valid Entity that a custom group can extend.
+   *
+   * We also update the description just incase the module was
+   * disabled before uninstallation.
    */
   public function apply() {
     $result = civicrm_api3('OptionValue', 'get', [
@@ -19,6 +22,8 @@ class CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue {
     ]);
 
     if ($result['count'] > 0) {
+      $this->toggleOptionValueStatus(TRUE);
+
       return;
     }
 
@@ -30,6 +35,35 @@ class CRM_CiviAwards_Setup_AddAwardsCgExtendsOptionValue {
       'description' => 'CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes;',
       'is_active' => TRUE,
       'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * Enables/Disables the Awards option values.
+   *
+   * The method also updates the Option Value 'description' to empty when the
+   * extension is disabled. Because the 'description' is dynamically loaded,
+   * this helps prevent the fatal error that is thrown when Civi tries
+   * to load a class from a disabled extension.
+   *
+   * @param bool $newStatus
+   *   True to enable, False to disable.
+   */
+  public function toggleOptionValueStatus($newStatus) {
+    $optionValueDescription = (
+      $newStatus ?
+        'CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes;' :
+          ''
+    );
+
+    civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => self::AWARDS_CATEGORY_CG_LABEL,
+      'api.OptionValue.create' => [
+        'id' => '$value.id',
+        'description' => $optionValueDescription,
+        'is_active' => $newStatus,
+      ],
     ]);
   }
 

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -142,4 +142,24 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     return ltrim($file, '_');
   }
 
+  /**
+   * Action triggered when extension is enabled.
+   *
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   */
+  public function enable() {
+    $awardsCgExtendsOptionValue = new AddAwardsCgExtendsOptionValue();
+    $awardsCgExtendsOptionValue->toggleOptionValueStatus(TRUE);
+  }
+
+  /**
+   * Action triggered when extension is disabled.
+   *
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   */
+  public function disable() {
+    $awardsCgExtendsOptionValue = new AddAwardsCgExtendsOptionValue();
+    $awardsCgExtendsOptionValue->toggleOptionValueStatus(FALSE);
+  }
+
 }


### PR DESCRIPTION
## Overview
When the extension is disabled and you try to access the url `/civicrm/admin/custom/group?reset=1`, an error is displayed as shown in the screenshot below. This PR fixes that. 
  

## Before
![CPS-25-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-25-before.png)

## After
![CPS-25-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-25-after.png)

## Technical Details
The fatal error is caused by the line `'description' => 'CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes;'` in https://github.com/compucorp/uk.co.compucorp.civiawards/blob/e9768872150931263bf1596bf3fa1b68305f8e37/CRM/CiviAwards/Setup/AddAwardsCgExtendsOptionValue.php#L30. When the module is disabled, the module files are not loaded again and when Civi tries to resolve the class  `CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes` to get the description of the Option value and fails to find the class (because it is not loaded), it throws the fatal error.

## Comments
When the extension is disabled, we remove the description and re-add it back when the extension is re-enabled