### PR TITLE
RSE-363: Fix more filters bug

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -62,12 +62,14 @@
      * Open more filtes dialog
      */
     function openMoreFiltersDialog () {
-      dialogService.open('MoreFilters', '~/civiawards/dashboard/directives/more-filters-popup.html', model, {
-        autoOpen: false,
-        height: 'auto',
-        width: '350px',
-        title: 'More Filters'
-      });
+      if (!dialogService.dialogs.MoreFilters) {
+        dialogService.open('MoreFilters', '~/civiawards/dashboard/directives/more-filters-popup.html', model, {
+          autoOpen: false,
+          height: 'auto',
+          width: '350px',
+          title: 'More Filters'
+        });
+      }
     }
 
     /**

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -20,6 +20,7 @@
       dialogService = _dialogService_;
       crmApi = _crmApi_;
 
+      dialogService.dialogs = {};
       crmApiMock.and.returnValue($q.resolve({
         values: [{
           case_type_id: 1
@@ -71,6 +72,17 @@
           height: 'auto',
           width: '350px',
           title: 'More Filters'
+        });
+      });
+
+      describe('when the action button is clicked again before closing the button', () => {
+        beforeEach(() => {
+          dialogService.dialogs.MoreFilters = true;
+          $scope.openMoreFiltersDialog();
+        });
+
+        it('does not reopen the more filter popup', () => {
+          expect(dialogService.open.calls.count()).toBe(1);
         });
       });
     });


### PR DESCRIPTION
## Overview
Previously if the More Filters button is pressed more than once, multiple popups were being created. This PR fixes that.

## Before
![2020-01-07 at 3 42 PM](https://user-images.githubusercontent.com/5058867/71887559-60dfed00-3164-11ea-9aa2-ff84501087a9.jpg)

## After
![2020-01-07 at 3 43 PM](https://user-images.githubusercontent.com/5058867/71887584-6dfcdc00-3164-11ea-8596-18aab7a8a698.jpg)

## Technical Details
In `more-filters-dashboard-action-button.controller.js`, added a check to see if the Popup already exists before creating a new one.