### PR TITLE
RSE-868: Fix Table Column width for review tab

### DIFF
--- a/ang/civiawards/award-creation/directives/review-fields-table.directive.html
+++ b/ang/civiawards/award-creation/directives/review-fields-table.directive.html
@@ -9,7 +9,7 @@
   <tr>
     <th>Review Field Name</th>
     <th>Order</th>
-    <th>Required</th>
+    <th width="20">Required</th>
     <th>Data Type</th>
     <th>Field Type</th>
     <th></th>

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
@@ -31,7 +31,7 @@
           <th ng-repeat="reviewField in reviewActivities[0].reviewFields">
             {{reviewField.label}}
           </th>
-          <th>&nbsp;</th>
+          <th width="20">&nbsp;</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Overview
Inside the Review tab while creating and award, and also inside the Case Details section, the "Required" column and the Action column was taking more width than its content, this PR fixes the same.

## Before
![2020-03-04 at 5 25 PM](https://user-images.githubusercontent.com/5058867/75877171-1b2a6280-5e3d-11ea-96f0-0429a61d8b7e.jpg)

![2020-03-04 at 5 26 PM](https://user-images.githubusercontent.com/5058867/75877284-5462d280-5e3d-11ea-8c71-d7f3acf3c747.jpg)

## After
![2020-03-04 at 5 26 PM](https://user-images.githubusercontent.com/5058867/75877250-457c2000-5e3d-11ea-8c27-11eae2051c12.jpg)


![2020-03-04 at 5 25 PM](https://user-images.githubusercontent.com/5058867/75877234-3ac18b00-5e3d-11ea-9015-b518c419323a.jpg)

## Technical Details
Added static width in the markup.

