### PR TITLE
RSE-372: Save More Information for Each Review Field

### DIFF
--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -97,7 +97,6 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
       return;
     }
 
-    $filteredReviewFields = [];
     foreach ($reviewFields as $reviewFieldOptions) {
       $invalidReviewFieldOptions = [];
       $validReviewFieldOptions = array_filter(
@@ -133,11 +132,7 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
         1 => implode(', ', $invalidReviewFieldOptions),
         2 => implode(', ', $missingReviewFieldOptions),
       ]));
-
-      $filteredReviewFields[] = $validReviewFieldOptions;
     }
-
-    $params['review_fields'] = $filteredReviewFields;
   }
 
 }

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -86,53 +86,10 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    *
    * @throws \Exception
    */
-  private static function validateReviewFields(array &$params) {
-    $reviewFieldsLegalOptions = [
-      'id' => FILTER_VALIDATE_INT,
-      'weight' => FILTER_VALIDATE_INT,
-      'required' => FILTER_VALIDATE_BOOLEAN
-    ];
+  private static function validateReviewFields(array $params) {
     $reviewFields = CRM_Utils_Array::value('review_fields', $params);
-    if (empty($reviewFields)) {
-      return;
-    }
-
-    foreach ($reviewFields as $reviewFieldOptions) {
-      $invalidReviewFieldOptions = [];
-      $validReviewFieldOptions = array_filter(
-        $reviewFieldOptions,
-        function($value, $key) use ($reviewFieldsLegalOptions, &$invalidReviewFieldOptions) {
-          if (!isset($reviewFieldsLegalOptions[$key])) {
-            return FALSE;
-          }
-
-          if (filter_var($value, $reviewFieldsLegalOptions[$key], FILTER_NULL_ON_FAILURE) !== NULL) {
-            return TRUE;
-          }
-          $invalidReviewFieldOptions[] = $key;
-        },
-        ARRAY_FILTER_USE_BOTH
-      );
-      if (count($validReviewFieldOptions) === count($reviewFieldsLegalOptions)) {
-        continue;
-      }
-
-      $missingReviewFieldOptions = array_diff(
-        array_keys($reviewFieldsLegalOptions),
-        array_merge($invalidReviewFieldOptions, array_keys($validReviewFieldOptions))
-      );
-      $exceptionPhrases = [
-        !empty($invalidReviewFieldOptions) ? "invalid values passed for [%1]" : "",
-        !empty($missingReviewFieldOptions) ? "required field" . (
-          count($missingReviewFieldOptions) > 1 ? "s [%2] are" : " [%2] is"
-        ) . " missing" : ""
-      ];
-
-      throw new Exception(ts(implode(' and ', array_filter($exceptionPhrases)), [
-        1 => implode(', ', $invalidReviewFieldOptions),
-        2 => implode(', ', $missingReviewFieldOptions),
-      ]));
-    }
+    $reviewFieldsValidator = new CRM_CiviAwards_Helper_CreateReviewFieldsValidator();
+    $reviewFieldsValidator->validate($reviewFields);
   }
 
 }

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -55,8 +55,9 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    * @param array $params
    *   Parameters.
    */
-  private static function validateParams(array $params) {
+  private static function validateParams(array &$params) {
     self::validateDates($params);
+    self::validateReviewFields($params);
   }
 
   /**
@@ -74,6 +75,69 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
         throw new Exception("Award Start Date must not be greater than the End Date");
       }
     }
+  }
+
+
+  /**
+   * Validates review_field options to ensure legal options are passed.
+   *
+   * @param array $params
+   *  Request Parameters
+   *
+   * @throws \Exception
+   */
+  private static function validateReviewFields(array &$params) {
+    $reviewFieldsLegalOptions = [
+      'id' => FILTER_VALIDATE_INT,
+      'weight' => FILTER_VALIDATE_INT,
+      'required' => FILTER_VALIDATE_BOOLEAN
+    ];
+    $reviewFields = CRM_Utils_Array::value('review_fields', $params);
+    if (empty($reviewFields)) {
+      return;
+    }
+
+    $filteredReviewFields = [];
+    foreach ($reviewFields as $reviewFieldOptions) {
+      $invalidReviewFieldOptions = [];
+      $validReviewFieldOptions = array_filter(
+        $reviewFieldOptions,
+        function($value, $key) use ($reviewFieldsLegalOptions, &$invalidReviewFieldOptions) {
+          if (!isset($reviewFieldsLegalOptions[$key])) {
+            return FALSE;
+          }
+
+          if (filter_var($value, $reviewFieldsLegalOptions[$key], FILTER_NULL_ON_FAILURE) !== NULL) {
+            return TRUE;
+          }
+          $invalidReviewFieldOptions[] = $key;
+        },
+        ARRAY_FILTER_USE_BOTH
+      );
+      if (count($validReviewFieldOptions) === count($reviewFieldsLegalOptions)) {
+        continue;
+      }
+
+      $missingReviewFieldOptions = array_diff(
+        array_keys($reviewFieldsLegalOptions),
+        array_merge($invalidReviewFieldOptions, array_keys($validReviewFieldOptions))
+      );
+      $exceptionPhrases = [
+        !empty($invalidReviewFieldOptions) ? "invalid values passed for [%1]" : "",
+        !empty($missingReviewFieldOptions) ? "required field" . (
+          count($missingReviewFieldOptions) > 1 ? "s [%2] are" : " [%2] is"
+        ) . " missing" : ""
+      ];
+
+      throw new Exception(ts(implode(' and ', array_filter($exceptionPhrases)), [
+        1 => implode(', ', $invalidReviewFieldOptions),
+        2 => implode(', ', $missingReviewFieldOptions),
+      ]));
+
+      $filteredReviewFields[] = $validReviewFieldOptions;
+    }
+
+    $params['review_fields'] = $filteredReviewFields;
   }
 
 }

--- a/CRM/CiviAwards/Helper/CreateReviewFieldsValidator.php
+++ b/CRM/CiviAwards/Helper/CreateReviewFieldsValidator.php
@@ -6,25 +6,25 @@
 class CRM_CiviAwards_Helper_CreateReviewFieldsValidator {
 
   /**
-   * Array of accepted review_fields with their validation filters
+   * Array of accepted review_fields with their validation filters.
    *
    * @var array
    */
   private $reviewFieldsLegalOptions = [
     'id' => FILTER_VALIDATE_INT,
     'weight' => FILTER_VALIDATE_INT,
-    'required' => FILTER_VALIDATE_BOOLEAN
+    'required' => FILTER_VALIDATE_BOOLEAN,
   ];
 
   /**
-   * Array to hold invalid field options
+   * Array to hold invalid field options.
    *
    * @var array
    */
   private $invalidReviewFieldOptions = [];
 
   /**
-   * Array to hold unknown review field options passeed
+   * Array to hold unknown review field options passed.
    *
    * @var array
    */
@@ -34,7 +34,7 @@ class CRM_CiviAwards_Helper_CreateReviewFieldsValidator {
    * Validates review_field options to ensure legal options are passed.
    *
    * @param array $reviewFields
-   *  Review fields
+   *   Review fields.
    *
    * @throws \Exception
    */
@@ -74,12 +74,12 @@ class CRM_CiviAwards_Helper_CreateReviewFieldsValidator {
    * Callback to filter review options.
    *
    * @param string $value
-   *  Value of review field option
+   *   Value of review field option.
    * @param string $key
-   *  Review field option
+   *   Review field option.
    *
-   * @return boolean
-   *  Returns TRUE if option passes validation
+   * @return bool
+   *   Returns TRUE if option passes validation.
    */
   private function reviewFieldOptionsFilter($value, $key) {
     if (!isset($this->reviewFieldsLegalOptions[$key])) {
@@ -102,20 +102,20 @@ class CRM_CiviAwards_Helper_CreateReviewFieldsValidator {
   }
 
   /**
-   * Constructs error message given the missing review field options
+   * Constructs error message given the missing review field options.
    *
    * @param array $missingReviewFieldOptions
-   *  Missing review field options
+   *   Missing review field options.
    *
    * @return string
-   *  Excption message
+   *   Exception message.
    */
   private function getReviewFieldValidationExceptionPhrase(array $missingReviewFieldOptions) {
     $exceptionPhrases = [
       !empty($this->invalidReviewFieldOptions) ? "invalid values passed for [%1]" : "",
       !empty($missingReviewFieldOptions) ? "required field" . (
         count($missingReviewFieldOptions) > 1 ? "s [%2] are" : " [%2] is"
-      ) . " missing" : ""
+      ) . " missing" : "",
     ];
 
     return ucfirst(implode(' and ', array_filter($exceptionPhrases)));

--- a/CRM/CiviAwards/Helper/CreateReviewFieldsValidator.php
+++ b/CRM/CiviAwards/Helper/CreateReviewFieldsValidator.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Class CRM_CiviAwards_Helper_CreateReviewFieldsValidator.
+ */
+class CRM_CiviAwards_Helper_CreateReviewFieldsValidator {
+
+  /**
+   * Array of accepted review_fields with their validation filters
+   *
+   * @var array
+   */
+  private $reviewFieldsLegalOptions = [
+    'id' => FILTER_VALIDATE_INT,
+    'weight' => FILTER_VALIDATE_INT,
+    'required' => FILTER_VALIDATE_BOOLEAN
+  ];
+
+  /**
+   * Array to hold invalid field options
+   *
+   * @var array
+   */
+  private $invalidReviewFieldOptions = [];
+
+  /**
+   * Validates review_field options to ensure legal options are passed.
+   *
+   * @param array $reviewFields
+   *  Review fields
+   *
+   * @throws \Exception
+   */
+  public function validate(array $reviewFields) {
+    if (empty($reviewFields)) {
+      return;
+    }
+
+    foreach ($reviewFields as $reviewFieldOptions) {
+      $validReviewFieldOptions = array_filter($reviewFieldOptions, [
+        $this,
+        'reviewFieldOptionsFilter',
+      ], ARRAY_FILTER_USE_BOTH);
+      if (count($validReviewFieldOptions) === count($this->reviewFieldsLegalOptions)) {
+        continue;
+      }
+
+      $missingReviewFieldOptions = array_diff(
+        array_keys($this->reviewFieldsLegalOptions),
+        array_merge($this->invalidReviewFieldOptions, array_keys($validReviewFieldOptions))
+      );
+      $exceptionPhrase = $this->getReviewFieldOptionsExceptionPhrase($missingReviewFieldOptions);
+
+      throw new Exception(ts($exceptionPhrase, [
+        1 => implode(', ', $this->invalidReviewFieldOptions),
+        2 => implode(', ', $missingReviewFieldOptions),
+      ]));
+    }
+  }
+
+  /**
+   * Callback to filter review options.
+   *
+   * @param string $value
+   *  Value of review field option
+   * @param string $key
+   *  Review field option
+   *
+   * @return boolean
+   */
+  private function reviewFieldOptionsFilter(string $value, string $key) {
+    
+    if (!isset($this->reviewFieldsLegalOptions[$key])) {
+      return FALSE;
+    }
+
+    $options = (
+      $this->reviewFieldsLegalOptions[$key] === FILTER_VALIDATE_BOOLEAN ? FILTER_NULL_ON_FAILURE : [
+        'options' => ['default' => NULL],
+      ]
+    );
+    if (filter_var($value, $this->reviewFieldsLegalOptions[$key], $options) !== NULL) {
+      return TRUE;
+    }
+    $this->invalidReviewFieldOptions[] = $key;
+
+    return FALSE;
+  }
+
+  /**
+   * Constructs error message given the missing review field options
+   *
+   * @param array $missingReviewFieldOptions
+   *  Missing review field options
+   *
+   * @return string
+   */
+  private function getReviewFieldOptionsExceptionPhrase(array $missingReviewFieldOptions) {
+    $exceptionPhrases = [
+      !empty($this->invalidReviewFieldOptions) ? "invalid values passed for [%1]" : "",
+      !empty($missingReviewFieldOptions) ? "required field" . (
+        count($missingReviewFieldOptions) > 1 ? "s [%2] are" : " [%2] is"
+      ) . " missing" : ""
+    ];
+
+    return ucfirst(implode(' and ', array_filter($exceptionPhrases)));
+  }
+
+}

--- a/api/v3/AwardDetail.php
+++ b/api/v3/AwardDetail.php
@@ -20,7 +20,7 @@ function _civicrm_api3_award_detail_create_spec(array &$spec) {
 
   $spec['review_fields'] = [
     'title' => 'Award review fields',
-    'description' => 'An array of Custom field IDs',
+    'description' => 'A two-dimensional array of Custom fields properties. Example [{\'id\': 2, \'required\': true, \'weight\': 14}]',
     'type' => CRM_Utils_Type::T_STRING,
   ];
 }


### PR DESCRIPTION
## Overview
At the moment, only the ID of every review field is saved as part of “AwardDetails“ API.

Now we need support to add “weight“, “required“ fields too.

 

Also there is a bug with existing implementation of “review_fields“. it always returns an extra NULL value. If an award is saved with [“19“, 20”], then the api return [“19”, “20“, ““].

## Before
Action was not preset
![RSE-372-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-372-before.png)

## After
![RSE-372-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-372-after.png)
![RSE-372-after-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-372-after-2.png)

## Technical Details
In the method `createProfileFields` , Instead of expecting just a dimensional array of custom field id, the method now expects a 2-dimensional array in the form `[['id' => 1, 'required' => FALSE, 'weight' => 3]]`. This field will now be used to create the `UFField` entry. 

To show, in the method `getProfileFields` , instead of just iterating over the custom fields and stripping and returning the IDs:
```php
foreach ($result['values'] as $profileField) {
  $customFields[] = [
    'id' => substr($profileField['field_name'], 7),
    'required' => $profileField['is_required'],
    'weight' => $profileField['weight'],
  ];
}
```