### PR TITLE
RSE-363: Fix Issue With Awards Showing For User Who is Not Manager

### DIFF
--- a/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/alterAPIPermissions/Award.php
@@ -36,6 +36,7 @@ class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
       ['administer CiviCase', 'create/edit awards'],
     ];
     $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
+    $permissions['award_manager']['get'] = $awardCreatePermission;
 
     if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
       $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;


### PR DESCRIPTION
## Overview
Currently an Award manager is able to see other awards belonging to another manager when viewing the dashboard.

## Before
Award manager is able to see other awards of which he is not the manager on the dashboard.

## After
Award manager is not able to see other awards of which he is not the manager on the dashboard.
The frontend normally calls the AwardManager.get API to fetch the award types that the current logged in manager has access to. This API call was failing because of permission issues: `insufficient permission, require administer Civicrm`. 
The fix was to set the correct permission for this API so that results are returned and the FE is able to filter award types that the user can see.