### PR TITLE
RSE-710: Add Tests For Award Panel Functionality

### DIFF
--- a/CRM/CiviAwards/BAO/AwardReviewPanel.php
+++ b/CRM/CiviAwards/BAO/AwardReviewPanel.php
@@ -38,7 +38,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
   private static function serializeSettingsParams(array &$params) {
     $settingsParams = ['contact_settings', 'visibility_settings'];
     foreach ($settingsParams as $setting) {
-      if (!empty($params[$setting])) {
+      if (isset($params[$setting])) {
         $params[$setting] = serialize($params[$setting]);
       }
     }

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -15,11 +15,13 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   Contact Id.
    * @param int $awardId
    *   Award Id.
+   * @param AwardReviewPanelContact $awardPanelContact
+   *   Award Panel contact service.
    *
    * @return array|void
    *   The contact access to the Award applications.
    */
-  public function get($contactId, $awardId) {
+  public function get($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
     $awardPanels = $this->getAwardPanels($awardId);
 
     if (empty($awardPanels)) {
@@ -27,7 +29,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     }
 
     $visibilitySettings = [];
-    $awardPanelContact = new AwardReviewPanelContact();
     foreach ($awardPanels as $awardPanelId) {
       if (!empty($awardPanelContact->get($awardPanelId, [$contactId]))) {
         $visibilitySettings[] = $this->getAwardVisibilitySettings($awardPanelId);

--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -196,16 +196,13 @@ class CRM_CiviAwards_Service_AwardPanelContact {
 
     $params = [
       'group' => ['IN' => $groupIds],
-      'return' => ['email'],
+      'return' => ['email', 'display_name'],
     ];
     if (!empty($filterContacts)) {
       $params['id'] = ['IN' => $filterContacts];
     }
 
-    $result = civicrm_api3('Contact', 'get', [
-      'group' => ['IN' => $groupIds],
-      'return' => ['email', 'display_name'],
-    ]);
+    $result = civicrm_api3('Contact', 'get', $params);
 
     return $result['values'];
   }

--- a/CRM/CiviAwards/Test/Fabricator/AwardReviewPanel.php
+++ b/CRM/CiviAwards/Test/Fabricator/AwardReviewPanel.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_CiviAwards_BAO_AwardReviewPanel as AwardReviewPanel;
+
+class CRM_CiviAwards_Test_Fabricator_AwardReviewPanel {
+
+  public static function fabricate($params = []) {
+    $params = self::mergeDefaultParams($params);
+
+    return AwardReviewPanel::create($params);
+  }
+
+  private static function mergeDefaultParams($params) {
+    $defaultParams = [
+      'title' => uniqid(),
+      'case_type_id' => 1,
+      'is_active' => 1,
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+
+}

--- a/CRM/CiviAwards/Test/Fabricator/CaseType.php
+++ b/CRM/CiviAwards/Test/Fabricator/CaseType.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_CiviAwards_Test_Fabricator_CaseType {
+
+  public static function fabricate($params = []) {
+    $params = self::mergeDefaultParams($params);
+    $result = civicrm_api3('CaseType', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+  private static function mergeDefaultParams($params) {
+    $name = uniqid();
+    $defaultParams = [
+      'name' => $name,
+      'title' => $name,
+      'is_active' => 1,
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+}

--- a/CRM/CiviAwards/Test/Fabricator/Contact.php
+++ b/CRM/CiviAwards/Test/Fabricator/Contact.php
@@ -1,0 +1,36 @@
+<?php
+
+class CRM_CiviAwards_Test_Fabricator_Contact {
+
+  private static $defaultParams = [
+    'contact_type' => 'Individual',
+    'first_name'   => 'John',
+    'last_name'    => 'Doe',
+    'sequential'   => 1
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $params['display_name'] = "{$params['first_name']} {$params['last_name']}";
+
+    $result = civicrm_api3(
+      'Contact',
+      'create',
+      $params
+    );
+
+    return array_shift($result['values']);
+  }
+
+  public static function fabricateWithEmail($params = [], $email = 'johndoe@test.com') {
+    $contact = self::fabricate($params);
+
+    civicrm_api3('Email', 'create', [
+      'email' => $email,
+      'contact_id' => $contact['id'],
+      'is_primary' => 1
+    ]);
+
+    return $contact;
+  }
+}

--- a/CRM/CiviAwards/Test/Fabricator/Relationship.php
+++ b/CRM/CiviAwards/Test/Fabricator/Relationship.php
@@ -1,0 +1,19 @@
+<?php
+
+class CRM_CiviAwards_Test_Fabricator_Relationship {
+
+  private static $defaultParams = [
+    'is_active' => 1,
+    'start_date' => null,
+    'end_date' => null,
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+
+    $result = civicrm_api3('Relationship', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/CRM/CiviAwards/Test/Fabricator/RelationshipType.php
+++ b/CRM/CiviAwards/Test/Fabricator/RelationshipType.php
@@ -1,0 +1,23 @@
+<?php
+
+class CRM_CiviAwards_Test_Fabricator_RelationshipType {
+
+  private static $defaultParams = [
+    'sequential' => 1,
+    'name_a_b' => 'test AB',
+    'name_b_a' => 'test BA',
+    'contact_type_a' => 'Individual',
+    'contact_type_b' => 'Individual',
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $result = civicrm_api3(
+      'RelationshipType',
+      'create',
+      $params
+    );
+
+    return array_shift($result['values']);
+  }
+}

--- a/api/v3/AwardReviewPanel.php
+++ b/api/v3/AwardReviewPanel.php
@@ -42,7 +42,8 @@ function _civicrm_api3_award_review_panel_getcontactaccess_spec(array &$spec) {
  */
 function civicrm_api3_award_review_panel_getcontactaccess(array $params) {
   $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
-  $contactAccess = $contactAccessService->get($params['contact_id'], $params['award_id']);
+  $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
+  $contactAccess = $contactAccessService->get($params['contact_id'], $params['award_id'], $awardPanelContact);
 
   return civicrm_api3_create_success($contactAccess);
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<phpunit
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  syntaxCheck="false"
+  bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="Full">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicase')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
+++ b/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
+
+/**
+ * @group headless
+ */
+class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
+
+  public function testCreateThrowsExceptionWhenExcludeGroupContactSettingContainsNonInteger() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => [1,3,'Sample'],
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Contact Settings :  One of the values of exclude_groups is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenExcludeGroupContactSettingIsNotAnArray() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => 'Sample',
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Contact Settings :  exclude_groups should be an array'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenIncludeGroupContactSettingContainsNonInteger() {
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [1,3,'Sample'],
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Contact Settings :  One of the values of include_groups is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenIncludeGroupContactSettingIsNotAnArray() {
+    $params = [
+      'contact_settings' => [
+        'include_groups' => 'Sample',
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Contact Settings :  include_groups should be an array'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenApplicationTagVisibilitySettingContainsNonInteger() {
+    $params = [
+      'visibility_settings' => [
+        'application_tags' => [1,3,'Sample'],
+        'anonymize_application' => 0
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings :  One of the values of application_tags is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenApplicationStatusVisibilitySettingContainsNonInteger() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3,'Sample'],
+        'anonymize_application' => 0
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings :  One of the values of application_status is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenAnonymizeApplicationParamForVisibilitySettingIsAbsent() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3],
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings :  anonymize_application is required'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+}

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_CiviAwards_Service_AwardApplicationContactAccess as ApplicationContactAccess;
+use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
+use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
+
+/**
+ * @group headless
+ */
+class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadlessTest {
+
+  public function testGetThrowsExceptionWhenNoAwardPanelsExistForAward() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $applicationContactAccess = new ApplicationContactAccess();
+    $contactId = 1;
+    $awardPanelContact = new AwardPanelContact();
+
+    $this->setExpectedException(
+      'Exception',
+      'No award panels available for this award type'
+    );
+    $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact);
+  }
+
+  public function testGetReturnsTheContactAccessForAContact() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $applicationContactAccess = new ApplicationContactAccess();
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_tags' => [1,2],
+          'application_status' => [5,6],
+          'anonymize_application' => 0
+        ]
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_tags' => [6,8],
+          'application_status' => [9,3],
+          'anonymize_application' => 1
+        ]
+      ]
+    ];
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    // anonymize application will be false overral because more permission takes precedence over less
+    // less permissions.
+
+    $expectedResult = [
+      'application_tags' => [1,2,6,8],
+      'application_status' => [3,5,6,9],
+      'anonymize_application' => FALSE
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
+  }
+
+  public function testAnonymizeApplicationReturnsTrueForContactWhenItIsSetToBeTrue() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $applicationContactAccess = new ApplicationContactAccess();
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'anonymize_application' => 1
+        ]
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'anonymize_application' => 1
+        ]
+      ]
+    ];
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $expectedResult = [
+      'application_tags' => [],
+      'application_status' => [],
+      'anonymize_application' => TRUE
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
+  }
+
+  private function getAwardPanelContactObject($awardPanel, $contactId) {
+    $awardPanelContact = $this->prophesize(AwardPanelContact::class);
+    foreach ($awardPanel as $awardPanel) {
+      $awardPanelContact->get($awardPanel->id, [$contactId])->willReturn(TRUE);
+    }
+
+    return $awardPanelContact->reveal();
+  }
+}

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardPanelContactTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardPanelContactTest.php
@@ -1,0 +1,444 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_Contact as ContactFabricator;
+use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
+use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
+use CRM_CiviAwards_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_CiviAwards_Test_Fabricator_Relationship as RelationshipFabricator;
+
+/**
+ * @group headless
+ */
+class CRM_CiviAwards_Service_AwardPanelContactTest extends BaseHeadlessTest {
+
+  public function testGetReturnsContactsBelongingToGroup() {
+    $groupA = $this->createGroup('Group A');
+    $groupB = $this->createGroup('Group B');
+    $groupC = $this->createGroup('Group C');
+
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+    $this->addContactToGroup($groupA, $contactA['id']);
+    $this->addContactToGroup($groupB, $contactB['id']);
+    $this->addContactToGroup($groupC, $contactC['id']);
+
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [$groupA, $groupB]
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+      $contactB['id'] => [
+        'display_name' => $contactB['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetDoesNotReturnsExcludedGroupContacts() {
+    $groupA = $this->createGroup('Group A');
+    $groupB = $this->createGroup('Group B');
+    $groupC = $this->createGroup('Group C');
+
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+    $this->addContactToGroup($groupA, $contactA['id']);
+    $this->addContactToGroup($groupB, $contactC['id']);
+    $this->addContactToGroup($groupB, $contactB['id']);
+    $this->addContactToGroup($groupC, $contactB['id']);
+
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [$groupA, $groupB],
+        'exclude_groups' => [$groupC]
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    //Contact B should be excluded because contact belongs to Group C also.
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+      $contactC['id'] => [
+        'display_name' => $contactC['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetReturnsContactsBasedOnRelationship() {
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
+
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+
+    //Contact B is Manager to Contact A
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeA['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    //Contact B is Regulator to Contact C
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactC['id'],
+      'relationship_type_id' => $relationshipTypeB['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    $params = [
+      'contact_settings' => [
+        'relationship' => [
+          [
+            'contact_id' => $contactB['id'],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeA['id']
+          ],
+          [
+            'contact_id' => $contactC['id'],
+            'is_a_to_b' => 0,
+            'relationship_type_id' => $relationshipTypeB['id']
+          ],
+        ],
+      ]
+    ];
+
+    // Returned contacts should be ContactA : Since it's manager is contact B
+    // Contact B since He is Regulator of ContactC
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+      $contactB['id'] => [
+        'display_name' => $contactB['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetReturnsContactsBasedOnRelationshipAndGroups() {
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+
+    //Contact B is Manager to Contact A
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeA['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    $groupC = $this->createGroup('Group C');
+    $this->addContactToGroup($groupC, $contactC['id']);
+
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [$groupC],
+        'relationship' => [
+          [
+            'contact_id' => $contactB['id'],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeA['id']
+          ],
+        ],
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+      $contactC['id'] => [
+        'display_name' => $contactC['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetReturnsContactsBelongingToGroupWhenContactFilterIsPassed() {
+    $groupA = $this->createGroup('Group A');
+    $groupB = $this->createGroup('Group B');
+
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $this->addContactToGroup($groupA, $contactA['id']);
+    $this->addContactToGroup($groupB, $contactB['id']);
+
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [$groupA, $groupB]
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    // ContactA and ContactB is supposed to be returned but since we are filtering
+    // By contactB, only contactB is returned
+    $contacts = $awardPanelContact->get($awardPanel->id, [$contactB['id']]);
+
+    $expectedResult = [
+      $contactB['id'] => [
+        'display_name' => $contactB['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetReturnsContactsBasedOnRelationshipWhenContactFilterIsPassed() {
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
+
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+
+    //Contact B is Manager to Contact A
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeA['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    //Contact B is Regulator to Contact C
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactC['id'],
+      'relationship_type_id' => $relationshipTypeB['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    $params = [
+      'contact_settings' => [
+        'relationship' => [
+          [
+            'contact_id' => $contactB['id'],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeA['id']
+          ],
+          [
+            'contact_id' => $contactC['id'],
+            'is_a_to_b' => 0,
+            'relationship_type_id' => $relationshipTypeB['id']
+          ],
+        ],
+      ]
+    ];
+
+    // Returned contacts should be ContactA and ContactA but since we are filtering
+    // By contactA, only contactA is returned
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id, [$contactA['id']]);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetDoesNotReturnDuplicateContactForContactBelongingToDifferentGroup() {
+    $groupA = $this->createGroup('Group A');
+    $groupB = $this->createGroup('Group B');
+
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $this->addContactToGroup($groupA, $contactA['id']);
+    $this->addContactToGroup($groupB, $contactA['id']);
+
+    $params = [
+      'contact_settings' => [
+        'include_groups' => [$groupA, $groupB]
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ]
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  public function testGetDoesNotReturnDuplicateContactForContactInvolvedInMoreThanOneRelationship() {
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
+
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate();
+
+    //Contact B is Manager to Contact A
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeA['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    //Contact C is Regulator to Contact A
+    $params = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeB['id']
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    //Both parameter condition should return Contact A
+    $params = [
+      'contact_settings' => [
+        'relationship' => [
+          [
+            'contact_id' => $contactB['id'],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeA['id']
+          ],
+          [
+            'contact_id' => $contactC['id'],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeB['id']
+          ],
+        ],
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id);
+
+    $expectedResult = [
+      $contactA['id'] => [
+        'display_name' => $contactA['display_name'],
+        'email' => '',
+      ],
+    ];
+    $this->cleanupUnwantedKeys($contacts);
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+  private function addContactToGroup($groupId, $contactId) {
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $groupId,
+      'contact_id' => $contactId,
+    ]);
+  }
+
+  private function createGroup($title) {
+    $result = civicrm_api3('Group', 'create', [
+      'title' => $title,
+    ]);
+
+    return $result['id'];
+  }
+
+  /**
+   * The return result from the Contact.get API is not reliable
+   * based on the parameters it returns even if the specific parameters
+   * are passed in the return array.
+   * This function makes sure only the keys we are concerned with are present.
+   *
+   * @param array $contacts
+   */
+  private function cleanupUnwantedKeys(&$contacts) {
+    $expectedKeys = ['email' => 0, 'display_name' => 1];
+    foreach ($contacts as &$contact) {
+      $contact = array_intersect_key($contact, $expectedKeys);
+    }
+
+  }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+require_once 'BaseHeadlessTest.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds Unit tests for the Award Panel functionality. Also currently there are no PHP unit tests for Back End for the Award extension, so this PR  also does the PHP unit tests setup for the extension.

## Before
- There were no tests for the Award Panel functionality

## After
- Tests were added for the Award Panel functionality

<img width="960" alt="vagrantcase-award buildkitbuildawardsnewsitesallmodulescivicrmextuk co compucorp civiawards (ssh) 2019-12-20 12-47-23" src="https://user-images.githubusercontent.com/6951813/71253769-1fa8aa00-2329-11ea-8141-5f954a9daf37.png">

