### PR TITLE
RSE-842: Display source contact on review form

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -73,10 +73,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $isAddAction = $this->_action & CRM_Core_Action::ADD;
 
     if ($this->activityId) {
-      $this->defaultValues = array_merge(
-        $this->defaultValues,
-        $this->getProfileFieldValues()
-      );
+      $this->defaultValues = $this->getProfileFieldValues();
     }
 
     $this->defaultValues['source_contact_id'] = $isAddAction

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -63,11 +63,21 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function setDefaultValues() {
-    if (empty($this->defaultValues) && $this->activityId) {
-      $this->defaultValues = $this->getProfileFieldValues();
+    $this->defaultValues = [];
+    $isAddAction = $this->_action & CRM_Core_Action::ADD;
 
-      return $this->defaultValues;
+    if ($this->activityId) {
+      $this->defaultValues = array_merge(
+        $this->defaultValues,
+        $this->getProfileFieldValues()
+      );
     }
+
+    $this->defaultValues['source_contact_id'] = $isAddAction
+      ? CRM_Core_Session::getLoggedInContactID()
+      : $this->activity['source_contact_id'];
+
+    return $this->defaultValues;
   }
 
   /**
@@ -79,7 +89,8 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     }
     else {
       $this->activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-      $this->caseId = $this->getActivityCaseId();
+      $this->activity = $this->getActivity();
+      $this->caseId = CRM_Utils_Array::first($this->activity['case_id']);
     }
 
     $this->profileId = $this->getProfileIdFromCaseType();
@@ -92,12 +103,21 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function buildQuickForm() {
+    $isViewAction = $this->_action & CRM_Core_Action::VIEW;
+
     $this->assign('caseContactDisplayName', $this->getCaseContactDisplayName());
     $this->assign('caseTypeName', $this->caseTypeName);
     $this->assign('caseTags', $this->caseTags);
-    if ($this->_action & CRM_Core_Action::VIEW) {
+    $this->assign('isViewAction', $isViewAction);
+
+    if ($isViewAction) {
+      $this->assign('sourceContactId', $this->activity['source_contact_id']);
+      $this->assign('sourceContactName', $this->activity['source_contact_name']);
       $editUrlParams = "action=update&id={$this->activityId}&reset=1";
       $this->assign('editUrlParams', $editUrlParams);
+    }
+    else {
+      $this->addEntityRef('source_contact_id', ts('Reported By'));
     }
 
     $fields = CRM_Core_BAO_UFGroup::getFields(
@@ -169,6 +189,8 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     else {
       $activityId = $this->activityId;
       $activityContact = $this->getActivityTargetContact();
+
+      $this->updateActivity();
     }
 
     $profileFields['activity_id'] = $activityId;
@@ -194,6 +216,23 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   }
 
   /**
+   * Returns case and source contact details for the current activity.
+   *
+   * @return array
+   *   Activity details.
+   */
+  private function getActivity() {
+    return civicrm_api3('Activity', 'getsingle', [
+      'id' => $this->activityId,
+      'return' => [
+        'case_id',
+        'source_contact_id',
+        'source_contact_name',
+      ],
+    ]);
+  }
+
+  /**
    * Returns the profile id linked to the Case Type.
    *
    * @return int
@@ -206,25 +245,6 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $awardDetail->find(TRUE);
 
     return $awardDetail->profile_id;
-  }
-
-  /**
-   * Returns the case id linked to the activity.
-   *
-   * @return int|null
-   *   Case ID.
-   */
-  private function getActivityCaseId() {
-    $result = civicrm_api3('Activity', 'getsingle', [
-      'id' => $this->activityId,
-      'return' => ['case_id'],
-    ]);
-
-    if (empty($result['case_id'])) {
-      return;
-    }
-
-    return $result['case_id'][0];
   }
 
   /**
@@ -382,8 +402,9 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    *   Returns the created Activity Id.
    */
   public function createActivity() {
+    $values = $this->exportValues();
     $result = civicrm_api3('Activity', 'create', [
-      'source_contact_id' => 'user_contact_id',
+      'source_contact_id' => $values['source_contact_id'],
       'target_id' => 'user_contact_id',
       'activity_type_id' => 'Applicant Review',
       'case_id' => $this->caseId,
@@ -423,6 +444,18 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     }
 
     return $customFieldLabels;
+  }
+
+  /**
+   * Updates the current activity with the submitted form values.
+   */
+  private function updateActivity() {
+    $values = $this->exportValues();
+
+    civicrm_api3('Activity', 'create', [
+      'id' => $this->activityId,
+      'source_contact_id' => $values['source_contact_id'],
+    ]);
   }
 
 }

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -63,6 +63,12 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function setDefaultValues() {
+    $hasDefaultValues = !empty($this->defaultValues);
+
+    if ($hasDefaultValues) {
+      return;
+    }
+
     $this->defaultValues = [];
     $isAddAction = $this->_action & CRM_Core_Action::ADD;
 

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -2,6 +2,33 @@
   <div class="civiawards__review-activity crm-form-block">
     <div class="panel panel-default">
       <div class="panel-body">
+        <div class="form-group row">
+          {if $isViewAction}
+            <div class="col-sm-5">
+              <label for="source_contact_id">
+                {ts}Added By{/ts}
+              </label>
+            </div>
+            <div class="col-sm-7">
+              <a
+                class="view-contact no-popup"
+                href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
+                title="{ts}View Contact{/ts}"
+              >
+                {$sourceContactName}
+              </a>
+            </div>
+          {/if}
+          {if !$isViewAction}
+            <div class="col-sm-5">
+              {$form.source_contact_id.label}
+            </div>
+            <div class="col-sm-7">
+              {$form.source_contact_id.html}
+            </div>
+          {/if}
+          <div class="clear"></div>
+        </div>
         {foreach from=$elementNames item=elementName}
           <div class="form-group row">
             <div class="col-sm-5">{$form.$elementName.label}</div>
@@ -11,7 +38,7 @@
         {/foreach}
       </div>
       <div class="crm-submit-buttons panel-footer clearfix">
-        {if $action eq 4}
+        {if $isViewAction}
           <a href="{crmURL p='civicrm/awardreview' q=$editUrlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil"></i> {ts}Edit{/ts}</span></a>
         {/if}
         {include file="CRM/common/formButtons.tpl" location="bottom"}


### PR DESCRIPTION
## Overview
This PR allows to modify and view the source contact for a particular review.

## Before
### Creating a new review
![Screen Shot 2020-02-20 at 11 40 00 AM](https://user-images.githubusercontent.com/1642119/74950628-c36c1000-53d5-11ea-879c-383e62f96b8c.png)

### Viewing and updating an existing review
![Screen Shot 2020-02-20 at 11 40 31 AM](https://user-images.githubusercontent.com/1642119/74950678-d7b00d00-53d5-11ea-80f8-6e2cb700cdb6.png)
![Screen Shot 2020-02-20 at 11 40 36 AM](https://user-images.githubusercontent.com/1642119/74950682-d848a380-53d5-11ea-97fa-c40b93f03b48.png)

## After

### Creating a new review
![pr-after-1](https://user-images.githubusercontent.com/1642119/74950391-696b4a80-53d5-11ea-81dc-a2cabb86361d.gif)

### Viewing and updating an existing review
![pr-after-2](https://user-images.githubusercontent.com/1642119/74950496-94559e80-53d5-11ea-8a93-d5b878450938.gif)

## Technical Details
We modified the review form class.

* Removed the `getActivityCaseId` function and replaced it with a `getActivity` function. The reason for this was to avoid making multiple calls just to get different fields of the same activity.
* For the default values we use the current logged in user when creating a new review, but the stored source contact when editing the review.

## Extra notes:

* We tried to replicate the experience from the regular activity form as much as possible hence the field is called "Reported By" when creating or editing the field, but "Added By" when viewing the field.