### PR TITLE
RSE-777: Fix Misc bugs

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels.directive.js
@@ -53,7 +53,7 @@
 
       var params = {
         title: $scope.reviewPanel.title,
-        is_active: $scope.reviewPanel.isEnabled,
+        is_active: $scope.reviewPanel.isEnabled ? '1' : '0',
         case_type_id: $scope.awardId
       };
 

--- a/ang/civiawards/dashboard/directives/edit-award-button.html
+++ b/ang/civiawards/dashboard/directives/edit-award-button.html
@@ -1,6 +1,6 @@
 <a class="btn btn-link"
   ng-controller="EditAwardButtonController"
-  ng-href="{{'civicrm/a/#/awards/' + caseType.id | civicaseCrmUrl}}"
+  ng-href="{{'civicrm/award/a/#/awards/' + caseType.id | civicaseCrmUrl}}"
   ng-show="canEditAwards()">
   <i class="fa fa-cog"></i>
 </a>

--- a/ang/test/civiawards/award-creation/directives/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels.directive.spec.js
@@ -106,7 +106,7 @@
         it('saves the review panel', () => {
           expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
             title: 'New Review Panel',
-            is_active: true,
+            is_active: '1',
             case_type_id: 1
           });
         });


### PR DESCRIPTION
## Bug 1
The Award edit page has been moved to the new namespace created in https://github.com/compucorp/uk.co.compucorp.civiawards/pull/64. This was missed previously.

## Bug 2
The ReviewPanels were always being saved as active, even if the active checkbox is disabled in UI.

### Technical Details
Sending `1` or `0` instead of true or false from review-panels.directive.js.