### PR TITLE
RSE-944: Fix API param value when case type id is null

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -91,7 +91,7 @@
         .then(processAwardTypeFilters)
         .then(function (awardTypeIds) {
           var param = {
-            case_type_id: awardTypeIds.length > 0 ? { IN: awardTypeIds } : ''
+            case_type_id: awardTypeIds.length > 0 ? { IN: awardTypeIds } : { 'IS NULL': 1 }
           };
 
           if (model.selectedFilters.statuses.length > 0) {

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -3,7 +3,7 @@
 (function (_) {
   describe('More Filters Dashboard Action Button', () => {
     let $q, $location, $scope, $controller, $rootScope, dialogService,
-      crmApiMock, crmApi;
+      crmApiMock, originalCrmAPIMock, crmApi;
 
     beforeEach(module('civiawards', function ($provide) {
       crmApiMock = jasmine.createSpy();
@@ -193,6 +193,32 @@
 
         it('shows a red dot inside the more filters button', () => {
           expect($scope.isNotificationVisible()).toBe(true);
+        });
+      });
+
+      describe('when filters response yields no awards types ids', () => {
+        beforeEach(() => {
+          originalCrmAPIMock = crmApiMock;
+
+          // Overwrite CRM API to return no results.
+          crmApiMock.and.returnValue($q.resolve({
+            values: []
+          }));
+        });
+
+        beforeEach(() => {
+          dialogModel.applyFilterAndCloseDialog();
+          $rootScope.$digest();
+        });
+
+        afterEach(() => {
+          crmApiMock = originalCrmAPIMock;
+        });
+
+        it('should set correct param value for case_type_id param', () => {
+          expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', jasmine.objectContaining({
+            case_type_id: { 'IS NULL': 1 }
+          }));
         });
       });
     });

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -3,7 +3,7 @@
 (function (_) {
   describe('More Filters Dashboard Action Button', () => {
     let $q, $location, $scope, $controller, $rootScope, dialogService,
-      crmApiMock, originalCrmAPIMock, crmApi;
+      crmApiMock, crmApi;
 
     beforeEach(module('civiawards', function ($provide) {
       crmApiMock = jasmine.createSpy();
@@ -198,8 +198,6 @@
 
       describe('when filters response yields no awards types ids', () => {
         beforeEach(() => {
-          originalCrmAPIMock = crmApiMock;
-
           // Overwrite CRM API to return no results.
           crmApiMock.and.returnValue($q.resolve({
             values: []
@@ -211,11 +209,7 @@
           $rootScope.$digest();
         });
 
-        afterEach(() => {
-          crmApiMock = originalCrmAPIMock;
-        });
-
-        it('should set correct param value for case_type_id param', () => {
+        it('hides all case types, cases and activities from dashboard', () => {
           expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', jasmine.objectContaining({
             case_type_id: { 'IS NULL': 1 }
           }));


### PR DESCRIPTION
## Overview
This PR is a supportive PR for the changes introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/404. This basically contains the related FE changes done on awards side.

## Before
![RSE-944-before](https://user-images.githubusercontent.com/3340537/77448554-f3fcfa80-6e16-11ea-80da-5082d5648405.gif)

## After
![RSE-944-after](https://user-images.githubusercontent.com/3340537/77448584-fc553580-6e16-11ea-93a0-baf5cb2a8311.gif)


## Technical Details
The `getStats` API is improved to support `IS NULL` operator for `case_type_id` parameter. See the technical details of https://github.com/compucorp/uk.co.compucorp.civicase/pull/404.
Related FE changes are being incorporated here