### PR TITLE
RSE-631: Sets Activity Status 'Scheduled' and 'Completed' for Applicant Review

### DIFF
--- a/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
@@ -11,6 +11,7 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
   public function apply() {
     $this->addApplicantReviewCategory();
     $this->addApplicantReviewActivityType();
+    $this->setApplicantReviewActivityTypeStatuses();
   }
 
   /**
@@ -43,6 +44,32 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
       'is_active' => TRUE,
       'is_reserved' => TRUE,
     ]);
+  }
+
+  /**
+   * Sets activity status 'Scheduled' and 'Completed' for applicant
+   * review activity type if not already set.
+   */
+  private function setApplicantReviewActivityTypeStatuses() {
+    $applicantReviewActivityName = 'Applicant Review';
+    $statuses = civicrm_api3('OptionValue', 'get', [
+      'name' => ['IN' => ['Scheduled', 'Completed']],
+      'option_group_id' => 'activity_status',
+    ])['values'];
+
+    foreach ($statuses as $status) {
+      $groupings = explode(',', $status['grouping']);
+      $index = array_search($applicantReviewActivityName, $groupings);
+      if ($index !== FALSE) {
+        continue;
+      }
+
+      array_push($groupings, $applicantReviewActivityName);
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $status['id'],
+        'grouping' => implode(',', $groupings),
+      ]);
+    }
   }
 
 }

--- a/xml/custom_fields/applicant_review_install.xml
+++ b/xml/custom_fields/applicant_review_install.xml
@@ -4,7 +4,7 @@
   <CustomGroups>
     <CustomGroup>
       <name>Applicant_Review</name>
-      <title>Applicant Review</title>
+      <title>Applicant Review Scoring Fields</title>
       <extends>Activity</extends>
       <extends_entity_column_value_option_group>activity_type</extends_entity_column_value_option_group>
       <extends_entity_column_value>Applicant Review</extends_entity_column_value>


### PR DESCRIPTION
## Overview
This PR sets correct activity status ('Completed' and 'Scheduled') options to be used by new activity category "Applicant Review"

## Before
Action was not present
![RSE-631-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-631-before.png)

## After
![RSE-631-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-631-after.png)

## Technical Details
I added a method in the upgrader to get the statuses `Completed` and `Scheduled` option values and append the name of the activity category `Applicant Review` to the grouping column.

```php
foreach ($statuses as $status) {
  civicrm_api3('OptionValue', 'create', [
    'id' => $status['id'],
    'grouping' => "{$status['grouping']},Applicant Review",
  ]);
}
```

I also added a method to undo the action above in the uninstaller.

```php
foreach ($statuses as $status) {
  $groupings = explode(',', $status['grouping']);
  $index = array_search('Applicant Review', $groupings);
  if ($index === FALSE){
    continue;
  } else {
    unset($groupings[$index]);
  }

  civicrm_api3('OptionValue', 'create', [
    'id' => $status['id'],
    'grouping' => implode(',', $groupings),
  ]);
}
```