### PR TITLE
RSE-681: Order Profile Fields by Weight on Review Form

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -96,7 +96,10 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $this->assign('caseTypeName', $this->caseTypeName);
     $this->assign('caseTags', $this->caseTags);
 
-    $fields = CRM_Core_BAO_UFGroup::getFields($this->profileId, FALSE, CRM_Core_Action::ADD);
+    $fields = CRM_Core_BAO_UFGroup::getFields(
+      $this->profileId, FALSE, CRM_Core_Action::ADD, NULL,
+      NULL, FALSE, NULL, FALSE, NULL, CRM_Core_Permission::CREATE, 'weight'
+    );
     $customFieldLabels = $this->getCustomFieldLabels(array_keys($fields));
     $elementNames = [];
 


### PR DESCRIPTION
## Overview
The award review fields are now created with more properties like weight, required.
On the Review form which is basically the profile containing the chosen custom fields for the Award, we need to make sure that the fields are ordered by the weight.

## Before
No logic to ensure fields were ordered by their weights

## After
Profile fields are now ordered with `weight`
![RSE-681](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-681-after.png)

## Technical Details
We just set the default options for `CRM_Core_BAO_UFGroup::getFields()` and set `weight` as the `$orderBy` param which is the 11th parameter