### PR TITLE
RSE-892: Fix HTML text formatting on the review table tab

### DIFF
--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
@@ -38,9 +38,7 @@
         <tr ng-repeat="reviewActivity in reviewActivities">
           <td>{{reviewActivity.source_contact_name}}</td>
           <td>{{reviewActivity.created_date | formatDate}}</td>
-          <td ng-repeat="reviewField in reviewActivity.reviewFields">
-            {{reviewField.value.display}}
-          </td>
+          <td ng-repeat="reviewField in reviewActivity.reviewFields" ng-bind-html="trustAsHtml(reviewField.value.display)"></td>
           <td>
             <div
               class="btn-group btn-group-md"

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -19,12 +19,13 @@
    *
    * @param {object} $q the $q service.
    * @param {object} $scope the scope object.
+   * @param {object} $sce angular Strict Contextual Escaping service.
    * @param {Function} crmApi the CiviCRM API service.
    * @param {string} reviewsActivityTypeName the reviews activity type name.
    * @param {string} reviewScoringFieldsGroupName the review scoring fields group name.
    * @param {Function} ts the translation function.
    */
-  function civiawardsReviewsCaseTabContentController ($q, $scope, crmApi, reviewsActivityTypeName,
+  function civiawardsReviewsCaseTabContentController ($q, $scope, $sce, crmApi, reviewsActivityTypeName,
     reviewScoringFieldsGroupName, ts) {
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
     var REVIEW_FORM_URL = 'civicrm/awardreview';
@@ -36,6 +37,7 @@
     $scope.handleViewReviewActivity = handleViewReviewActivity;
     $scope.handleEditReviewActivity = handleEditReviewActivity;
     $scope.handleDeleteReviewActivity = handleDeleteReviewActivity;
+    $scope.trustAsHtml = $sce.trustAsHtml;
 
     (function init () {
       loadReviewActivities();


### PR DESCRIPTION
## Overview
 This PR fixes the HTML rich text formatting on the reviews tab for awards section.

### Description
When adding a review field which contains HTML rich text, the table content doesn't get formatted and show unformatted text for the review pane. See `Before` Screenshot for e.g.

## Before
<img width="1636" alt="Screenshot 2020-03-25 at 1 36 46 PM" src="https://user-images.githubusercontent.com/3340537/77516857-1cc9d200-6ea1-11ea-9bec-f7c5bf70050f.png">

## After
<img width="942" alt="Screenshot 2020-03-25 at 1 40 36 PM" src="https://user-images.githubusercontent.com/3340537/77516912-3539ec80-6ea1-11ea-93b7-ce326a12b2f3.png">

## Technical Details
The text was not getting formatted because the HTML was not marked as trusted/safe HTML to be passed through to the browser and angular was not parsing it as an HTML string and passing it as a normal encoded string to the browser.

To fix this, we used `$sce.trustAsHtml` function from the core angular `$sce` service. Using this service while binding HTML in the template fixed the issue.
The solution is being encouraged from [this PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/345/files)