### PR TITLE
RSE-657: Award buttons permissions

### DIFF
--- a/ang/civiawards.ang.php
+++ b/ang/civiawards.ang.php
@@ -16,6 +16,17 @@ $options = [
 ];
 
 OptionValuesHelper::setToJsVariables($options);
+expose_permissions();
+
+/**
+ * Exposes the awards permissions values on the `CRM.permissions` object.
+ */
+function expose_permissions() {
+  Civi::resources()
+    ->addPermissions([
+      'create/edit awards',
+    ]);
+}
 
 /**
  * Get a list of JS files.

--- a/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
+++ b/ang/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.js
@@ -1,17 +1,27 @@
-(function (angular) {
+(function (angular, checkPermission) {
   var module = angular.module('civiawards');
+  var EDIT_AWARD_PERMISSION = 'create/edit awards';
 
-  module.config(function (DashboardActionButtonsProvider) {
+  module.config(function (DashboardActionButtonsProvider, tsProvider) {
+    var ts = tsProvider.$get();
+    var canCreateAwards = checkPermission(EDIT_AWARD_PERMISSION);
     var awardsActionButtons = [
       {
         buttonClass: 'btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--light',
         iconClass: 'add_circle',
         identifier: 'AddAward',
-        label: 'Create new award',
+        label: ts('Create new award'),
         weight: 100
       }
     ];
 
-    DashboardActionButtonsProvider.addButtons(awardsActionButtons);
+    (function () {
+      if (!canCreateAwards) {
+        return;
+      }
+
+      DashboardActionButtonsProvider
+        .addButtons(awardsActionButtons);
+    })();
   });
-})(angular);
+})(angular, CRM.checkPerm);

--- a/ang/civiawards/shared/configs/case-type-buttons.config.js
+++ b/ang/civiawards/shared/configs/case-type-buttons.config.js
@@ -1,29 +1,35 @@
-(function (angular, _, url) {
+(function (angular, _, checkPermission, url) {
   var module = angular.module('civiawards');
   var AWARDS_CATEGORY_NAME = 'awards';
   var AWARD_CONFIG_URL = 'civicrm/a/#/awards/';
+  var EDIT_AWARD_PERMISSION = 'create/edit awards';
 
   module.config(function (CaseTypeProvider, CaseTypeCategoryProvider, DashboardCaseTypeButtonsProvider) {
     var awardCategory = CaseTypeCategoryProvider.findByName(AWARDS_CATEGORY_NAME);
     var awardCaseTypes = CaseTypeProvider.getByCategory(awardCategory.value);
+    var canEditAwards = checkPermission(EDIT_AWARD_PERMISSION);
 
-    addConfigurationButtonsToCaseTypes(awardCaseTypes);
+    (function () {
+      if (!canEditAwards) {
+        return;
+      }
+
+      _.forEach(awardCaseTypes, addConfigurationButtonsToCaseType);
+    })();
 
     /**
-     * Adds configuration buttons to the given case types. The buttons url point
+     * Adds configuration buttons to the given case type. The buttons url point
      * towards the awards configuration form.
      *
-     * @param {object[]} caseTypes a list of case types objects.
+     * @param {object} caseType case type data.
      */
-    function addConfigurationButtonsToCaseTypes (caseTypes) {
-      _.forEach(caseTypes, function (caseType) {
-        var caseTypeConfigUrl = url(AWARD_CONFIG_URL + caseType.id);
+    function addConfigurationButtonsToCaseType (caseType) {
+      var caseTypeConfigUrl = url(AWARD_CONFIG_URL + caseType.id);
 
-        DashboardCaseTypeButtonsProvider.addButtons(caseType.name, [{
-          icon: 'fa fa-cog',
-          url: caseTypeConfigUrl
-        }]);
-      });
+      DashboardCaseTypeButtonsProvider.addButtons(caseType.name, [{
+        icon: 'fa fa-cog',
+        url: caseTypeConfigUrl
+      }]);
     }
   });
-})(angular, CRM._, CRM.url);
+})(angular, CRM._, CRM.checkPerm, CRM.url);

--- a/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/awards-dashboard-action-buttons.config.spec.js
@@ -13,23 +13,59 @@
 
     beforeEach(module('civicase-base', 'civiawards'));
 
-    beforeEach(inject((_AddAwardDashboardActionButton_, _DashboardActionButtons_) => {
-      AddAwardDashboardActionButton = _AddAwardDashboardActionButton_;
-      DashboardActionButtons = _DashboardActionButtons_;
-    }));
+    describe('when the user can create awards', () => {
+      beforeEach(() => {
+        CRM.checkPerm.and.returnValue(true);
 
-    describe('after the awards module has been configured', () => {
-      it('it adds the "Create new award" action button', () => {
-        expect(DashboardActionButtons)
-          .toContain(jasmine.objectContaining(expectedActionButton));
+        injectDependencies();
       });
 
-      it('sets the "AddAward" action button service as the handler', () => {
-        expect(DashboardActionButtons)
-          .toContain(_.extend({}, expectedActionButton, {
-            service: AddAwardDashboardActionButton
-          }));
+      describe('after the awards module has been configured', () => {
+        it('checks if the user can create awards', () => {
+          expect(CRM.checkPerm).toHaveBeenCalledWith('create/edit awards');
+        });
+
+        it('adds the "Create new award" action button', () => {
+          expect(DashboardActionButtons)
+            .toContain(jasmine.objectContaining(expectedActionButton));
+        });
+
+        it('sets the "AddAward" action button service as the handler', () => {
+          expect(DashboardActionButtons)
+            .toContain(_.extend({}, expectedActionButton, {
+              service: AddAwardDashboardActionButton
+            }));
+        });
       });
     });
+
+    describe('when the user cannot create awards', () => {
+      beforeEach(() => {
+        CRM.checkPerm.and.returnValue(false);
+
+        injectDependencies();
+      });
+
+      describe('after the awards module has been configured', () => {
+        it('checks if the user can create awards', () => {
+          expect(CRM.checkPerm).toHaveBeenCalledWith('create/edit awards');
+        });
+
+        it('does not add the "Create new award" action button', () => {
+          expect(DashboardActionButtons)
+            .not.toContain(jasmine.objectContaining(expectedActionButton));
+        });
+      });
+    });
+
+    /**
+     * Injects and hoists the dependencies needed for the test.
+     */
+    function injectDependencies () {
+      inject((_AddAwardDashboardActionButton_, _DashboardActionButtons_) => {
+        AddAwardDashboardActionButton = _AddAwardDashboardActionButton_;
+        DashboardActionButtons = _DashboardActionButtons_;
+      });
+    }
   });
 })(CRM._);

--- a/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
+++ b/ang/test/civiawards/shared/configs/case-type-buttons.config.spec.js
@@ -9,40 +9,75 @@
 
     beforeEach(module('civiawards.data', 'civicase-base', 'civiawards'));
 
-    beforeEach(inject((_AwardMockData_, _DashboardCaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
-      AwardMockData = _AwardMockData_;
-      CaseTypesMockData = _CaseTypesMockData_.get();
-      DashboardCaseTypeButtons = _DashboardCaseTypeButtons_;
-      AwardsCategory = _.find(
-        caseTypeCategoriesMockData,
-        (category) => category.name === AWARDS_CATEGORY_NAME
-      );
-    }));
+    describe('when the user can edit awards', () => {
+      beforeEach(() => {
+        CRM.checkPerm.and.returnValue(true);
 
-    describe('after the awards module has been configured', () => {
-      it('it adds the configuration url to the awards case type', () => {
-        expect(DashboardCaseTypeButtons).toEqual({
-          [AwardMockData.name]: [{
-            icon: 'fa fa-cog',
-            url: getCrmUrl(AWARD_CONFIG_URL + AwardMockData.id)
-          }]
+        injectDependencies();
+      });
+
+      describe('after the awards module has been configured', () => {
+        it('checks that the user can edit awards', () => {
+          expect(CRM.checkPerm).toHaveBeenCalledWith('create/edit awards');
+        });
+
+        it('adds the configuration url to the awards case type', () => {
+          expect(DashboardCaseTypeButtons).toEqual({
+            [AwardMockData.name]: [{
+              icon: 'fa fa-cog',
+              url: getCrmUrl(AWARD_CONFIG_URL + AwardMockData.id)
+            }]
+          });
+        });
+      });
+
+      describe('when requesting the buttons for non award case types', () => {
+        let nonAwardscaseTypes;
+
+        beforeEach(() => {
+          nonAwardscaseTypes = _.chain(CaseTypesMockData)
+            .filter(caseType => caseType.category !== AwardsCategory.value)
+            .map('name')
+            .value();
+        });
+
+        it('does not add configuration buttons to non award case types', () => {
+          expect(_.keys(DashboardCaseTypeButtons)).not.toContain(nonAwardscaseTypes);
         });
       });
     });
 
-    describe('when requesting the buttons for non award case types', () => {
-      let nonAwardscaseTypes;
-
+    describe('when the user cannot edit awards', () => {
       beforeEach(() => {
-        nonAwardscaseTypes = _.chain(CaseTypesMockData)
-          .filter(caseType => caseType.category !== AwardsCategory.value)
-          .map('name')
-          .value();
+        CRM.checkPerm.and.returnValue(false);
+
+        injectDependencies();
       });
 
-      it('it does not add configuration buttons to non award case types', () => {
-        expect(_.keys(DashboardCaseTypeButtons)).not.toContain(nonAwardscaseTypes);
+      describe('after the awards module has been configured', () => {
+        it('checks that the user can edit awards', () => {
+          expect(CRM.checkPerm).toHaveBeenCalledWith('create/edit awards');
+        });
+
+        it('does not add the configuration url to the awards case type', () => {
+          expect(DashboardCaseTypeButtons).toEqual({});
+        });
       });
     });
+
+    /**
+     * Injects and hoists the dependencies needed for the test.
+     */
+    function injectDependencies () {
+      inject((_AwardMockData_, _DashboardCaseTypeButtons_, caseTypeCategoriesMockData, _CaseTypesMockData_) => {
+        AwardMockData = _AwardMockData_;
+        CaseTypesMockData = _CaseTypesMockData_.get();
+        DashboardCaseTypeButtons = _DashboardCaseTypeButtons_;
+        AwardsCategory = _.find(
+          caseTypeCategoriesMockData,
+          (category) => category.name === AWARDS_CATEGORY_NAME
+        );
+      });
+    }
   });
 })(CRM._, angular, CRM.url);


### PR DESCRIPTION
## Overview

This PR only displays the "Create New Award" button, and the edit award cogs when the user has permission to create or edit awards only.

## Before & After

<table>
  <tr>
    <th></th>
    <th>No Permission</th>
    <th>With Permission</th>
  </tr>
  <tr>
    <th>Before</th>
    <td><img src="https://user-images.githubusercontent.com/1642119/71793261-89f06880-3012-11ea-8421-8ef1ad8e7902.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/71793262-89f06880-3012-11ea-9c86-85a1b534fb0a.png" /></td>
  </tr>
  <tr>
    <th>After</th>
    <td>
<img src="https://user-images.githubusercontent.com/1642119/71793153-f5860600-3011-11ea-800a-f4efe9566890.png" />
</td>
    <td>
<img src="https://user-images.githubusercontent.com/1642119/71793164-020a5e80-3012-11ea-9792-77a9a3c8ff7f.png" />

</td>
  </tr>
</table>

## Technical Details

This PR uses the permission introduced in https://github.com/compucorp/uk.co.compucorp.civiawards/pull/33

CiviCRM does not automatically add every permission to the `CRM.permissions` variable so we needed to manually expose it:

```php
  Civi::resources()
    ->addPermissions([
      'create/edit awards',
    ]);
```

The configuration files for adding the buttons use `CRM.checkPerm` to determine if they should or should not add the respective buttons.
