### PR TITLE
RSE-657: Add Create Edit Awards Permissions

### DIFF
--- a/civiawards.php
+++ b/civiawards.php
@@ -161,6 +161,11 @@ function civiawards_civicrm_permission(&$permissions) {
     'CiviAwards: Access applicant portal',
     ts('Allows a user to access the awards applicant portal'),
   ];
+
+  $permissions['create/edit awards'] = [
+    'CiviAwards: Create/Edit awards',
+    ts('Allows a user to create or edit awards'),
+  ];
 }
 /**
  * Implements addCiviCaseDependentAngularModules().


### PR DESCRIPTION
## Overview
This PR adds `create/edit` permission for the extension

## Before
Permission did not exists

## After
![RSE-657-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-657-after.png)