### PR TITLE
RSE-956: Define award activity types

### DIFF
--- a/ang/civiawards/activity-forms/services/review-form.service.js
+++ b/ang/civiawards/activity-forms/services/review-form.service.js
@@ -1,4 +1,4 @@
-(function (angular, getCrmUrl) {
+(function (_, angular, getCrmUrl) {
   var module = angular.module('civiawards');
 
   module.service('ReviewActivityForm', ReviewActivityForm);
@@ -23,22 +23,24 @@
      * be shown in a popup it automatically opens the form in edit mode.
      *
      * @param {object} activity an activity object.
-     * @param {object} options form options.
+     * @param {object} overridingOptions form options.
      * @returns {string} the form URL.
      */
-    function getActivityFormUrl (activity, options) {
-      var action = 'view';
-      var isPopupForm = options && options.formType === 'popup';
-
-      if (isPopupForm) {
-        action = 'update';
-      }
-
-      return getCrmUrl('civicrm/awardreview', {
-        action: action,
-        id: activity.id,
+    function getActivityFormUrl (activity, overridingOptions) {
+      var options = _.defaults({}, overridingOptions, {
+        action: 'view',
         reset: 1
       });
+
+      if (activity.id) {
+        options.id = activity.id;
+      }
+
+      if (options.action === 'add') {
+        options.case_id = activity.case_id;
+      }
+
+      return getCrmUrl('civicrm/awardreview', options);
     }
   }
-})(angular, CRM.url);
+})(CRM._, angular, CRM.url);

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -16,14 +16,12 @@
   module.controller('CiviAwardCreateEditAwardController', function (
     $location, $q, $scope, $window, CaseTypeCategory, crmApi, crmStatus, getSelect2Value) {
     var ts = CRM.ts('civicase');
-    var DEFAULT_COMMUNICATION_ACTIVITY_TYPES = [
+    var DEFAULT_ACTIVITY_TYPES = [
+      { name: 'Applicant Review' },
       { name: 'Email' },
       { name: 'Follow up' },
       { name: 'Meeting' },
       { name: 'Phone Call' }
-    ];
-    var DEFAULT_REVIEW_ACTIVITY_TYPES = [
-      { name: 'Applicant Review' }
     ];
 
     $scope.ts = ts;
@@ -220,10 +218,7 @@
         case_type_category: CaseTypeCategory.findByName('awards').value,
         name: generateAwardName($scope.basicDetails.title),
         definition: {
-          activityTypes: [].concat(
-            DEFAULT_REVIEW_ACTIVITY_TYPES,
-            DEFAULT_COMMUNICATION_ACTIVITY_TYPES
-          ),
+          activityTypes: DEFAULT_ACTIVITY_TYPES,
           caseRoles: [{
             name: 'Application Manager',
             manager: 1

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -22,6 +22,9 @@
       { name: 'Meeting' },
       { name: 'Phone Call' }
     ];
+    var DEFAULT_REVIEW_ACTIVITY_TYPES = [
+      { name: 'Applicant Review' }
+    ];
 
     $scope.ts = ts;
     $scope.pageTitle = 'New Award';
@@ -217,7 +220,10 @@
         case_type_category: CaseTypeCategory.findByName('awards').value,
         name: generateAwardName($scope.basicDetails.title),
         definition: {
-          activityTypes: DEFAULT_COMMUNICATION_ACTIVITY_TYPES,
+          activityTypes: [].concat(
+            DEFAULT_REVIEW_ACTIVITY_TYPES,
+            DEFAULT_COMMUNICATION_ACTIVITY_TYPES
+          ),
           caseRoles: [{
             name: 'Application Manager',
             manager: 1

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -16,6 +16,12 @@
   module.controller('CiviAwardCreateEditAwardController', function (
     $location, $q, $scope, $window, CaseTypeCategory, crmApi, crmStatus, getSelect2Value) {
     var ts = CRM.ts('civicase');
+    var DEFAULT_COMMUNICATION_ACTIVITY_TYPES = [
+      { name: 'Email' },
+      { name: 'Follow up' },
+      { name: 'Meeting' },
+      { name: 'Phone Call' }
+    ];
 
     $scope.ts = ts;
     $scope.pageTitle = 'New Award';
@@ -211,6 +217,7 @@
         case_type_category: CaseTypeCategory.findByName('awards').value,
         name: generateAwardName($scope.basicDetails.title),
         definition: {
+          activityTypes: DEFAULT_COMMUNICATION_ACTIVITY_TYPES,
           caseRoles: [{
             name: 'Application Manager',
             manager: 1

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -41,6 +41,8 @@
 
     (function init () {
       loadReviewActivities();
+
+      $scope.$on('updateCaseData', loadReviewActivities);
     })();
 
     /**

--- a/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
+++ b/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
@@ -53,14 +53,33 @@
         });
       });
 
-      describe('when getting the activity popup form url', () => {
+      describe('when getting the update review form url', () => {
         beforeEach(() => {
           activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity, {
-            formType: 'popup'
+            action: 'update'
           });
           expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
             action: 'update',
             id: reviewActivity.id,
+            reset: 1
+          });
+        });
+
+        it('returns the url for the review activity popup form', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the add review form url', () => {
+        beforeEach(() => {
+          delete reviewActivity.id;
+          reviewActivity.case_id = _.uniqueId();
+          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity, {
+            action: 'add'
+          });
+          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
+            action: 'add',
+            case_id: reviewActivity.case_id,
             reset: 1
           });
         });

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -282,7 +282,7 @@
           });
         });
 
-        it('keeps the default activity types', () => {
+        it('creates the award with default activity types', () => {
           expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
             definition: jasmine.objectContaining({
               activityTypes: [

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -197,13 +197,26 @@
               is_active: true,
               case_type_category: '3',
               name: 'title',
-              definition: {
+              definition: jasmine.objectContaining({
                 caseRoles: [{
                   name: 'Application Manager',
                   manager: 1
                 }]
-              }
+              })
             });
+          });
+
+          it('saves default activity types for the award', () => {
+            expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+              definition: jasmine.objectContaining({
+                activityTypes: [
+                  { name: 'Email' },
+                  { name: 'Follow up' },
+                  { name: 'Meeting' },
+                  { name: 'Phone Call' }
+                ]
+              })
+            }));
           });
 
           it('saves the additional award details', () => {
@@ -257,15 +270,28 @@
             is_active: true,
             case_type_category: '3',
             name: 'title',
-            definition: {
+            definition: jasmine.objectContaining({
               caseRoles: [{
                 name: 'Application Manager',
                 manager: 1
               }],
               statuses: ['Open']
-            },
+            }),
             id: '10'
           });
+        });
+
+        it('keeps the default activity types', () => {
+          expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+            definition: jasmine.objectContaining({
+              activityTypes: [
+                { name: 'Email' },
+                { name: 'Follow up' },
+                { name: 'Meeting' },
+                { name: 'Phone Call' }
+              ]
+            })
+          }));
         });
       });
     });

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -210,6 +210,7 @@
             expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
               definition: jasmine.objectContaining({
                 activityTypes: [
+                  { name: 'Applicant Review' },
                   { name: 'Email' },
                   { name: 'Follow up' },
                   { name: 'Meeting' },
@@ -285,6 +286,7 @@
           expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
             definition: jasmine.objectContaining({
               activityTypes: [
+                { name: 'Applicant Review' },
                 { name: 'Email' },
                 { name: 'Follow up' },
                 { name: 'Meeting' },

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -101,6 +101,17 @@
       });
     });
 
+    describe('on case updated', () => {
+      beforeEach(() => {
+        crmApi.calls.reset();
+        $scope.$emit('updateCaseData');
+      });
+
+      it('reloads the list of reviews', () => {
+        expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
+      });
+    });
+
     describe('review forms', () => {
       let expectedUrl, mockedConfirmElement, mockedFormElement, selectedReview;
       const CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';

--- a/civiawards.php
+++ b/civiawards.php
@@ -215,3 +215,12 @@ function civiawards_civicrm_aclGroup($type, $contactID, $tableName, &$allGroups,
 function civiawards_addCiviCaseDependentAngularModules(&$dependentModules) {
   $dependentModules[] = "civiawards";
 }
+
+/**
+ * Implements hook_civicrm_alterMenu().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMenu
+ */
+function civiawards_civicrm_alterMenu(&$items) {
+  $items['civicrm/awardreview']['ids_arguments']['json'][] = 'civicase_reload';
+}


### PR DESCRIPTION
## Overview
This PR adds default activity types to awards so users can use them to create activities related to applications.

**Note:** this PR is linked to https://github.com/compucorp/uk.co.compucorp.civicase/pull/408

## Before
![Screen Shot 2020-03-25 at 4 43 16 PM](https://user-images.githubusercontent.com/1642119/77583613-c3b96880-6eb7-11ea-9765-ecbb738c81ef.png)
The menu does not exist

## After
![pr-after](https://user-images.githubusercontent.com/1642119/77713120-f04eac80-6fab-11ea-9972-c853be4785d5.gif)

## Technical Details

* We modified the `awards.directive.js` file so it always send the Email, Follow up, Meeting, and Phone Call activities when saving the award (case type) definition. These activities are manually selected because that's how core defines them instead of selecting the communication activity grouping, which includes extra activities.
* The `review-form.service.js` service was refactored so it allows for options overriding so we can display different kind of forms depending on the action (ie: add, update, and view forms)
* `civiawards.php` implements `hook_civicrm_alterMenu` so we can pass the `civicase_reload` argument to it. Without the form is not displayed at all, and we need this parameter to trigger a case refresh after the review is saved.