### PR TITLE
RSE-751: Contact Cases Tab Word Replacement

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-popup.html
+++ b/ang/civiawards/dashboard/directives/more-filters-popup.html
@@ -6,7 +6,7 @@
         crm-ui-select="{allowClear: false, multiple: false, data: model.awardOptions}"
         ng-model="model.selectedFilters.awardFilter" />
 
-      <label>Award Statuses</label>
+      <label>Application Statuses</label>
       <input
         class="form-control"
         crm-ui-select="{allowClear: false, multiple: true, data: model.statuses}"

--- a/config/word_replacement/awards_category.php
+++ b/config/word_replacement/awards_category.php
@@ -4,9 +4,10 @@
  * @file
  * Returns the words to be replaced and the replacement words.
  */
+
 return [
-  'Case' => 'Award',
-  'Cases' => 'Awards',
-  'case' => 'award',
-  'cases' => 'awards',
+  'Case' => 'Application',
+  'Cases' => 'Applications',
+  'case' => 'application',
+  'cases' => 'applications',
 ];


### PR DESCRIPTION
## Overview
As part of this PR, the word replacement has been set up for CiviAwards.

## Before
![2020-03-03 at 11 00 AM](https://user-images.githubusercontent.com/5058867/75745730-32365b00-5d3e-11ea-92df-0ac980c07b61.jpg)

![2020-03-03 at 11 00 AM](https://user-images.githubusercontent.com/5058867/75745738-3cf0f000-5d3e-11ea-958f-75615fe636e0.jpg)

![2020-03-03 at 11 00 AM](https://user-images.githubusercontent.com/5058867/75745748-48dcb200-5d3e-11ea-9458-02a204ca657d.jpg)

![2020-03-03 at 11 01 AM](https://user-images.githubusercontent.com/5058867/75745792-5c881880-5d3e-11ea-9d9b-d96b7399fc80.jpg)

## After
![2020-03-03 at 10 56 AM](https://user-images.githubusercontent.com/5058867/75745581-c05e1180-5d3d-11ea-9fed-cfee92bb013e.jpg)

![2020-03-03 at 10 57 AM](https://user-images.githubusercontent.com/5058867/75745606-d966c280-5d3d-11ea-8f16-9208fec8b4bf.jpg)

![2020-03-03 at 10 58 AM](https://user-images.githubusercontent.com/5058867/75745638-f3080a00-5d3d-11ea-977f-3bc73fa60e12.jpg)

![2020-03-03 at 10 59 AM](https://user-images.githubusercontent.com/5058867/75745669-07e49d80-5d3e-11ea-9f47-46248f8291ed.jpg)

## Technical Details
1. In `awards_category.php`. `Award` has been replaced with `Application`.
2. In `more-filters-popup.html`, `Award Statuses` has been replaced with `Application Statuses`.