### PR TITLE
RSE-366: Add award button

### DIFF
--- a/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
+++ b/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
@@ -7,7 +7,8 @@
         buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
         iconClass: 'add_circle',
         identifier: 'AddAward',
-        label: 'Create new award'
+        label: 'Create new award',
+        weight: 100
       }
     ];
 

--- a/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
+++ b/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
@@ -1,0 +1,16 @@
+(function (angular) {
+  var module = angular.module('civiawards');
+
+  module.config(function (DashboardActionButtonsProvider) {
+    var awardsActionButtons = [
+      {
+        buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
+        iconClass: 'add_circle',
+        identifier: 'AddAward',
+        label: 'Create new award'
+      }
+    ];
+
+    DashboardActionButtonsProvider.addButtons(awardsActionButtons);
+  });
+})(angular);

--- a/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
+++ b/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
@@ -4,7 +4,7 @@
   module.config(function (DashboardActionButtonsProvider) {
     var awardsActionButtons = [
       {
-        buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
+        buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--light',
         iconClass: 'add_circle',
         identifier: 'AddAward',
         label: 'Create new award',

--- a/ang/civiawards/dashboard/services/add-award-dashboard-action-button.service.js
+++ b/ang/civiawards/dashboard/services/add-award-dashboard-action-button.service.js
@@ -1,0 +1,35 @@
+(function (angular, url) {
+  var module = angular.module('civiawards');
+
+  module.service('AddAwardDashboardActionButton', AddAwardDashboardActionButton);
+
+  /**
+   * Handles the visibility and click event for the "Add Award" dashboard action button.
+   *
+   * @param {object} $location the location service
+   */
+  function AddAwardDashboardActionButton ($location) {
+    this.clickHandler = clickHandler;
+    this.isVisible = isVisible;
+
+    /**
+     * Redirects the user to the awards creation screen.
+     */
+    function clickHandler () {
+      var newAwardUrl = url('awards/new');
+
+      $location.url(newAwardUrl);
+    }
+
+    /**
+     * Is only visible on the Awards dashboard.
+     *
+     * @returns {boolean} true when case type category url param is awards
+     */
+    function isVisible () {
+      var urlParams = $location.search();
+
+      return urlParams.case_type_category === 'awards';
+    }
+  }
+})(angular, CRM.url);

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -20,6 +20,7 @@
         var caseTypeConfigUrl = url(AWARD_CONFIG_URL + caseType.id);
 
         DashboardCaseTypeButtonsProvider.addButtons(caseType.name, [{
+          icon: 'fa fa-cog',
           url: caseTypeConfigUrl
         }]);
       });

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -3,9 +3,9 @@
   var AWARDS_CATEGORY_NAME = 'awards';
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
-  module.config(function (CaseTypeProvider, DashboardCaseTypeButtonsProvider) {
+  module.config(function (CaseTypeProvider, CaseTypeCategoryProvider, DashboardCaseTypeButtonsProvider) {
     var allCaseTypes = CaseTypeProvider.getAll();
-    var awardCategory = getAwardCategory();
+    var awardCategory = CaseTypeCategoryProvider.findByName(AWARDS_CATEGORY_NAME);
     var awardCaseTypes = filterCaseTypesByCategory(allCaseTypes, awardCategory.value);
 
     addConfigurationButtonsToCaseTypes(awardCaseTypes);
@@ -37,17 +37,6 @@
     function filterCaseTypesByCategory (caseTypes, categoryValue) {
       return _.filter(caseTypes, function (caseType) {
         return caseType.case_type_category === categoryValue;
-      });
-    }
-
-    /**
-     * Returns the award case type category.
-     *
-     * @returns {object} the case type category.
-     */
-    function getAwardCategory () {
-      return _.find(CRM['civicase-base'].caseTypeCategories, function (category) {
-        return category.name === AWARDS_CATEGORY_NAME;
       });
     }
   });

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -4,9 +4,8 @@
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
   module.config(function (CaseTypeProvider, CaseTypeCategoryProvider, DashboardCaseTypeButtonsProvider) {
-    var allCaseTypes = CaseTypeProvider.getAll();
     var awardCategory = CaseTypeCategoryProvider.findByName(AWARDS_CATEGORY_NAME);
-    var awardCaseTypes = filterCaseTypesByCategory(allCaseTypes, awardCategory.value);
+    var awardCaseTypes = CaseTypeProvider.getByCategory(awardCategory.value);
 
     addConfigurationButtonsToCaseTypes(awardCaseTypes);
 
@@ -24,19 +23,6 @@
           icon: 'fa fa-cog',
           url: caseTypeConfigUrl
         }]);
-      });
-    }
-
-    /**
-     * Filters the given case types and returns the ones belonging to the given category.
-     *
-     * @param {object[]} caseTypes the list of case types.
-     * @param {number} categoryValue the case type category value.
-     * @returns {object[]} a list of case types.
-     */
-    function filterCaseTypesByCategory (caseTypes, categoryValue) {
-      return _.filter(caseTypes, function (caseType) {
-        return caseType.case_type_category === categoryValue;
       });
     }
   });

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -3,9 +3,10 @@
   var AWARDS_CATEGORY_NAME = 'awards';
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
-  module.config(function (DashboardCaseTypeButtonsProvider) {
+  module.config(function (CaseTypeProvider, DashboardCaseTypeButtonsProvider) {
+    var allCaseTypes = CaseTypeProvider.getAll();
     var awardCategory = getAwardCategory();
-    var awardCaseTypes = getCaseTypesForCategory(awardCategory.value);
+    var awardCaseTypes = filterCaseTypesByCategory(allCaseTypes, awardCategory.value);
 
     addConfigurationButtonsToCaseTypes(awardCaseTypes);
 
@@ -27,6 +28,19 @@
     }
 
     /**
+     * Filters the given case types and returns the ones belonging to the given category.
+     *
+     * @param {object[]} caseTypes the list of case types.
+     * @param {number} categoryValue the case type category value.
+     * @returns {object[]} a list of case types.
+     */
+    function filterCaseTypesByCategory (caseTypes, categoryValue) {
+      return _.filter(caseTypes, function (caseType) {
+        return caseType.case_type_category === categoryValue;
+      });
+    }
+
+    /**
      * Returns the award case type category.
      *
      * @returns {object} the case type category.
@@ -34,18 +48,6 @@
     function getAwardCategory () {
       return _.find(CRM['civicase-base'].caseTypeCategories, function (category) {
         return category.name === AWARDS_CATEGORY_NAME;
-      });
-    }
-
-    /**
-     * Returns a list of case types that belong to the given category.
-     *
-     * @param {number} categoryValue the case type category value.
-     * @returns {object[]} a list of case types.
-     */
-    function getCaseTypesForCategory (categoryValue) {
-      return _.filter(CRM['civicase-base'].caseTypes, function (caseType) {
-        return caseType.case_type_category === categoryValue;
       });
     }
   });

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -1,0 +1,51 @@
+(function (angular, _, url) {
+  var module = angular.module('civiawards');
+  var AWARDS_CATEGORY_NAME = 'awards';
+  var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
+
+  module.config(function (CaseTypeButtonsProvider) {
+    var awardCategory = getAwardCategory();
+    var awardCaseTypes = getCaseTypesForCategory(awardCategory.value);
+
+    addConfigurationButtonsToCaseTypes(awardCaseTypes);
+
+    /**
+     * Adds configuration buttons to the given case types. The buttons url point
+     * towards the awards configuration form.
+     *
+     * @param {object[]} caseTypes a list of case types objects.
+     */
+    function addConfigurationButtonsToCaseTypes (caseTypes) {
+      _.forEach(caseTypes, function (caseType) {
+        var caseTypeConfigUrl = url(AWARD_CONFIG_URL + caseType.id);
+
+        CaseTypeButtonsProvider.addButtons(caseType.name, [{
+          url: caseTypeConfigUrl
+        }]);
+      });
+    }
+
+    /**
+     * Returns the award case type category.
+     *
+     * @returns {object} the case type category.
+     */
+    function getAwardCategory () {
+      return _.find(CRM['civicase-base'].caseTypeCategories, function (category) {
+        return category.name === AWARDS_CATEGORY_NAME;
+      });
+    }
+
+    /**
+     * Returns a list of case types that belong to the given category.
+     *
+     * @param {number} categoryValue the case type category value.
+     * @returns {object[]} a list of case types.
+     */
+    function getCaseTypesForCategory (categoryValue) {
+      return _.filter(CRM['civicase-base'].caseTypes, function (caseType) {
+        return caseType.case_type_category === categoryValue;
+      });
+    }
+  });
+})(angular, CRM._, CRM.url);

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -3,7 +3,7 @@
   var AWARDS_CATEGORY_NAME = 'awards';
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
-  module.config(function (CaseTypeButtonsProvider) {
+  module.config(function (DashboardCaseTypeButtonsProvider) {
     var awardCategory = getAwardCategory();
     var awardCaseTypes = getCaseTypesForCategory(awardCategory.value);
 
@@ -19,7 +19,7 @@
       _.forEach(caseTypes, function (caseType) {
         var caseTypeConfigUrl = url(AWARD_CONFIG_URL + caseType.id);
 
-        CaseTypeButtonsProvider.addButtons(caseType.name, [{
+        DashboardCaseTypeButtonsProvider.addButtons(caseType.name, [{
           url: caseTypeConfigUrl
         }]);
       });

--- a/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
@@ -1,0 +1,34 @@
+/* eslint-env jasmine */
+
+(function (_) {
+  describe('Awards Dashboard Action Buttons', () => {
+    let AddAwardDashboardActionButton, DashboardActionButtons;
+    const expectedActionButton = {
+      buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
+      iconClass: 'add_circle',
+      identifier: 'AddAward',
+      label: 'Create new award'
+    };
+
+    beforeEach(module('civicase-base', 'civiawards'));
+
+    beforeEach(inject((_AddAwardDashboardActionButton_, _DashboardActionButtons_) => {
+      AddAwardDashboardActionButton = _AddAwardDashboardActionButton_;
+      DashboardActionButtons = _DashboardActionButtons_;
+    }));
+
+    describe('after the awards module has been configured', () => {
+      it('it adds the "Create new award" action button', () => {
+        expect(DashboardActionButtons)
+          .toContain(jasmine.objectContaining(expectedActionButton));
+      });
+
+      it('sets the "AddAward" action button service as the handler', () => {
+        expect(DashboardActionButtons)
+          .toContain(_.extend({}, expectedActionButton, {
+            service: AddAwardDashboardActionButton
+          }));
+      });
+    });
+  });
+})(CRM._);

--- a/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
@@ -7,7 +7,8 @@
       buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
       iconClass: 'add_circle',
       identifier: 'AddAward',
-      label: 'Create new award'
+      label: 'Create new award',
+      weight: 100
     };
 
     beforeEach(module('civicase-base', 'civiawards'));

--- a/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
+++ b/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-(function (_) {
+(function (_, getCrmUrl) {
   describe('Add Award Dashboard Action Button', () => {
     let $location, AddAwardDashboardActionButton;
 
@@ -40,14 +40,16 @@
     });
 
     describe('when clicking the action button', () => {
+      const expectedUrl = getCrmUrl('awards/new');
+
       beforeEach(() => {
         spyOn($location, 'url');
         AddAwardDashboardActionButton.clickHandler();
       });
 
       it('redirects the user to the create award screen', () => {
-        expect($location.url).toHaveBeenCalledWith('awards/new');
+        expect($location.url).toHaveBeenCalledWith(expectedUrl);
       });
     });
   });
-})(CRM._);
+})(CRM._, CRM.url);

--- a/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
+++ b/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jasmine */
+
+(function (_) {
+  describe('Add Award Dashboard Action Button', () => {
+    let $location, AddAwardDashboardActionButton;
+
+    beforeEach(module('civiawards'));
+
+    beforeEach(inject((_$location_, _AddAwardDashboardActionButton_) => {
+      $location = _$location_;
+      AddAwardDashboardActionButton = _AddAwardDashboardActionButton_;
+    }));
+
+    describe('button visibility', () => {
+      var isButtonVisible;
+
+      describe('when viewing the awards dashboard', () => {
+        beforeEach(() => {
+          $location.search('case_type_category', 'awards');
+
+          isButtonVisible = AddAwardDashboardActionButton.isVisible();
+        });
+
+        it('displays the add award button', () => {
+          expect(isButtonVisible).toBe(true);
+        });
+      });
+
+      describe('when viewing any other dashboard', () => {
+        beforeEach(() => {
+          $location.search('case_type_category', 'cases');
+
+          isButtonVisible = AddAwardDashboardActionButton.isVisible();
+        });
+
+        it('does not display the add award button', () => {
+          expect(isButtonVisible).toBe(false);
+        });
+      });
+    });
+
+    describe('when clicking the action button', () => {
+      beforeEach(() => {
+        spyOn($location, 'url');
+        AddAwardDashboardActionButton.clickHandler();
+      });
+
+      it('redirects the user to the create award screen', () => {
+        expect($location.url).toHaveBeenCalledWith('awards/new');
+      });
+    });
+  });
+})(CRM._);

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -1,0 +1,49 @@
+/* eslint-env jasmine */
+
+(function (_, angular) {
+  var AWARDS_CATEGORY_NAME = 'awards';
+  var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
+
+  describe('CaseTypeButtons provider', () => {
+    let AwardMockData, AwardsCategory, CaseTypeButtons, CaseTypesMockData;
+
+    beforeEach(() => {
+      module('civicase-base', 'civiawards.data', 'civiawards');
+    });
+
+    beforeEach(inject((_AwardMockData_, _CaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
+      AwardMockData = _AwardMockData_;
+      CaseTypesMockData = _CaseTypesMockData_.get();
+      CaseTypeButtons = _CaseTypeButtons_;
+      AwardsCategory = _.find(
+        caseTypeCategoriesMockData,
+        (category) => category.name === AWARDS_CATEGORY_NAME
+      );
+    }));
+
+    describe('after the awards module has been configured', () => {
+      it('it adds the configuration url to the awards case type', () => {
+        expect(CaseTypeButtons).toEqual({
+          [AwardMockData.name]: [{
+            url: AWARD_CONFIG_URL + AwardMockData.id
+          }]
+        });
+      });
+    });
+
+    describe('when requesting the buttons for non award case types', () => {
+      let nonAwardscaseTypes;
+
+      beforeEach(() => {
+        nonAwardscaseTypes = _.chain(CaseTypesMockData)
+          .filter(caseType => caseType.category !== AwardsCategory.value)
+          .map('name')
+          .value();
+      });
+
+      it('it does not add configuration buttons to non award case types', () => {
+        expect(_.keys(CaseTypeButtons)).not.toContain(nonAwardscaseTypes);
+      });
+    });
+  });
+})(CRM._, angular);

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -25,6 +25,7 @@
       it('it adds the configuration url to the awards case type', () => {
         expect(DashboardCaseTypeButtons).toEqual({
           [AwardMockData.name]: [{
+            icon: 'fa fa-cog',
             url: AWARD_CONFIG_URL + AwardMockData.id
           }]
         });

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -5,16 +5,16 @@
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
   describe('CaseTypeButtons provider', () => {
-    let AwardMockData, AwardsCategory, CaseTypeButtons, CaseTypesMockData;
+    let AwardMockData, AwardsCategory, DashboardCaseTypeButtons, CaseTypesMockData;
 
     beforeEach(() => {
       module('civicase-base', 'civiawards.data', 'civiawards');
     });
 
-    beforeEach(inject((_AwardMockData_, _CaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
+    beforeEach(inject((_AwardMockData_, _DashboardCaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
       AwardMockData = _AwardMockData_;
       CaseTypesMockData = _CaseTypesMockData_.get();
-      CaseTypeButtons = _CaseTypeButtons_;
+      DashboardCaseTypeButtons = _DashboardCaseTypeButtons_;
       AwardsCategory = _.find(
         caseTypeCategoriesMockData,
         (category) => category.name === AWARDS_CATEGORY_NAME
@@ -23,7 +23,7 @@
 
     describe('after the awards module has been configured', () => {
       it('it adds the configuration url to the awards case type', () => {
-        expect(CaseTypeButtons).toEqual({
+        expect(DashboardCaseTypeButtons).toEqual({
           [AwardMockData.name]: [{
             url: AWARD_CONFIG_URL + AwardMockData.id
           }]
@@ -42,7 +42,7 @@
       });
 
       it('it does not add configuration buttons to non award case types', () => {
-        expect(_.keys(CaseTypeButtons)).not.toContain(nonAwardscaseTypes);
+        expect(_.keys(DashboardCaseTypeButtons)).not.toContain(nonAwardscaseTypes);
       });
     });
   });

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-(function (_, angular) {
+(function (_, angular, getCrmUrl) {
   var AWARDS_CATEGORY_NAME = 'awards';
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
 
@@ -24,7 +24,7 @@
         expect(DashboardCaseTypeButtons).toEqual({
           [AwardMockData.name]: [{
             icon: 'fa fa-cog',
-            url: AWARD_CONFIG_URL + AwardMockData.id
+            url: getCrmUrl(AWARD_CONFIG_URL + AwardMockData.id)
           }]
         });
       });
@@ -45,4 +45,4 @@
       });
     });
   });
-})(CRM._, angular);
+})(CRM._, angular, CRM.url);

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -7,9 +7,7 @@
   describe('CaseTypeButtons provider', () => {
     let AwardMockData, AwardsCategory, DashboardCaseTypeButtons, CaseTypesMockData;
 
-    beforeEach(() => {
-      module('civicase-base', 'civiawards.data', 'civiawards');
-    });
+    beforeEach(module('civiawards.data', 'civicase-base', 'civiawards'));
 
     beforeEach(inject((_AwardMockData_, _DashboardCaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
       AwardMockData = _AwardMockData_;

--- a/ang/test/mocks/configs/awards-case-types.config.js
+++ b/ang/test/mocks/configs/awards-case-types.config.js
@@ -1,0 +1,9 @@
+(function () {
+  var module = angular.module('civiawards.data');
+
+  module.config((AwardMockData, CaseTypesMockDataProvider) => {
+    CaseTypesMockDataProvider.add({
+      [AwardMockData.id]: AwardMockData
+    });
+  });
+}());

--- a/ang/test/mocks/data/award.data.js
+++ b/ang/test/mocks/data/award.data.js
@@ -15,7 +15,7 @@
         'Urgent'
       ]
     },
-    case_type_category: '4',
+    case_type_category: '3',
     is_forkable: '1',
     is_forked: ''
   }

--- a/ang/test/mocks/modules.mock.js
+++ b/ang/test/mocks/modules.mock.js
@@ -1,3 +1,3 @@
 (function () {
-  angular.module('civiawards.data', []);
+  angular.module('civiawards.data', ['civicase.data']);
 })();


### PR DESCRIPTION
## Overview
This PR adds the "Create new award" button to the Awards Dashboard. 

## Before
![Screen Shot 2019-12-09 at 10 24 06 PM](https://user-images.githubusercontent.com/1642119/70491978-45d47b80-1ad9-11ea-8638-3b286ffd8479.png)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/70492169-e5920980-1ad9-11ea-8073-7b2b70c53ab3.gif)

## Technical Details

This PR uses https://github.com/compucorp/uk.co.compucorp.civicase/pull/309 in order to add a new action button to the awards dashboard. The configuration options for the button are:

```js
{
  buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
  iconClass: 'add_circle',
  identifier: 'AddAward',
  label: 'Create new award',
  weight: 100
}
```

The weight is set to `100` so it's displayed after the "Add Case" button.

This button makes reference to the `AddAwardDashboardActionButton` service.

For the visibility method we check that the `case_type_category` URL param is set to `awards`:

```js
function isVisible () {
  var urlParams = $location.search();

  return urlParams.case_type_category === 'awards';
}
```

And when the button is clicked we use the location service to redirect the user to the awards creation page: `/awards/new` :

```js
function clickHandler () {
  var newAwardUrl = url('awards/new');

  $location.url(newAwardUrl);
}
```