### PR TITLE
RSE-898: Allow applications to be filtered by closed statuses.

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -95,13 +95,35 @@
           };
 
           if (model.selectedFilters.statuses.length > 0) {
-            param.status_id = { IN: getSelect2Value(model.selectedFilters.statuses) };
+            var statusIds = getSelect2Value(model.selectedFilters.statuses);
+            var statusGroupings = getGroupingsForCaseStatuses(statusIds);
+
+            param.status_id = { IN: statusIds };
+            param['status_id.grouping'] = { IN: statusGroupings };
           } else {
             param.status_id = { 'IS NOT NULL': 1 };
           }
 
           $rootScope.$broadcast('civicase::dashboard-filters::updated', param);
         });
+    }
+
+    /**
+     * Given a list of status IDs, it will return the groupings that apply to
+     * all of them.
+     *
+     * @param {string[]} statusIds a list of status IDs.
+     * @returns {string[]} a list of status groupings.
+     */
+    function getGroupingsForCaseStatuses (statusIds) {
+      var allCaseStatuses = CaseStatus.getAll();
+
+      return _.chain(statusIds)
+        .map(function (statusId) {
+          return allCaseStatuses[statusId].grouping;
+        })
+        .unique()
+        .value();
     }
 
     /**

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -119,7 +119,7 @@
             dialogModel.selectedFilters.start_date = '10/12/2019';
             dialogModel.selectedFilters.end_date = '15/12/2019';
             dialogModel.selectedFilters.award_types = '1,2';
-            dialogModel.selectedFilters.statuses = '3,4';
+            dialogModel.selectedFilters.statuses = '2,3';
             dialogModel.applyFilterAndCloseDialog();
             $rootScope.$digest();
           });
@@ -135,7 +135,8 @@
             });
             expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', {
               case_type_id: { IN: [1, 2] },
-              status_id: { IN: ['3', '4'] }
+              status_id: { IN: ['2', '3'] },
+              'status_id.grouping': { IN: ['Closed', 'Opened'] }
             });
           });
         });


### PR DESCRIPTION
## Overview
This PR fixes an issue where applications would not be shown when filtering by "closed" award statuses.

## Before
![gif](https://user-images.githubusercontent.com/1642119/79395146-074b4380-7f47-11ea-8018-5fcea798946f.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/79395050-ceab6a00-7f46-11ea-9245-ebd84324b62d.gif)

## Technical Details

The issue happens because we pass the `Opened` status grouping by default when filtering cases and applications on the dashboard:
https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase/dashboard/directives/dashboard-tab.directive.js#L49

To be able to support the `Closed` status grouping we need to override the `status_id.grouping` parameters so we get all the groupings for the selected statuses and pass them to the `civicase::dashboard-filters::updated` event so it can be passed down to the case panels in turn.