### PR TITLE
RSE-303: Add CiviAwards menu items

### DIFF
--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -7,14 +7,9 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
 
   /**
    * Creates the Awards menu items.
-   *
-   * @return bool
-   *   returns true when the menu items have been created successfully.
    */
   public function apply() {
     $this->createMenuItems();
-
-    return TRUE;
   }
 
   /**
@@ -37,7 +32,6 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
     $params = [
       'label' => ts('Awards'),
       'name' => 'awards',
-      'url' => NULL,
       'permission_operator' => 'OR',
       'is_active' => 1,
       'permission' => 'access my awards and activities,access all awards and activities',

--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -62,13 +62,6 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts('New Award'),
-        'name' => 'new_award',
-        'url' => 'civicrm/a/#/awards/new',
-        'permission' => 'add awards,access all awards and activities',
-        'permission_operator' => 'OR',
-      ],
-      [
         'label' => ts('Manage Applications'),
         'name' => 'manage_awards_applications',
         'url' => 'civicrm/case/a/?case_type_category=awards#/case/list?cf=%7B%22case_type_category%22:%22awards%22%7D',

--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Creates the menu items for Civi Awards.
+ */
+class CRM_CiviAwards_Setup_CreateAwardsMenus {
+
+  /**
+   * Creates the Awards menu items.
+   *
+   * @return bool
+   *   returns true when the menu items have been created successfully.
+   */
+  public function apply() {
+    $this->createMenuItems();
+
+    return TRUE;
+  }
+
+  /**
+   * Creates Awards Main menu.
+   */
+  private function createMenuItems() {
+    $result = civicrm_api3('Navigation', 'get', ['name' => 'awards']);
+
+    if ($result['count'] > 0) {
+      return;
+    }
+
+    $casesWeight = CRM_Core_DAO::getFieldValue(
+      'CRM_Core_DAO_Navigation',
+      'Cases',
+      'weight',
+      'name'
+    );
+
+    $params = [
+      'label' => ts('Awards'),
+      'name' => 'awards',
+      'url' => NULL,
+      'permission_operator' => 'OR',
+      'is_active' => 1,
+      'permission' => 'access my awards and activities,access all awards and activities',
+      'icon' => 'crm-i fa-folder-open-o',
+    ];
+    $menu = civicrm_api3('Navigation', 'create', $params);
+
+    civicrm_api3('Navigation', 'create', [
+      'id' => $menu['id'],
+      'weight' => $casesWeight + 1,
+    ]);
+    $this->createSubmenus($menu['id']);
+  }
+
+  /**
+   * Creates sub menu items.
+   *
+   * @param int $parentMenuId
+   *   The id for the parent menu containing the sub menu items.
+   */
+  private function createSubmenus($parentMenuId) {
+    $submenus = [
+      [
+        'label' => ts('Dashboard'),
+        'name' => 'awards_dashboard',
+        'url' => '/civicrm/case/a/?case_type_category=awards#/case?case_type_category=awards',
+        'permission' => 'access my awards and activities,access all awards and activities',
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('New Award'),
+        'name' => 'new_award',
+        'url' => 'civicrm/a/#/awards/new',
+        'permission' => 'add awards,access all awards and activities',
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('Manage Applications'),
+        'name' => 'manage_awards_applications',
+        'url' => 'civicrm/case/a/?case_type_category=awards#/case/list?cf=%7B%22case_type_category%22:%22awards%22%7D',
+        'permission' => 'access my awards and activities,access all awards and activities',
+        'permission_operator' => 'OR',
+      ],
+    ];
+
+    foreach ($submenus as $i => $item) {
+      $item['weight'] = $i;
+      $item['parent_id'] = $parentMenuId;
+      $item['is_active'] = 1;
+
+      civicrm_api3('Navigation', 'create', $item);
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -8,6 +8,7 @@ use CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup as CreateAwardTypeOptionGrou
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 use CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField as DeleteApplicantReviewCustomField;
 use CRM_CiviAwards_Setup_AddAwardsCategoryWordReplacement as AddAwardsCategoryWordReplacement;
+use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
 
 /**
  * Collection of upgrade steps.
@@ -31,6 +32,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new CreateAwardTypeOptionGroup(),
       new CreateApplicantReviewActivityType(),
       new AddAwardsCategoryWordReplacement(),
+      new CreateAwardsMenus(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/Upgrader/Steps/Step1001.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1001.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
+
+/**
+ * Upgrader that creates the Civi Awards menu items.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1001 {
+
+  /**
+   * Creates the Awards menu items.
+   *
+   * @return bool
+   *   returns true when the menu items have been created successfully.
+   */
+  public function apply() {
+    $step = new CreateAwardsMenus();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds the Civi Awards menu.

## Before
![Screen Shot 2019-12-02 at 4 26 50 PM](https://user-images.githubusercontent.com/1642119/69992658-90298b80-1520-11ea-9330-60864f57e028.png)

The awards menu does not exist.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/70140580-7183db80-166b-11ea-9620-7fcbb8635340.gif)


## Technical Details
Follows the same pattern as https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/19/files but the permissions are specific to CiviAwards thanks to this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/247
