### PR TITLE
RSE-644: Show reviews form

### DIFF
--- a/ang/civiawards/activity-forms/activity-forms.config.js
+++ b/ang/civiawards/activity-forms/activity-forms.config.js
@@ -1,0 +1,21 @@
+(function (angular) {
+  var module = angular.module('civiawards');
+
+  module.config(activityFormsConfiguration);
+
+  /**
+   * Award activity forms configuration.
+   *
+   * @param {object} ActivityFormsProvider the activity forms provider.
+   */
+  function activityFormsConfiguration (ActivityFormsProvider) {
+    var activityFormConfigs = [
+      {
+        name: 'ReviewActivityForm',
+        weight: -1
+      }
+    ];
+
+    ActivityFormsProvider.addActivityForms(activityFormConfigs);
+  }
+})(angular);

--- a/ang/civiawards/activity-forms/services/review-form.service.js
+++ b/ang/civiawards/activity-forms/services/review-form.service.js
@@ -1,0 +1,44 @@
+(function (angular, getCrmUrl) {
+  var module = angular.module('civiawards');
+
+  module.service('ReviewActivityForm', ReviewActivityForm);
+
+  /**
+   * Review Activity Form service.
+   */
+  function ReviewActivityForm () {
+    this.canHandleActivity = canHandleActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {boolean} true when the activity is an application review.
+     */
+    function canHandleActivity (activity) {
+      return activity.type === 'Applicant Review';
+    }
+
+    /**
+     * Returns the form's URL for the review activity. If the form will
+     * be shown in a popup it automatically opens the form in edit mode.
+     *
+     * @param {object} activity an activity object.
+     * @param {object} options form options.
+     * @returns {string} the form URL.
+     */
+    function getActivityFormUrl (activity, options) {
+      var action = 'view';
+      var isPopupForm = options && options.formType === 'popup';
+
+      if (isPopupForm) {
+        action = 'update';
+      }
+
+      return getCrmUrl('civicrm/awardreview', {
+        action: action,
+        id: activity.id,
+        reset: 1
+      });
+    }
+  }
+})(angular, CRM.url);

--- a/ang/test/civiawards/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civiawards/activity-forms/activity-forms.config.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env jasmine */
+(() => {
+  describe('Acitivity forms configuration', () => {
+    let ActivityFormsProvider;
+
+    beforeEach(module('civicase-base', (_ActivityFormsProvider_) => {
+      ActivityFormsProvider = _ActivityFormsProvider_;
+
+      spyOn(ActivityFormsProvider, 'addActivityForms');
+    }));
+
+    beforeEach(module('civiawards'));
+
+    beforeEach(inject);
+
+    describe('when the awards module is configured', () => {
+      it('adds the reviews activity form before any other activity forms', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'ReviewActivityForm',
+            weight: -1
+          }]));
+      });
+    });
+  });
+})();

--- a/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
+++ b/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('ReviewActivityForm', () => {
+    let activityFormUrl, expectedActivityFormUrl, ReviewActivityForm, canHandle, reviewActivity;
+
+    beforeEach(module('civiawards', 'civicase-base', 'civiawards.data'));
+
+    beforeEach(inject((_ReviewActivitiesMockData_, _ReviewActivityForm_) => {
+      ReviewActivityForm = _ReviewActivityForm_;
+      reviewActivity = _.chain(_ReviewActivitiesMockData_)
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('handling activity forms', () => {
+      describe('when handling a review activity type', () => {
+        beforeEach(() => {
+          reviewActivity.type = 'Applicant Review';
+          canHandle = ReviewActivityForm.canHandleActivity(reviewActivity);
+        });
+
+        it('can handle the application activity', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling any other activity type', () => {
+        beforeEach(() => {
+          reviewActivity.type = 'Housing Support';
+          canHandle = ReviewActivityForm.canHandleActivity(reviewActivity);
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+    });
+
+    describe('getting the activity form url', () => {
+      describe('when getting the activity form url', () => {
+        beforeEach(() => {
+          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
+            action: 'view',
+            id: reviewActivity.id,
+            reset: 1
+          });
+        });
+
+        it('returns the url for the review activity form', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the activity popup form url', () => {
+        beforeEach(() => {
+          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity, {
+            formType: 'popup'
+          });
+          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
+            action: 'update',
+            id: reviewActivity.id,
+            reset: 1
+          });
+        });
+
+        it('returns the url for the review activity popup form', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/mocks/data/reviews.data.js
+++ b/ang/test/mocks/data/reviews.data.js
@@ -1,0 +1,66 @@
+(() => {
+  var module = angular.module('civiawards.data');
+
+  module.constant('ReviewActivitiesMockData', [
+    {
+      id: '128',
+      activity_type_id: '69',
+      activity_date_time: '2019-12-23 08:19:09',
+      status_id: '2',
+      priority_id: '2',
+      is_test: '0',
+      is_auto: '0',
+      is_current_revision: '1',
+      is_deleted: '0',
+      is_star: '0',
+      created_date: '2019-12-23 08:19:09',
+      modified_date: '2019-12-23 08:19:09',
+      custom_19: '80',
+      custom_20: '50',
+      custom_21: '19',
+      source_contact_id: '2',
+      source_contact_name: 'Compu Admin',
+      source_contact_sort_name: 'Admin, Compu'
+    },
+    {
+      id: '129',
+      activity_type_id: '69',
+      activity_date_time: '2019-12-23 08:20:06',
+      status_id: '2',
+      priority_id: '2',
+      is_test: '0',
+      is_auto: '0',
+      is_current_revision: '1',
+      is_deleted: '0',
+      is_star: '0',
+      created_date: '2019-12-23 08:20:06',
+      modified_date: '2019-12-23 08:20:06',
+      custom_19: '81',
+      custom_20: '51',
+      custom_21: '20',
+      source_contact_id: '2',
+      source_contact_name: 'Compu Admin',
+      source_contact_sort_name: 'Admin, Compu'
+    },
+    {
+      id: '132',
+      activity_type_id: '69',
+      activity_date_time: '2019-12-23 08:56:00',
+      status_id: '2',
+      priority_id: '2',
+      is_test: '0',
+      is_auto: '0',
+      is_current_revision: '1',
+      is_deleted: '0',
+      is_star: '0',
+      created_date: '2019-12-23 08:56:00',
+      modified_date: '2019-12-23 08:56:00',
+      custom_19: '82',
+      custom_20: '52',
+      custom_21: '21',
+      source_contact_id: '2',
+      source_contact_name: 'Compu Admin',
+      source_contact_sort_name: 'Admin, Compu'
+    }
+  ]);
+})();


### PR DESCRIPTION
## Overview
This PR displays the review custom form when viewing activities of the review type.

## Before

### Opening review activity popup
![popup-before](https://user-images.githubusercontent.com/1642119/72028502-1ee4a300-3259-11ea-81e1-e7c70cc563f7.gif)

### View Review Activity details
![activity-before](https://user-images.githubusercontent.com/1642119/72028572-6bc87980-3259-11ea-818d-00eac33b9799.gif)

## After

### Opening review activity popup
![popup-after](https://user-images.githubusercontent.com/1642119/72028300-60c11980-3258-11ea-97b8-8d9c43589c4b.gif)

### View Review Activity details
![activity-after](https://user-images.githubusercontent.com/1642119/72028354-8f3ef480-3258-11ea-933f-5c143df0c8f4.gif)

## Technical Details

* Uses the activity form provider introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/329
* Adds a `ReviewActivityForm` activity form service that can handle any activity of the `'Applicant Review` type.