### PR TITLE
RSE-654: Fix error when no Relationships are present in Review Panels

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -133,6 +133,10 @@
         });
       });
 
+      if (contactIdsToFetch.length === 0) {
+        return $q.resolve([]);
+      }
+
       return crmApi('Contact', 'get', {
         sequential: 1,
         return: ['display_name'],

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -2,14 +2,8 @@
 (function (_) {
   describe('civiawardReviewPanels', () => {
     let $rootScope, $controller, $scope, crmApi, $q, crmStatus, ts, ContactsData,
-      dialogService, RelationshipTypeData, GroupData, ReviewPanelsMockData;
-    const entityActionHandlers = {
-      'AwardReviewPanel.create': _.noop,
-      'RelationshipType.get': relationshipTypeGetHandler,
-      'AwardReviewPanel.get': awardReviewPanelGetHandler,
-      'Contact.get': contactGetHandler,
-      'Group.get': groupGetHandler
-    };
+      dialogService, RelationshipTypeData, GroupData, ReviewPanelsMockData,
+      entityActionHandlers;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'crmUtil', 'civicase.data', 'civiawards.data', function ($provide) {
       $provide.value('crmApi', getCrmApiMock());
@@ -20,6 +14,7 @@
     beforeEach(inject((_$q_, _$controller_, _$rootScope_, _crmApi_, _crmStatus_,
       _ts_, _dialogService_, _RelationshipTypeData_, _GroupData_,
       _ReviewPanelsMockData_, _ContactsData_) => {
+      setApiActionHandlers();
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
@@ -271,58 +266,138 @@
     });
 
     describe('review panels list', () => {
-      beforeEach(() => {
-        $scope.awardId = '10';
-        createController();
-        $scope.$digest();
-      });
+      describe('when there is atleast one relationship', () => {
+        beforeEach(() => {
+          $scope.awardId = '10';
+          createController();
+          $scope.$digest();
+        });
 
-      it('fetches all exisiting review panels for the award', () => {
-        expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
-          sequential: 1,
-          case_type_id: '10',
-          options: { limit: 0 }
+        it('fetches all exisiting review panels for the award', () => {
+          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+            sequential: 1,
+            case_type_id: '10',
+            options: { limit: 0 }
+          });
+        });
+
+        it('displays all existing review panels for the award', () => {
+          expect($scope.existingReviewPanels).toEqual([{
+            id: '46',
+            title: 'New Panel',
+            case_type_id: '62',
+            contact_settings: {
+              exclude_groups: ['1'],
+              include_groups: ['2'],
+              relationship: [{
+                is_a_to_b: '1',
+                relationship_type_id: '14',
+                contact_id: ['4', '2']
+              }, {
+                is_a_to_b: '0',
+                relationship_type_id: '14',
+                contact_id: ['3', '1']
+              }]
+            },
+            visibility_settings: {
+              application_status: ['1'],
+              anonymize_application: '1'
+            },
+            is_active: '1',
+            formattedContactSettings: {
+              include: ['Group 2'],
+              exclude: ['Group 1'],
+              relation: [{
+                relationshipLabel: 'Benefits Specialist is',
+                contacts: ['Shauna Barkley', 'Shauna Wattson']
+              }, {
+                relationshipLabel: 'Benefits Specialist',
+                contacts: ['Kiara Jones', 'Default Organization']
+              }]
+            },
+            formattedVisibilitySettings: {
+              applicationStatus: ['Ongoing']
+            }
+          }, {
+            id: '47',
+            title: 'New Panel 2',
+            case_type_id: '62',
+            contact_settings: {
+              exclude_groups: [],
+              include_groups: [],
+              relationship: []
+            },
+            visibility_settings: {
+              application_status: [],
+              anonymize_application: '0'
+            },
+            is_active: '0',
+            formattedContactSettings: {
+              include: [],
+              exclude: [],
+              relation: []
+            },
+            formattedVisibilitySettings: {
+              applicationStatus: []
+            }
+          }]);
+        });
+
+        it('shows the contacts name in the contact list', () => {
+          expect(crmApi).toHaveBeenCalledWith('Contact', 'get', {
+            sequential: 1,
+            return: ['display_name'],
+            id: { IN: ['4', '2', '3', '1'] },
+            options: { limit: 0 }
+          });
         });
       });
 
-      it('displays all existing review panels for the award', () => {
-        expect($scope.existingReviewPanels).toEqual([{
-          id: '46',
-          title: 'New Panel',
-          case_type_id: '62',
-          contact_settings: {
-            exclude_groups: ['1'],
-            include_groups: ['2'],
-            relationship: [{
-              is_a_to_b: '1',
-              relationship_type_id: '14',
-              contact_id: ['4', '2']
-            }, {
-              is_a_to_b: '0',
-              relationship_type_id: '14',
-              contact_id: ['3', '1']
-            }]
-          },
-          visibility_settings: {
-            application_status: ['1'],
-            anonymize_application: '1'
-          },
-          is_active: '1',
-          formattedContactSettings: {
-            include: ['Group 2'],
-            exclude: ['Group 1'],
-            relation: [{
-              relationshipLabel: 'Benefits Specialist is',
-              contacts: ['Shauna Barkley', 'Shauna Wattson']
-            }, {
-              relationshipLabel: 'Benefits Specialist',
-              contacts: ['Kiara Jones', 'Default Organization']
-            }]
-          },
-          formattedVisibilitySettings: {
-            applicationStatus: ['Ongoing']
-          }
-        }]);
+      describe('when there no relationships in all review panels', () => {
+        beforeEach(() => {
+          setApiActionHandlers({ noRelationPresentInAllReviewPanels: true });
+          $scope.awardId = '10';
+          createController();
+          $scope.$digest();
+        });
+
+        it('fetches all exisiting review panels for the award', () => {
+          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+            sequential: 1,
+            case_type_id: '10',
+            options: { limit: 0 }
+          });
+        });
+
+        it('displays all existing review panels for the award', () => {
+          expect($scope.existingReviewPanels).toEqual([{
+            id: '47',
+            title: 'New Panel 2',
+            case_type_id: '62',
+            contact_settings: {
+              exclude_groups: [],
+              include_groups: [],
+              relationship: []
+            },
+            visibility_settings: {
+              application_status: [],
+              anonymize_application: '0'
+            },
+            is_active: '0',
+            formattedContactSettings: {
+              include: [],
+              exclude: [],
+              relation: []
+            },
+            formattedVisibilitySettings: {
+              applicationStatus: []
+            }
+          }]);
+        });
+
+        it('does not fetch any contact information', () => {
+          expect(crmApi).not.toHaveBeenCalledWith('Contact', 'get', jasmine.any(Object));
+        });
       });
     });
 
@@ -523,6 +598,25 @@
     });
 
     /**
+     * Set Api Action Handlers
+     *
+     * @param {object} options configurations
+     * @param {string} options.noRelationPresentInAllReviewPanels if no relationships are present in all fetched review panels
+     */
+    function setApiActionHandlers (options) {
+      options = options || {};
+
+      entityActionHandlers = {
+        'AwardReviewPanel.create': _.noop,
+        'RelationshipType.get': relationshipTypeGetHandler,
+        'AwardReviewPanel.get': function () {
+          return awardReviewPanelGetHandler(options);
+        },
+        'Contact.get': contactGetHandler,
+        'Group.get': groupGetHandler
+      };
+    }
+    /**
      * Create Controller
      */
     function createController () {
@@ -556,15 +650,21 @@
     }
 
     /**
+     * @param {object} options configurations
+     * @param {string} options.noRelationPresentInAllReviewPanels if no relationships are present in all fetched review panels
      * @returns {object} the mocked response for the AwardReviewPanel.Get
      * api action.
      */
-    function awardReviewPanelGetHandler () {
+    function awardReviewPanelGetHandler (options) {
+      var mockData = options.noRelationPresentInAllReviewPanels
+        ? [ReviewPanelsMockData[1]]
+        : ReviewPanelsMockData;
+
       return {
         is_error: 0,
         version: 3,
-        count: ReviewPanelsMockData.length,
-        values: _.cloneDeep(ReviewPanelsMockData)
+        count: mockData.length,
+        values: _.cloneDeep(mockData)
       };
     }
 

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -281,66 +281,44 @@
           });
         });
 
-        it('displays all existing review panels for the award', () => {
-          expect($scope.existingReviewPanels).toEqual([{
-            id: '46',
-            title: 'New Panel',
-            case_type_id: '62',
-            contact_settings: {
-              exclude_groups: ['1'],
-              include_groups: ['2'],
-              relationship: [{
-                is_a_to_b: '1',
-                relationship_type_id: '14',
-                contact_id: ['4', '2']
-              }, {
-                is_a_to_b: '0',
-                relationship_type_id: '14',
-                contact_id: ['3', '1']
-              }]
-            },
-            visibility_settings: {
-              application_status: ['1'],
-              anonymize_application: '1'
-            },
-            is_active: '1',
-            formattedContactSettings: {
-              include: ['Group 2'],
-              exclude: ['Group 1'],
-              relation: [{
-                relationshipLabel: 'Benefits Specialist is',
-                contacts: ['Shauna Barkley', 'Shauna Wattson']
-              }, {
-                relationshipLabel: 'Benefits Specialist',
-                contacts: ['Kiara Jones', 'Default Organization']
-              }]
-            },
-            formattedVisibilitySettings: {
-              applicationStatus: ['Ongoing']
-            }
-          }, {
-            id: '47',
-            title: 'New Panel 2',
-            case_type_id: '62',
-            contact_settings: {
-              exclude_groups: [],
-              include_groups: [],
-              relationship: []
-            },
-            visibility_settings: {
-              application_status: [],
-              anonymize_application: '0'
-            },
-            is_active: '0',
-            formattedContactSettings: {
-              include: [],
-              exclude: [],
-              relation: []
-            },
-            formattedVisibilitySettings: {
-              applicationStatus: []
-            }
-          }]);
+        describe('existing review panels', () => {
+          let expectedReviewPanelsValue;
+
+          beforeEach(() => {
+            const reviewPanel1 = _.extend(ReviewPanelsMockData[0], {
+              formattedContactSettings: {
+                include: ['Group 2'],
+                exclude: ['Group 1'],
+                relation: [{
+                  relationshipLabel: 'Benefits Specialist is',
+                  contacts: ['Shauna Barkley', 'Shauna Wattson']
+                }, {
+                  relationshipLabel: 'Benefits Specialist',
+                  contacts: ['Kiara Jones', 'Default Organization']
+                }]
+              },
+              formattedVisibilitySettings: {
+                applicationStatus: ['Ongoing']
+              }
+            });
+
+            const reviewPanel2 = _.extend(ReviewPanelsMockData[1], {
+              formattedContactSettings: {
+                include: [],
+                exclude: [],
+                relation: []
+              },
+              formattedVisibilitySettings: {
+                applicationStatus: []
+              }
+            });
+
+            expectedReviewPanelsValue = [reviewPanel1, reviewPanel2];
+          });
+
+          it('displays all existing review panels for the award', () => {
+            expect($scope.existingReviewPanels).toEqual(expectedReviewPanelsValue);
+          });
         });
 
         it('shows the contacts name in the contact list', () => {
@@ -369,30 +347,27 @@
           });
         });
 
-        it('displays all existing review panels for the award', () => {
-          expect($scope.existingReviewPanels).toEqual([{
-            id: '47',
-            title: 'New Panel 2',
-            case_type_id: '62',
-            contact_settings: {
-              exclude_groups: [],
-              include_groups: [],
-              relationship: []
-            },
-            visibility_settings: {
-              application_status: [],
-              anonymize_application: '0'
-            },
-            is_active: '0',
-            formattedContactSettings: {
-              include: [],
-              exclude: [],
-              relation: []
-            },
-            formattedVisibilitySettings: {
-              applicationStatus: []
-            }
-          }]);
+        describe('existing review panels', () => {
+          let expectedReviewPanelsValue;
+
+          beforeEach(() => {
+            const reviewPanel = _.extend(ReviewPanelsMockData[1], {
+              formattedContactSettings: {
+                include: [],
+                exclude: [],
+                relation: []
+              },
+              formattedVisibilitySettings: {
+                applicationStatus: []
+              }
+            });
+
+            expectedReviewPanelsValue = [reviewPanel];
+          });
+
+          it('displays all existing review panels for the award', () => {
+            expect($scope.existingReviewPanels).toEqual(expectedReviewPanelsValue);
+          });
         });
 
         it('does not fetch any contact information', () => {

--- a/ang/test/mocks/data/review-panels.data.js
+++ b/ang/test/mocks/data/review-panels.data.js
@@ -27,6 +27,20 @@
         anonymize_application: '1'
       },
       is_active: '1'
+    }, {
+      id: '47',
+      title: 'New Panel 2',
+      case_type_id: '62',
+      contact_settings: {
+        exclude_groups: [],
+        include_groups: [],
+        relationship: []
+      },
+      visibility_settings: {
+        application_status: [],
+        anonymize_application: '0'
+      },
+      is_active: '0'
     }
   ]);
 }());


### PR DESCRIPTION
## Overview
When there are no defined Specific Relationship in all the Review panels of an award, the Review Panels cannot be seen. This PR fixed that issue.

## Before
![2020-03-25 at 3 27 PM](https://user-images.githubusercontent.com/5058867/77524335-2d804500-6ead-11ea-81e3-5f232b962e1f.jpg)

![2020-03-25 at 4 08 PM](https://user-images.githubusercontent.com/5058867/77527831-e72de480-6eb2-11ea-96aa-282a198d3a8c.jpg)

## After
![2020-03-25 at 3 28 PM](https://user-images.githubusercontent.com/5058867/77524400-45f05f80-6ead-11ea-9545-00e6bbef25a5.jpg)

The `Contact.get` api call is not happening anymore.

## Technical Details
In `review-panels.directive.js`, after fetching the Review Panels, we fetch  the list of Contact names from the list of Relationships, but when the relationships are empty, we used to send an empty array to the `Contact.get` api call.
```javascript
return crmApi('Contact', 'get', {
	sequential: 1,
	return: ['display_name'],
	id: { IN: contactIdsToFetch }, // this used to be an empty array
	options: { limit: 0 }
})
.then(function (contactsData) {
	return contactsData.values;
});
```

So we were getting an `invalid criteria for IN` error.

To fix this, now we check if the list of contacts are empty, and if yes, we directly resolve the promise
```javascript
if (contactIdsToFetch.length === 0) {
    return $q.resolve([]);
}
```
