### PR TITLE
RSE-664: Add API to return a Contact's Access to an Award Application

### DIFF
--- a/CRM/CiviAwards/BAO/AwardReviewPanel.php
+++ b/CRM/CiviAwards/BAO/AwardReviewPanel.php
@@ -108,7 +108,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
         'is_array' => TRUE,
         'fields' => [
           'contact_id' => ['validate_filter' => FILTER_VALIDATE_INT],
-          'relationship_id' => ['validate_filter' => FILTER_VALIDATE_INT],
+          'relationship_type_id' => ['validate_filter' => FILTER_VALIDATE_INT],
           'is_a_to_b' => [
             'validate_filter' => FILTER_VALIDATE_INT,
             'options' => ['min_range' => 0, 'max_range' => 1],
@@ -162,6 +162,9 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
     }
 
     foreach ($config as $fieldName => $setting) {
+      if (empty($setting['is_required']) && !isset($params[$fieldName])) {
+        continue;
+      }
       if (!empty($setting['is_required']) && !isset($params[$fieldName])) {
         throw new Exception(ts("{$settingName} :  {$fieldName} is required"));
       }

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -1,0 +1,122 @@
+<?php
+
+use CRM_CiviAwards_BAO_AwardReviewPanel as AwardReviewPanel;
+use CRM_CiviAwards_Service_AwardPanelContact as AwardReviewPanelContact;
+
+/**
+ * Class CRM_CiviAwards_Service_AwardApplicationContactAccess.
+ */
+class CRM_CiviAwards_Service_AwardApplicationContactAccess {
+
+  /**
+   * Returns the contact access to the Award Applications.
+   *
+   * @param int $contactId
+   *   Contact Id.
+   * @param int $awardId
+   *   Award Id.
+   *
+   * @return array|void
+   *   The contact access to the Award applications.
+   */
+  public function get($contactId, $awardId) {
+    $awardPanels = $this->getAwardPanels($awardId);
+
+    if (empty($awardPanels)) {
+      throw new Exception("No award panels available for this award type");
+    }
+
+    $visibilitySettings = [];
+    $awardPanelContact = new AwardReviewPanelContact();
+    foreach ($awardPanels as $awardPanelId) {
+      if (!empty($awardPanelContact->get($awardPanelId, [$contactId]))) {
+        $visibilitySettings[] = $this->getAwardVisibilitySettings($awardPanelId);
+      }
+    }
+
+    return $this->processVisibilitySettings($visibilitySettings);
+  }
+
+  /**
+   * Processes the contact visibility results.
+   *
+   * @param array $visibilitySettings
+   *   Visibility settings.
+   *
+   * @return array
+   *   The contact access to the Award applications.
+   */
+  private function processVisibilitySettings(array $visibilitySettings) {
+    $applicationTags = [];
+    $applicationStatus = [];
+    $anonymizeApplication = TRUE;
+
+    foreach ($visibilitySettings as $visibilitySetting) {
+      if (isset($visibilitySetting['application_tags'])) {
+        $applicationTags = array_merge($applicationTags, $visibilitySetting['application_tags']);
+      }
+      if (isset($visibilitySetting['application_status'])) {
+        $applicationStatus = array_merge($applicationStatus, $visibilitySetting['application_status']);
+      }
+
+      if (isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0) {
+        $anonymizeApplication = FALSE;
+      }
+    }
+    $applicationTags = array_unique($applicationTags);
+    $applicationStatus = array_unique($applicationStatus);
+    sort($applicationStatus);
+    sort($applicationTags);
+
+    return [
+      'application_tags' => $applicationTags,
+      'application_status' => $applicationStatus,
+      'anonymize_application' => $anonymizeApplication,
+    ];
+  }
+
+  /**
+   * Returns the Award Panels for an Award.
+   *
+   * @param int $awardId
+   *   Award Id.
+   *
+   * @return array
+   *   Award panels.
+   */
+  private function getAwardPanels($awardId) {
+    $awardReviewPanelObject = new AwardReviewPanel();
+    $awardReviewPanelObject->case_type_id = $awardId;
+    $awardReviewPanelObject->is_active = 1;
+    $awardReviewPanelObject->find();
+
+    $panelIds = [];
+    while ($awardReviewPanelObject->fetch()) {
+      $panelIds[] = $awardReviewPanelObject->id;
+    }
+
+    return $panelIds;
+  }
+
+  /**
+   * Returns Award Visibility settings.
+   *
+   * @param int $awardPanelId
+   *   Award ID.
+   *
+   * @return array
+   *   Award contact settings.
+   */
+  private function getAwardVisibilitySettings($awardPanelId) {
+    $awardReviewPanelObject = new AwardReviewPanel();
+    $awardReviewPanelObject->id = $awardPanelId;
+    $awardReviewPanelObject->find(TRUE);
+
+    if (!empty($awardReviewPanelObject->visibility_settings)) {
+      return unserialize($awardReviewPanelObject->visibility_settings);
+    }
+
+    return NULL;
+  }
+
+}

--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -1,0 +1,213 @@
+<?php
+
+use CRM_CiviAwards_BAO_AwardReviewPanel as AwardReviewPanel;
+
+/**
+ * Class CRM_CiviAwards_Service_AwardReviewPanelContact.
+ */
+class CRM_CiviAwards_Service_AwardPanelContact {
+
+  /**
+   * Gets the all panel contacts for an Award.
+   *
+   * @param int $awardPanelId
+   *   Award Id.
+   * @param array $filterContacts
+   *   If present, filters the results to return only for
+   *   contacts present in filter contacts.
+   *
+   * @return array
+   *   The panel contacts data.
+   */
+  public function get($awardPanelId, array $filterContacts = []) {
+    $awardContactSettings = $this->getAwardContactSettings($awardPanelId);
+
+    if (empty($awardContactSettings)) {
+      return [];
+    }
+
+    $includeGroups = isset($awardContactSettings['include_groups']) ? $awardContactSettings['include_groups'] : [];
+    $excludeGroups = isset($awardContactSettings['exclude_groups']) ? $awardContactSettings['exclude_groups'] : [];
+    $groupContacts = [];
+
+    if (!empty($includeGroups)) {
+      $groupContacts = $this->getGroupContacts($includeGroups, $excludeGroups, $filterContacts);
+    }
+
+    $relationshipContacts = [];
+    if (!empty($awardContactSettings['relationship'])) {
+      foreach ($awardContactSettings['relationship'] as $relationshipSettings) {
+        $relationshipContacts[] = $this->getRelationshipContacts(
+          $relationshipSettings['relationship_type_id'],
+          $relationshipSettings['is_a_to_b'],
+          $relationshipSettings['contact_id'],
+          $filterContacts
+        );
+      }
+    }
+
+    return $this->mergeAllRelatedContacts($groupContacts, $relationshipContacts);
+  }
+
+  /**
+   * Merges all the contacts gotten from panel contact settings.
+   *
+   * @param array $groupContacts
+   *   Group contacts.
+   * @param array $relationshipContacts
+   *   Relationship contacts.
+   */
+  private function mergeAllRelatedContacts(array $groupContacts, array $relationshipContacts) {
+    $allContacts = [];
+    foreach ($relationshipContacts as $contacts) {
+      $allContacts = $allContacts + $contacts;
+    }
+
+    $allContacts = $allContacts + $groupContacts;
+
+    return $allContacts;
+  }
+
+  /**
+   * Returns the panel contacts based on the group settings.
+   *
+   * Returns results based on the Award panel group settings.
+   *
+   * @param array $includeGroups
+   *   Include contacts belonging to this group.
+   * @param array $excludeGroups
+   *   Exclude contacts belonging to ths group.
+   * @param array $filterContacts
+   *   If present, filters the results to return only for
+   *   contacts present in filter contacts.
+   *
+   * @return array
+   *   Group contacts.
+   */
+  private function getGroupContacts(array $includeGroups, array $excludeGroups = [], array $filterContacts = []) {
+    $includeGroupContacts = $this->getContactsForGroup($includeGroups, $filterContacts);
+    $excludeGroupContacts = $this->getContactsForGroup($excludeGroups, $filterContacts);
+
+    return array_diff_key($includeGroupContacts, $excludeGroupContacts);
+  }
+
+  /**
+   * Returns the panel contacts based on the relationship settings.
+   *
+   *  Returns results based on the Award panel relationship settings.
+   *
+   * @param int $relationshipTypeId
+   *   Relationship type Id.
+   * @param bool $isAToB
+   *   If relationship is a to b or not.
+   * @param int $contactId
+   *   Contact Id linked to the relationship.
+   * @param array $filterContacts
+   *   If present, filters the results to return only for
+   *   contacts present in filter contacts.
+   *
+   * @return array
+   *   Relationship contacts.
+   */
+  private function getRelationshipContacts($relationshipTypeId, $isAToB, $contactId, array $filterContacts = []) {
+    $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
+    $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
+    $contactTable = CRM_Contact_BAO_Contact::getTableName();
+    $contactEmailTable = CRM_Core_BAO_Email::getTableName();
+    $relationshipJoinCondition = $isAToB ? 'ON r.contact_id_a = c.id' : 'ON r.contact_id_b = c.id';
+    $contactCondition = $isAToB ? 'AND r.contact_id_b = %1' : 'AND r.contact_id_a = %1';
+    $filterContactCondition = $filterContacts ? 'AND c.id IN(' . implode(', ', $filterContacts) . ')' : '';
+
+    $query = "
+      SELECT c.id, c.display_name, ce.email
+      FROM {$contactTable } c
+      INNER JOIN {$relationshipTable} r
+       {$relationshipJoinCondition}
+      INNER JOIN {$relationshipTypeTable} rt
+        ON rt.id = r.relationship_type_id
+      LEFT JOIN {$contactEmailTable} ce
+        ON (c.id = ce.contact_id AND ce.is_primary = 1)
+      WHERE r.is_active = 1 AND rt.is_active = 1
+      AND rt.id = %2
+      {$contactCondition}
+      {$filterContactCondition}
+      AND (r.start_date IS NULL OR r.start_date <= %3)
+      AND (r.end_date IS NULL OR r.end_date >= %3)
+      ORDER by c.id ASC
+    ";
+
+    $params = [
+      1 => [$contactId, 'Integer'],
+      2 => [$relationshipTypeId, 'Integer'],
+      3 => [date('Y-m-d'), 'String'],
+    ];
+
+    $result = CRM_Core_DAO::executeQuery($query, $params);
+    $contacts = [];
+
+    while ($result->fetch()) {
+      $contacts[$result->id] = [
+        'id' => $result->id,
+        'email' => $result->email,
+        'display_name' => $result->display_name,
+      ];
+    }
+
+    return $contacts;
+  }
+
+  /**
+   * Returns Award contact settings.
+   *
+   * @param int $awardPanelId
+   *   Award ID.
+   *
+   * @return array
+   *   Award contact settings.
+   */
+  private function getAwardContactSettings($awardPanelId) {
+    $awardReviewPanelObject = new AwardReviewPanel();
+    $awardReviewPanelObject->id = $awardPanelId;
+    $awardReviewPanelObject->find(TRUE);
+
+    if (!empty($awardReviewPanelObject->contact_settings)) {
+      return unserialize($awardReviewPanelObject->contact_settings);
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Returns contacts for a given group.
+   *
+   * @param array $groupIds
+   *   Group Ids.
+   * @param array $filterContacts
+   *   If present, filters the results to return only for
+   *   contacts present in filter contacts.
+   *
+   * @return array
+   *   Group contacts.
+   */
+  private function getContactsForGroup(array $groupIds, array $filterContacts = []) {
+    if (empty($groupIds)) {
+      return [];
+    }
+
+    $params = [
+      'group' => ['IN' => $groupIds],
+      'return' => ['email'],
+    ];
+    if (!empty($filterContacts)) {
+      $params['id'] = ['IN' => $filterContacts];
+    }
+
+    $result = civicrm_api3('Contact', 'get', [
+      'group' => ['IN' => $groupIds],
+      'return' => ['email', 'display_name'],
+    ]);
+
+    return $result['values'];
+  }
+
+}

--- a/api/v3/AwardReviewPanel.php
+++ b/api/v3/AwardReviewPanel.php
@@ -6,6 +6,48 @@
  */
 
 /**
+ * AwardReviewPanel.getContactAccess API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_award_review_panel_getcontactaccess_spec(array &$spec) {
+  $spec['contact_id'] = [
+    'title' => 'Contact ID',
+    'description' => 'Award Panel Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName'  => 'CRM_Contact_DAO_Contact',
+    'FKApiName'    => 'Contact',
+  ];
+
+  $spec['award_id'] = [
+    'title' => 'Award ID',
+    'description' => 'Award ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName'  => 'CRM_Case_BAO_CaseType',
+    'FKApiName'    => 'CaseType',
+  ];
+}
+
+/**
+ * AwardReviewPanel.getContactAccess API.
+ *
+ * @param array $params
+ *   Parameters.
+ *
+ * @return array
+ *   API result descriptor.
+ */
+function civicrm_api3_award_review_panel_getcontactaccess(array $params) {
+  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
+  $contactAccess = $contactAccessService->get($params['contact_id'], $params['award_id']);
+
+  return civicrm_api3_create_success($contactAccess);
+}
+
+/**
  * AwardReviewPanel.create API.
  *
  * @param array $params


### PR DESCRIPTION
## Overview
An Award Panel consists of settings that define contacts that has access to an Award application and the access they have to the Award application.
When a panel member logs in to the Self Service Portal, we need a way to determine if he has access to review an Award application and if he has, what kind of access does he have i.e what application statuses can he view? Does he have access to real or anonymised data?

This PR adds an API to get this information.

## Before
The AwardReviewPanel.getcontactaccess API does not exist.

## After
The AwardReviewPanel.getcontactaccess is added.

**Sample Request**
```php
$result = civicrm_api3('AwardReviewPanel', 'getcontactaccess', [
  'contact_id' => 9,
  'award_id' => 2,
]);
```
**Sample Response:**

```php
{

    "is_error": 0,
    "version": 3,
    "count": 3,
    "values": {
        "application_tags": [
            "1",
            "2",
            "3"
        ],
        "application_status": [
            "1",
            "2",
            "4",
            "6"
        ],
        "anonymize_application": false
    }
}
```