### PR TITLE
RSE-362: Fix Add Award button

### DIFF
--- a/ang/civiawards/dashboard/services/add-award-dashboard-action-button.service.js
+++ b/ang/civiawards/dashboard/services/add-award-dashboard-action-button.service.js
@@ -1,4 +1,4 @@
-(function (angular, url) {
+(function (angular, getCrmUrl) {
   var module = angular.module('civiawards');
 
   module.service('AddAwardDashboardActionButton', AddAwardDashboardActionButton);
@@ -6,9 +6,10 @@
   /**
    * Handles the visibility and click event for the "Add Award" dashboard action button.
    *
-   * @param {object} $location the location service
+   * @param {object} $location the location service.
+   * @param {object} $window the window object reference.
    */
-  function AddAwardDashboardActionButton ($location) {
+  function AddAwardDashboardActionButton ($location, $window) {
     this.clickHandler = clickHandler;
     this.isVisible = isVisible;
 
@@ -16,9 +17,9 @@
      * Redirects the user to the awards creation screen.
      */
     function clickHandler () {
-      var newAwardUrl = url('awards/new');
+      var newAwardUrl = getCrmUrl('civicrm/a/#/awards/new');
 
-      $location.url(newAwardUrl);
+      $window.location.href = newAwardUrl;
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -85,32 +85,8 @@
 
         it('fires an event with the award details', () => {
           expect($scope.$emit).toHaveBeenCalledWith('civiawards::edit-award::details-fetched', {
-            caseType: {
-              id: '10',
-              name: 'new_award',
-              title: 'New Award',
-              description: 'Description',
-              is_active: '1',
-              weight: '1',
-              definition: {
-                statuses: ['Open', 'Closed', 'Urgent']
-              },
-              case_type_category: '4',
-              is_forkable: '1',
-              is_forked: ''
-            },
-            additionalDetails: {
-              id: '1',
-              case_type_id: '10',
-              award_type: '1',
-              start_date: '2019-10-29',
-              end_date: '2019-11-29',
-              award_manager: ['2', '1'],
-              review_fields: [
-                { id: '19', weight: 1, required: '1' },
-                { id: '20', weight: 2, required: '0' }
-              ]
-            }
+            caseType: AwardMockData,
+            additionalDetails: AwardAdditionalDetailsMockData
           });
         });
       });

--- a/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
@@ -4,7 +4,7 @@
   describe('Awards Dashboard Action Buttons', () => {
     let AddAwardDashboardActionButton, DashboardActionButtons;
     const expectedActionButton = {
-      buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--white',
+      buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--light',
       iconClass: 'add_circle',
       identifier: 'AddAward',
       label: 'Create new award',

--- a/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
+++ b/ang/test/civiawards/dashboard/services/add-award-dashboard-action-button.service.spec.js
@@ -2,9 +2,13 @@
 
 (function (_, getCrmUrl) {
   describe('Add Award Dashboard Action Button', () => {
-    let $location, AddAwardDashboardActionButton;
+    let $location, $window, AddAwardDashboardActionButton;
 
-    beforeEach(module('civiawards'));
+    beforeEach(module('civiawards', ($provide) => {
+      $window = { location: { href: '' } };
+
+      $provide.value('$window', $window);
+    }));
 
     beforeEach(inject((_$location_, _AddAwardDashboardActionButton_) => {
       $location = _$location_;
@@ -40,15 +44,14 @@
     });
 
     describe('when clicking the action button', () => {
-      const expectedUrl = getCrmUrl('awards/new');
+      const expectedUrl = getCrmUrl('civicrm/a/#/awards/new');
 
       beforeEach(() => {
-        spyOn($location, 'url');
         AddAwardDashboardActionButton.clickHandler();
       });
 
       it('redirects the user to the create award screen', () => {
-        expect($location.url).toHaveBeenCalledWith(expectedUrl);
+        expect($window.location.href).toBe(expectedUrl);
       });
     });
   });


### PR DESCRIPTION
## Overview
This PR fixes the "Add Award" button. After creating a new award the new award would not be seen on the dashboard overview section.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/71602801-48eae680-2b30-11ea-8d68-465231f70d0c.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/71602846-7768c180-2b30-11ea-8821-4108ba8e81d9.gif)

## Technical Details

The problem happened because we were using the `$location` service to redirect the user the the `awards/new` form. This only changes the hash and does not change the actual page. That means that for the browser, the user was always looking at the dashboard and there was no need to refresh the page.

In turn, not refreshing the page is an issue because the case types (awards in this case) are fetched by PHP when the pages refreshes and are stored in the `CRM['civicase-base'].caseType`  variable.

To force the page to reload we redirect the user to `civicrm/a/#/awards/new` which in turn will redirect to the dashboard by refreshing the page and loading the right case types.

## Notes

Some tests were failing, but were fixed as part of this PR:

* `award.directive.spec.js` was referencing the expected values directly, although these values came from mock data objects. After these objects were updated, the test started failing.
* `awards-dashboard-action-buttons.config.spec.js` had the wrong expectation. That right value was changed in the actual configuration file, but the spec was not updated.

