### PR TITLE
RSE-652: Set API Permissions for AwardReviewPanel Entity

### DIFF
--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -37,6 +37,8 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
     ];
     $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
     $permissions['award_manager']['get'] = $awardCreatePermission;
+    $permissions['award_review_panel']['get'] = $awardCreatePermission;
+    $permissions['award_review_panel']['create'] = $permissions['award_review_panel']['update'] = $awardCreatePermission;
 
     if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
       $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;

--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -38,7 +38,8 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
     $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
     $permissions['award_manager']['get'] = $awardCreatePermission;
     $permissions['award_review_panel']['get'] = $awardCreatePermission;
-    $permissions['award_review_panel']['create'] = $permissions['award_review_panel']['update'] = $awardCreatePermission;
+    $permissions['award_review_panel']['create'] = $awardCreatePermission;
+    $permissions['award_review_panel']['update'] = $awardCreatePermission;
 
     if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
       $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;


### PR DESCRIPTION
## Overview
An Award manager cannot add review panels currently because the default API permission `Administer Civicrm` is required. This PR fixes that and sets appropriate permissions for the AwardReviewPanel API's

## Before
- Award Manager cannot create a review panel.

## After
- Award Manager can now create review panels.
The API permissions for AwardReviewPanel Get/Create/Update is set to permissions required for creating an Award.

![ReviewPanel](https://user-images.githubusercontent.com/6951813/75887824-ac440e00-5e2a-11ea-94be-0ebd66f8074f.gif)
