### PR TITLE
RSE-1052: Hide delete button when creating new panel

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -464,26 +464,41 @@
           height: 'auto',
           width: '650px',
           title: ts('Create Review Panel'),
-          buttons: [{
-            text: ts('Save'),
-            icons: { primary: 'fa-check' },
-            click: function () {
-              $scope.$apply(function () {
-                saveReviewPanel();
-              });
-            }
-          }, {
-            text: ts('Delete'),
-            icons: { primary: 'fa-times' },
-            class: 'civiawards__award__review-panel-form__delete',
-            click: function () {
-              $scope.$apply(function () {
-                handleDeleteReviewPanel($scope.currentReviewPanel);
-              });
-            }
-          }]
+          buttons: prepareButtonsForReviewPanelPopup()
         }
       );
+    }
+
+    /**
+     * Prepare buttons for the review panel popup
+     *
+     * @returns {Array} list of buttons
+     */
+    function prepareButtonsForReviewPanelPopup () {
+      var buttons = [{
+        text: ts('Save'),
+        icons: { primary: 'fa-check' },
+        click: function () {
+          $scope.$apply(function () {
+            saveReviewPanel();
+          });
+        }
+      }];
+
+      if ($scope.currentReviewPanel.id) {
+        buttons.push({
+          text: ts('Delete'),
+          icons: { primary: 'fa-times' },
+          class: 'civiawards__award__review-panel-form__delete',
+          click: function () {
+            $scope.$apply(function () {
+              handleDeleteReviewPanel($scope.currentReviewPanel);
+            });
+          }
+        });
+      }
+
+      return buttons;
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -197,7 +197,7 @@
 
       describe('delete button', () => {
         describe('when creating new review panel', () => {
-          it('hides the delete button inside the popup', () => {
+          it('displays only the save button inside the popup', () => {
             expect(dialogService.open).toHaveBeenCalledWith('ReviewPanels',
               '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
               $scope,
@@ -225,7 +225,7 @@
             $scope.openCreateReviewPanelPopup();
           });
 
-          it('shows the delete button inside the popup', () => {
+          it('displays both the save button and delete button inside the popup', () => {
             expect(dialogService.open).toHaveBeenCalledWith('ReviewPanels',
               '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
               $scope,

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -194,6 +194,54 @@
           }, jasmine.any(Object));
         });
       });
+
+      describe('delete button', () => {
+        describe('when creating new review panel', () => {
+          it('hides the delete button inside the popup', () => {
+            expect(dialogService.open).toHaveBeenCalledWith('ReviewPanels',
+              '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
+              $scope,
+              jasmine.objectContaining({
+                buttons: [jasmine.objectContaining({
+                  text: ts('Save'),
+                  icons: { primary: 'fa-check' }
+                })]
+              })
+            );
+          });
+        });
+
+        describe('when editing existing review panel', () => {
+          beforeEach(() => {
+            createController();
+            $scope.review_panel_form = {};
+
+            dialogService.open.and.callFake(function (__, ___, ____, options) {
+              saveButtonClickHandler = options.buttons[0].click;
+            });
+
+            $scope.currentReviewPanel.id = '1';
+
+            $scope.openCreateReviewPanelPopup();
+          });
+
+          it('shows the delete button inside the popup', () => {
+            expect(dialogService.open).toHaveBeenCalledWith('ReviewPanels',
+              '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
+              $scope,
+              jasmine.objectContaining({
+                buttons: [jasmine.objectContaining({
+                  text: ts('Save'),
+                  icons: { primary: 'fa-check' }
+                }), jasmine.objectContaining({
+                  text: ts('Delete'),
+                  icons: { primary: 'fa-times' }
+                })]
+              })
+            );
+          });
+        });
+      });
     });
 
     describe('relationship types', () => {


### PR DESCRIPTION
## Overview
When creating a new Review Panel, the delete button is visible inside the Review Panel Popup, which is wrong, as it should only appear when editing an existing review panel. This PR fixes this bug.

## Before
**Create Mode**
![2020-04-01 at 12 58 PM](https://user-images.githubusercontent.com/5058867/78110391-805f7c80-7418-11ea-9eb3-52b2b7546624.jpg)

**Edit Mode**
![2020-04-01 at 12 19 PM](https://user-images.githubusercontent.com/5058867/78107422-0b3d7880-7413-11ea-9a88-da81f730c852.jpg)


## After
**Create Mode**
![2020-04-01 at 12 58 PM](https://user-images.githubusercontent.com/5058867/78110439-9705d380-7418-11ea-9d95-bfd851dcf7e7.jpg)

**Edit Mode**
![2020-04-01 at 12 18 PM](https://user-images.githubusercontent.com/5058867/78107376-f82aa880-7412-11ea-8032-8a2c0fc160d4.jpg)

## Technical Details
1. Inside `review-panels/review-panels.directive.js`, added a new function `prepareButtonsForReviewPanelPopup`, which adds the Delete button only if the Award Review panel id is present(which means an existing review panel).
```javascript

if ($scope.currentReviewPanel.id) {
  buttons.push({
    text: ts('Delete'),
    icons: { primary: 'fa-times' },
    class: 'civiawards__award__review-panel-form__delete',
    click: function () {
      $scope.$apply(function () {
        handleDeleteReviewPanel($scope.currentReviewPanel);
      });
    }
  });
}
```