### PR TITLE
RSE-891:  Allow Award Manger Access Review Custom Field set without ACL configuration

### DIFF
--- a/CRM/CiviAwards/Helper/ApplicantReview.php
+++ b/CRM/CiviAwards/Helper/ApplicantReview.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
+
+/**
+ * Class CRM_CiviAwards_Helper_ApplicantReview.
+ */
+class CRM_CiviAwards_Helper_ApplicantReview {
+
+  /**
+   * Return the Activity Applicant review Id.
+   *
+   * @return int
+   *   Activity Type Id.
+   */
+  public static function getActivityTypeId() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'return' => ['value'],
+      'sequential' => 1,
+      'option_group_id' => 'activity_type',
+      'name' => CreateApplicantReviewActivityType::APPLICANT_REVIEW,
+    ]);
+
+    return $result['values'][0]['value'];
+  }
+
+}

--- a/CRM/CiviAwards/Hook/AclGroup/AllowAccessToApplicantReviewGroups.php
+++ b/CRM/CiviAwards/Hook/AclGroup/AllowAccessToApplicantReviewGroups.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
+
+/**
+ * Class CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups.
+ */
+class CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups {
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $type
+   *   The type of permission needed.
+   * @param int $contactID
+   *   The contactID for whom the check is made.
+   * @param string $tableName
+   *   The tableName which is being permissioned.
+   * @param array $allGroups
+   *   The set of all the objects for the above table.
+   * @param array $currentGroups
+   *   The set of objects that are currently permissioned for this contact.
+   */
+  public function run($type, $contactID, $tableName, array &$allGroups, array &$currentGroups) {
+    if (!$this->shouldRun($tableName)) {
+      return;
+    }
+    $applicantReviewCustomGroups = $this->getApplicantReviewCustomGroups();
+    if (!$applicantReviewCustomGroups) {
+      return;
+    }
+
+    foreach ($applicantReviewCustomGroups as $applicantReviewCustomGroup) {
+      $currentGroups[] = $applicantReviewCustomGroup['id'];
+    }
+
+    $currentGroups = array_unique($currentGroups);
+  }
+
+  /**
+   * Returns the Custom groups attached to the Applicant review activity type.
+   */
+  private function getApplicantReviewCustomGroups() {
+    $applicantReviewCustomGroups = [];
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'extends' => 'Activity',
+      'extends_entity_column_value' => ApplicantReviewHelper::getActivityTypeId(),
+    ]);
+
+    if (!empty($result['values'])) {
+      $applicantReviewCustomGroups = $result['values'];
+    }
+
+    return $applicantReviewCustomGroups;
+  }
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $tableName
+   *   The tableName which is being permissioned.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($tableName) {
+    return $tableName == CRM_Core_BAO_CustomGroup::getTableName() && CRM_Core_Permission::check('access review custom field set');
+  }
+
+}

--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -1,9 +1,9 @@
 <?php
 
+use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_CiviAwards_Helper_CaseTypeCategory as CaseAwardHelper;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
-use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 
 /**
  * Class CRM_Civicase_Hook_APIPermissions_alterPermissions.
@@ -143,13 +143,7 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
       return FALSE;
     }
 
-    $result = civicrm_api3('OptionValue', 'get', [
-      'return' => ['value'],
-      'sequential' => 1,
-      'option_group_id' => 'activity_type',
-      'name' => CreateApplicantReviewActivityType::APPLICANT_REVIEW,
-    ]);
-    $applicantReviewId = $result['values'][0]['value'];
+    $applicantReviewId = ApplicantReviewHelper::getActivityTypeId();
     $isOfApplicantReview = FALSE;
     foreach ($groupDetails as $groupDetail) {
       $groupExtendsActivity = $groupDetail['extends'] == 'Activity';

--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -8,7 +8,7 @@ use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantRev
 /**
  * Class CRM_Civicase_Hook_APIPermissions_alterPermissions.
  */
-class CRM_CiviAwards_Hook_alterAPIPermissions_Award {
+class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
 
   /**
    * Alters the API permissions.

--- a/civiawards.php
+++ b/civiawards.php
@@ -195,6 +195,21 @@ function civiawards_civicrm_alterAPIPermissions($entity, $action, &$params, &$pe
 }
 
 /**
+ * Implements hook_civicrm_aclGroup().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_aclGroup/
+ */
+function civiawards_civicrm_aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
+  $hooks = [
+    new CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($type, $contactID, $tableName, $allGroups, $currentGroups);
+  }
+}
+
+/**
  * Implements addCiviCaseDependentAngularModules().
  */
 function civiawards_addCiviCaseDependentAngularModules(&$dependentModules) {

--- a/civiawards.php
+++ b/civiawards.php
@@ -186,7 +186,7 @@ function civiawards_civicrm_permission(&$permissions) {
  */
 function civiawards_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   $hooks = [
-    new CRM_CiviAwards_Hook_alterAPIPermissions_Award(),
+    new CRM_CiviAwards_Hook_AlterAPIPermissions_Award(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
Currently for the Award manager to view and save custom field set for an Award, the combination of the `access review custom field set` permission and ACL configuration for the Applicant Review custom group is needed.  We don't need that to happen anymore as we only want the `access review custom field set` permission to be sufficient for the Award manager to view and save applicant review custom field set for an Award.

## Before
- For the Award manager to view and save custom field set for an Award, the combination of the `access review custom field set` and ACL configuration for the Applicant Review custom group is needed.

## After
- For the Award manager to view and save custom field set for an Award, only the `access review custom field set` permission is needed.

## Technical Details
The `civiawards_civicrm_aclGroup` hook is implemented to solve the problem here. 
The logged in user is allowed access to all custom groups attached to the applicant review type as long as the user has the `access review custom field set` permission

```php
  public function run($type, $contactID, $tableName, array &$allGroups, array &$currentGroups) {
    if (!$this->shouldRun($tableName)) {
      return;
    }
    $applicantReviewCustomGroups = $this->getApplicantReviewCustomGroups();
    if (!$applicantReviewCustomGroups) {
      return;
    }

    foreach ($applicantReviewCustomGroups as $applicantReviewCustomGroup) {
      $currentGroups[] = $applicantReviewCustomGroup['id'];
    }

    $currentGroups = array_unique($currentGroups);
  }
```