### PR TITLE
RSE-733: Add Application manager role for Awards

### DIFF
--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -202,7 +202,13 @@
         description: $scope.basicDetails.description,
         is_active: $scope.basicDetails.isEnabled,
         case_type_category: CaseTypeCategory.findByName('awards').value,
-        name: generateAwardName($scope.basicDetails.title)
+        name: generateAwardName($scope.basicDetails.title),
+        definition: {
+          caseRoles: [{
+            name: 'Application Manager',
+            manager: 1
+          }]
+        }
       };
 
       prepareAwardStagesWhenEditings(params);
@@ -249,9 +255,7 @@
         .value();
       var areAllAwardsSelected = selectedAwardStageNames.length === _.size($scope.awardStages);
 
-      params.definition = {
-        statuses: areAllAwardsSelected ? [] : selectedAwardStageNames
-      };
+      params.definition.statuses = areAllAwardsSelected ? [] : selectedAwardStageNames;
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -186,7 +186,13 @@
               description: 'description',
               is_active: true,
               case_type_category: '3',
-              name: 'title'
+              name: 'title',
+              definition: {
+                caseRoles: [{
+                  name: 'Application Manager',
+                  manager: 1
+                }]
+              }
             });
           });
 
@@ -234,7 +240,13 @@
             is_active: true,
             case_type_category: '3',
             name: 'title',
-            definition: { statuses: ['Open'] },
+            definition: {
+              caseRoles: [{
+                name: 'Application Manager',
+                manager: 1
+              }],
+              statuses: ['Open']
+            },
             id: '10'
           });
         });


### PR DESCRIPTION
## Overview
Previously the People Tab under Case Details was broken for Award Type Cases. This PR fixes that by adding a `Application manager` role for all Awards.

## Before
![2020-02-07 at 2 01 PM](https://user-images.githubusercontent.com/5058867/74013383-59557300-49b2-11ea-96ed-8a61243120d0.jpg)

## After
![2020-02-07 at 2 00 PM](https://user-images.githubusercontent.com/5058867/74013344-42168580-49b2-11ea-9924-55ad9de5d7a4.jpg)

## Technical Details
Unlike Case Type of Non Award type, while creating Awards, the `CaseRoles` are not defined, which resulted in the People Tab being broken. To fix this, a role called `Application Manager` is created and the `manager` flag is set to true. Means people assigned to this role, will also be Award Application Manager.

```javascript
definition: {
  caseRoles: [{
    name: 'Application Manager',
    manager: 1
  }]
}
```
