### PR TITLE
RSE-298: Fix Permission Issue with Creating Award for An Award Manager

### DIFF
--- a/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
@@ -1,0 +1,98 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseAwardHelper;
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+
+/**
+ * Class CRM_Civicase_Hook_APIPermissions_alterPermissions.
+ */
+class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
+
+  /**
+   * Alters the API permissions.
+   *
+   * @param string $entity
+   *   The API entity.
+   * @param string $action
+   *   The API action.
+   * @param array $params
+   *   The API parameters.
+   * @param array $permissions
+   *   The API permissions.
+   */
+  public function run($entity, $action, array &$params, array &$permissions) {
+    $permissionService = new CaseCategoryPermission();
+    $caseCategoryPermissions = $permissionService->get(CaseAwardHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
+    $permissions['award_detail']['get'] = [
+      [
+        $caseCategoryPermissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+        $caseCategoryPermissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+        $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name'],
+      ],
+    ];
+    $awardCreatePermission = [
+      ['administer CiviCase', 'create/edit awards']
+    ];
+    $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
+
+    if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
+      $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;
+    }
+  }
+
+  /**
+   * @param $entity
+   * @param $action
+   * @param array $params
+   * @return bool
+   */
+  private function modifyCaseTypeApiPermission($entity, $action, array &$params) {
+    $isCaseTypeCreateOrEdit = $entity == 'case_type' && in_array($action, ['create', 'update']);
+    if (!$isCaseTypeCreateOrEdit) {
+      return FALSE;
+    }
+
+    $caseCategoryName = $this->getCaseCategoryNameForCaseTypeWhenActionIsCreateOrEdit($params);
+    if ($caseCategoryName == CaseAwardHelper::AWARDS_CASE_TYPE_CATEGORY_NAME) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Returns the case category name when action is create/edit
+   *
+   * @param array $params
+   *   API parameters.
+   *
+   * @return string|null
+   *   Case category name.
+   */
+  private function getCaseCategoryNameForCaseTypeWhenActionIsCreateOrEdit(array $params) {
+    if (empty($params['case_type_category'])) {
+      return;
+    }
+
+    return $this->getCaseTypeCategoryNameFromOptions($params['case_type_category']);
+  }
+
+  /**
+   * Returns the case category name from case type id or name.
+   *
+   * @param mixed $caseTypeCategory
+   *   Case category name.
+   *
+   * @return string
+   *   Case category name.
+   */
+  private function getCaseTypeCategoryNameFromOptions($caseTypeCategory) {
+    if (!is_numeric($caseTypeCategory)) {
+      return $caseTypeCategory;
+    }
+
+    return CaseCategoryHelper::getCaseCategoryNameFromOptionValue($caseTypeCategory);
+  }
+
+}

--- a/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
@@ -32,7 +32,7 @@ class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
       ],
     ];
     $awardCreatePermission = [
-      ['administer CiviCase', 'create/edit awards']
+      ['administer CiviCase', 'create/edit awards'],
     ];
     $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
 
@@ -42,10 +42,20 @@ class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
   }
 
   /**
-   * @param $entity
-   * @param $action
+   * Checks whether to modify case type API permissions.
+   *
+   * When the case type to be created is of type award, the permission
+   * is to be modified and function returns true.
+   *
+   * @param string $entity
+   *   The API entity.
+   * @param string $action
+   *   The API action.
    * @param array $params
+   *   Params.
+   *
    * @return bool
+   *   Whether to modify API permission or not.
    */
   private function modifyCaseTypeApiPermission($entity, $action, array &$params) {
     $isCaseTypeCreateOrEdit = $entity == 'case_type' && in_array($action, ['create', 'update']);
@@ -62,7 +72,7 @@ class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
   }
 
   /**
-   * Returns the case category name when action is create/edit
+   * Returns the case category name when action is create/edit.
    *
    * @param array $params
    *   API parameters.

--- a/civiawards.php
+++ b/civiawards.php
@@ -179,16 +179,13 @@ function civiawards_civicrm_permission(&$permissions) {
  * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_alterAPIPermissions/
  */
 function civiawards_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
-  $permissionService = new CaseCategoryPermission();
-  $caseCategoryPermissions = $permissionService->get(CRM_CiviAwards_Helper_CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME);
-  $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
-  $permissions['award_detail']['get'] = [
-    [
-      $caseCategoryPermissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
-      $caseCategoryPermissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name'],
-      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name'],
-    ],
+  $hooks = [
+    new CRM_CiviAwards_Hook_alterAPIPermissions_Award(),
   ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($entity, $action, $params, $permissions);
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
For a user to be able to create and Award, the user must either of `Create / edit award` or `Administer CiviCase`.  Currently when creating an award Case Type, the permission required is the Administer CiviAward  permission. We don't need this permission and it has been removed [here](https://github.com/compucorp/uk.co.compucorp.civicase/pull/326). This PR makes sure that the required permission to create an Award case type is set.

## Before
- Currently when creating an award Case Type, the permission required is the Administer CiviAward  permission

## After
-  When creating an award Case Type, the permission required is either `Create / edit award` or `Administer CiviCase`

## Technical Details
The `civiawards_civicrm_alterAPIPermissions` hook is used to achieve the functionality. When a call to update/create a Case Type via an API is made, the case type category is checked and if it is an Award case type to be created, the permission is modified to require either the `Create / edit award` or `Administer CiviCase` permission

```php
    $awardCreatePermission = [
      ['administer CiviCase', 'create/edit awards'],
    ];

    // If case type of award category is to be created
    if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
      $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;
    }
```
