### PR TITLE
RSE-856: Add Access Review Custom Field Set Permission & Functionality

### DIFF
--- a/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
@@ -23,7 +23,7 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'activity_category',
       'name' => self::APPLICANT_REVIEW,
-      'label' => self::APPLICANT_REVIEW,
+      'label' => ts(self::APPLICANT_REVIEW),
       'is_default' => 1,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
@@ -38,7 +38,7 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'activity_type',
       'name' => self::APPLICANT_REVIEW,
-      'label' => self::APPLICANT_REVIEW,
+      'label' => ts(self::APPLICANT_REVIEW),
       'grouping' => self::APPLICANT_REVIEW,
       'icon' => 'fa-user',
       'component_id' => !empty($civicaseComponent->componentID) ? $civicaseComponent->componentID : '',

--- a/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
@@ -5,6 +5,8 @@
  */
 class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
 
+  const APPLICANT_REVIEW = 'Applicant Review';
+
   /**
    * Adds the Applicant review activity type and category.
    */
@@ -20,8 +22,8 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
   private function addApplicantReviewCategory() {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'activity_category',
-      'name' => 'Applicant Review',
-      'label' => 'Applicant Review',
+      'name' => self::APPLICANT_REVIEW,
+      'label' => self::APPLICANT_REVIEW,
       'is_default' => 1,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
@@ -35,9 +37,9 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
     $civicaseComponent = CRM_Core_Component::get('CiviCase');
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'activity_type',
-      'name' => 'Applicant Review',
-      'label' => 'Applicant Review',
-      'grouping' => 'Applicant Review',
+      'name' => self::APPLICANT_REVIEW,
+      'label' => self::APPLICANT_REVIEW,
+      'grouping' => self::APPLICANT_REVIEW,
       'icon' => 'fa-user',
       'component_id' => !empty($civicaseComponent->componentID) ? $civicaseComponent->componentID : '',
       'is_default' => 1,
@@ -47,11 +49,12 @@ class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
   }
 
   /**
-   * Sets activity status 'Scheduled' and 'Completed' for applicant
-   * review activity type if not already set.
+   * Sets activity status 'Scheduled' and 'Completed'.
+   *
+   * Sets for applicant review activity type if not already set.
    */
   private function setApplicantReviewActivityTypeStatuses() {
-    $applicantReviewActivityName = 'Applicant Review';
+    $applicantReviewActivityName = self::APPLICANT_REVIEW;
     $statuses = civicrm_api3('OptionValue', 'get', [
       'name' => ['IN' => ['Scheduled', 'Completed']],
       'option_group_id' => 'activity_status',

--- a/civiawards.php
+++ b/civiawards.php
@@ -5,8 +5,6 @@
  * CiviAwards Extension.
  */
 
-use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
-
 require_once 'civiawards.civix.php';
 
 /**
@@ -170,6 +168,14 @@ function civiawards_civicrm_permission(&$permissions) {
   $permissions['create/edit awards'] = [
     'CiviAwards: Create/Edit awards',
     ts('Allows a user to create or edit awards'),
+  ];
+
+  $permissions['access review custom field set'] = [
+    'CiviAwards: Access review fields ',
+    ts(
+      "This allows the user to view any review field sets on the reserved review activity type.
+       Note that this can also be done through ACLs or allocating the user 'Access all custom data' permission"
+    ),
   ];
 }
 

--- a/civiawards.php
+++ b/civiawards.php
@@ -156,22 +156,22 @@ function civiawards_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 function civiawards_civicrm_permission(&$permissions) {
   // Add permission defined by this extension.
   $permissions['access awards panel portal'] = [
-    'CiviAwards: Access awards panel portal',
+    ts('CiviAwards: Access awards panel portal'),
     ts('Allows a user to access the awards panel portal'),
   ];
 
   $permissions['access applicant portal'] = [
-    'CiviAwards: Access applicant portal',
+    ts('CiviAwards: Access applicant portal'),
     ts('Allows a user to access the awards applicant portal'),
   ];
 
   $permissions['create/edit awards'] = [
-    'CiviAwards: Create/Edit awards',
+    ts('CiviAwards: Create/Edit awards'),
     ts('Allows a user to create or edit awards'),
   ];
 
   $permissions['access review custom field set'] = [
-    'CiviAwards: Access review fields ',
+    ts('CiviAwards: Access review fields '),
     ts(
       "This allows the user to view any review field sets on the reserved review activity type.
        Note that this can also be done through ACLs or allocating the user 'Access all custom data' permission"


### PR DESCRIPTION
## Overview
Currently when the Award manager is not able to view or add review custom fields to an award except the Award manager has the `administer CiviCRM` and the `access all custom data` permissions. In the real scenario, the Award manager will not have access to these two permissions (at least the `administer CiviCRM` permission). This PR adds a new permission `access review custom field set` that allows the Award manager to view Award review custom fields only (i.e Custom fields belonging to a Custom Group that belongs to the reserved Applicant Review activity type).

## Before
Award manager cannot view not add review custom fields without having both the `administer CiviCRM` and the `access all custom data` permissions.

<img width="1280" alt="Configure Award - Latest Award  CiviAwards 2020-02-10 14-50-06" src="https://user-images.githubusercontent.com/6951813/74155364-c36d5280-4c14-11ea-8ebd-92972b64c23f.png">


## After
Award manager can view and add review custom fields when assigned the new permission : `access review custom field set`

<img width="1279" alt="Configure Award - Latest Award  CiviAwards 2020-02-10 14-52-13" src="https://user-images.githubusercontent.com/6951813/74155524-062f2a80-4c15-11ea-85ae-e25ac456f040.png">


## Technical Details
- The `civiawards_civicrm_alterAPIPermissions` is used for this implementation. A new function `modifyCustomFieldApiPermission` is added to the `CRM_CiviAwards_Hook_alterAPIPermissions_Award` class ensures that the permission for the CustomField.get API is only modified if the Custom group for the custom fields only extend the Applicant Review activity type. 

```php
    if ($this->modifyCustomFieldApiPermission($entity, $action, $params)) {
      $permissions['custom_field']['get'] = [
        ['access review custom field set', 'access all custom data'],
      ];
    }
```

