### PR TITLE
RSE-298: Fix Permission Errors

### DIFF
--- a/civiawards.php
+++ b/civiawards.php
@@ -5,6 +5,8 @@
  * CiviAwards Extension.
  */
 
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+
 require_once 'civiawards.civix.php';
 
 /**
@@ -168,6 +170,24 @@ function civiawards_civicrm_permission(&$permissions) {
   $permissions['create/edit awards'] = [
     'CiviAwards: Create/Edit awards',
     ts('Allows a user to create or edit awards'),
+  ];
+}
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_alterAPIPermissions/
+ */
+function civiawards_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissionService = new CaseCategoryPermission();
+  $caseCategoryPermissions = $permissionService->get(CRM_CiviAwards_Helper_CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME);
+  $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
+  $permissions['award_detail']['get'] = [
+    [
+      $caseCategoryPermissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+      $caseCategoryPermissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name'],
+    ],
   ];
 }
 


### PR DESCRIPTION
## Overview
Each case category like Awards, Prospects now have their own respective permissions defined and the permission is needed to access the respective pages for each of the categories.
When testing this functionality, an errors came up for the Award manager when trying to create an Award : API Permission check failed for CaseType/create call: insufficient permission: require Administer Civicase. After fixing this error in https://github.com/compucorp/uk.co.compucorp.civicase/pull/314, an error came up also about permission issue for the AwardDetail entity.

## Before
Permission error when Award manager is trying to create an Award

## After
The default permission when an API permission is not defined is `administer Civicrm`, this was the permission set for the AwardDetail API actions and teh Award manager does not have access to this permission.
This PR fixes the issue by setting appropriate permission for the AwardDetail API actions

- Award manager can now create an Award