### PR TITLE
RSE-952: Show cases/activities when status filter is removed

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -94,6 +94,8 @@
 
           if (model.selectedFilters.statuses.length > 0) {
             param.status_id = { IN: getSelect2Value(model.selectedFilters.statuses) };
+          } else {
+            param.status_id = { 'IS NOT NULL': 1 };
           }
 
           $rootScope.$broadcast('civicase::dashboard-filters::updated', param);


### PR DESCRIPTION
## Overview
In Award Dashboard, when Award Status filter is applied, and then removed, it hides all cases/activities. This PR fixes the same.

## Before
![before](https://user-images.githubusercontent.com/5058867/75773759-8825f580-5d74-11ea-92ce-69edc44869ea.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/75773708-704e7180-5d74-11ea-8349-077afe6e93ca.gif)

## Technical Details
In https://github.com/compucorp/uk.co.compucorp.civicase/blob/ac67e18c9830754687f0c1ea30561c9fa12ff51a/ang/civicase/dashboard/directives/dashboard.directive.js#L123, the controller listens for `civicase::dashboard-filters::updated`, and adds the sent parameters to `$scope.activityFilters.case_filter` object.

When the status filter is added, `status_id` key gets added, but second time when status filter is removed and as we are using `_.extend`, the `status_id` stays in `$scope.activityFilters.case_filter` object.

To fix this, when status filter is not present, `{ 'IS NOT NULL': 1 }` value is set from `more-filters-dashboard-action-button.controller.js`.