### PR TITLE
RSE-363: Filter by Award Status

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -88,13 +88,15 @@
       processMyAwardsFilter()
         .then(processAwardTypeFilters)
         .then(function (awardTypeIds) {
-          var caseTypeFilter = awardTypeIds.length > 0
-            ? { IN: awardTypeIds }
-            : '';
+          var param = {
+            case_type_id: awardTypeIds.length > 0 ? { IN: awardTypeIds } : ''
+          };
 
-          $rootScope.$broadcast('civicase::dashboard-filters::updated', {
-            case_type_id: caseTypeFilter
-          });
+          if (model.selectedFilters.statuses.length > 0) {
+            param.status_id = { IN: getSelect2Value(model.selectedFilters.statuses) };
+          }
+
+          $rootScope.$broadcast('civicase::dashboard-filters::updated', param);
         });
     }
 

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -20,6 +20,8 @@
       dialogService = _dialogService_;
       crmApi = _crmApi_;
 
+      spyOn($rootScope, '$broadcast').and.callThrough();
+
       dialogService.dialogs = {};
       crmApiMock.and.returnValue($q.resolve({
         values: [{
@@ -104,6 +106,7 @@
           dialogModel.selectedFilters.start_date = '10/12/2019';
           dialogModel.selectedFilters.end_date = '15/12/2019';
           dialogModel.selectedFilters.award_types = '1,2';
+          dialogModel.selectedFilters.statuses = '3,4';
           dialogModel.applyFilterAndCloseDialog();
           $rootScope.$digest();
         });
@@ -116,6 +119,10 @@
             end_date: '15/12/2019',
             case_type_id: { IN: [1, 2] },
             award_type: { IN: ['1', '2'] }
+          });
+          expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', {
+            case_type_id: { IN: [1, 2] },
+            status_id: { IN: ['3', '4'] }
           });
         });
       });


### PR DESCRIPTION
## Overview
As part of this PR, the Award Status filter functionality is fixed.

## Before
![before](https://user-images.githubusercontent.com/5058867/74632754-1d769680-5186-11ea-9e25-2547bfc20d5f.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/74632298-0a16fb80-5185-11ea-8b4a-6395a9a598c9.gif)

## Technical Details
Previously the Award Status filter was completely missed, that is why it did not work. This is fixed now.
In `more-filters-dashboard-action-button.controller.js` added the `status_id` parameter to the broadcasted object.
```javascript
var param = {
  case_type_id: awardTypeIds.length > 0 ? { IN: awardTypeIds } : ''
};

if (model.selectedFilters.statuses.length > 0) {
  param.status_id = { IN: getSelect2Value(model.selectedFilters.statuses) };
}

$rootScope.$broadcast('civicase::dashboard-filters::updated', param);
```