### PR TITLE
RSE-967: Do not apply More Filters in non awards dashboard

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -41,7 +41,9 @@
     $scope.isVisible = isAwardsScreen;
 
     (function init () {
-      applyFilter();
+      if (isAwardsScreen()) {
+        applyFilter();
+      }
     }());
 
     /**

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -40,6 +40,8 @@
       describe('when viewing the awards dashboard', () => {
         beforeEach(() => {
           $location.search('case_type_category', 'awards');
+          initController();
+          $rootScope.$digest();
 
           isButtonVisible = $scope.isVisible();
         });
@@ -47,17 +49,27 @@
         it('displays the more filter button', () => {
           expect(isButtonVisible).toBe(true);
         });
+
+        it('filters by my awards', () => {
+          expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', jasmine.any(Object));
+        });
       });
 
       describe('when viewing any other dashboard', () => {
         beforeEach(() => {
           $location.search('case_type_category', 'cases');
+          initController();
+          $rootScope.$digest();
 
           isButtonVisible = $scope.isVisible();
         });
 
         it('does not display the more filter button', () => {
           expect(isButtonVisible).toBe(false);
+        });
+
+        it('does not filter by my awards', () => {
+          expect($rootScope.$broadcast).not.toHaveBeenCalledWith('civicase::dashboard-filters::updated', jasmine.any(Object));
         });
       });
     });


### PR DESCRIPTION
## Overview
When viewing the Case Dashboard, Case Types were not appearing in Case Overview section. This PR fixes the same.

## Before
![2020-03-05 at 4 03 PM](https://user-images.githubusercontent.com/5058867/75973272-e54bb380-5efa-11ea-8302-e539e3b76b20.jpg)

## After
![2020-03-05 at 4 03 PM](https://user-images.githubusercontent.com/5058867/75973235-d95ff180-5efa-11ea-8a80-0f108fd5b40f.jpg)

## Technical Details
This bug happened, because the “More Filters” also was working on the background for cases dashboard. In https://github.com/compucorp/uk.co.compucorp.civiawards/blob/4a8c31cba8e4f6839d8fb6c2e9f1862e35fdf7b2/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.html#L3, as we use `ng-show`, the controller is working on the background. We cant use `ng-if` here, because that way the whole button will stop working, as `isVisible` function is written inside the controller.

So to fix this, in `ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js`, added the following check

```javascript
(function init () {
  if (isAwardsScreen()) { // this is added
    applyFilter();
  }
}());
```