### PR TITLE
RSE-653: Set Permissions For Deleting Award Panels

### DIFF
--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -40,6 +40,7 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
     $permissions['award_review_panel']['get'] = $awardCreatePermission;
     $permissions['award_review_panel']['create'] = $awardCreatePermission;
     $permissions['award_review_panel']['update'] = $awardCreatePermission;
+    $permissions['award_review_panel']['delete'] = $awardCreatePermission;
 
     if ($this->modifyCaseTypeApiPermission($entity, $action, $params)) {
       $permissions['case_type']['create'] = $permissions['case_type']['update'] = $awardCreatePermission;


### PR DESCRIPTION
## Overview
An Award manager cannot delete review panels currently because the default API permission Administer Civicrm is required. This PR fixes that and sets appropriate permissions for deleting review panels.

## Before
Award Manager cannot delete a review panel.

## After
Award Manager can now delete a review panel.
