### PR TITLE
ACU-67: Add Extra Fields To Award Panel Parameters To Support Application Status Restriction

### DIFF
--- a/CRM/CiviAwards/BAO/AwardReviewPanel.php
+++ b/CRM/CiviAwards/BAO/AwardReviewPanel.php
@@ -79,6 +79,16 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
         'is_array' => TRUE,
         'validate_filter' => FILTER_VALIDATE_INT,
       ],
+      'is_application_status_restricted' => [
+        'is_required' => TRUE,
+        'validate_filter' => FILTER_VALIDATE_INT,
+        'options' => ['min_range' => 0, 'max_range' => 1],
+      ],
+      'restricted_application_status' => [
+        'is_array' => TRUE,
+        'is_required' => !empty($params['visibility_settings']['is_application_status_restricted']) ? TRUE : FALSE,
+        'validate_filter' => FILTER_VALIDATE_INT,
+      ],
     ];
 
     self::validateSettingFields($fieldConfig, $params['visibility_settings'], 'Visibility Settings');

--- a/CRM/CiviAwards/BAO/AwardReviewPanel.php
+++ b/CRM/CiviAwards/BAO/AwardReviewPanel.php
@@ -179,19 +179,19 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
         continue;
       }
       if (!empty($setting['is_required']) && !isset($params[$fieldName])) {
-        throw new Exception(ts("{$settingName} :  {$fieldName} is required"));
+        throw new Exception(ts("{$settingName}: {$fieldName} is required"));
       }
 
       if (!empty($setting['is_array'])) {
         if (!is_array($params[$fieldName])) {
-          throw new Exception(ts("{$settingName} :  {$fieldName} should be an array"));
+          throw new Exception(ts("{$settingName}: {$fieldName} should be an array"));
         }
 
         if (!empty($setting['validate_filter'])) {
           $options = isset($setting['options']) ? ['options' => $setting['options']] : NULL;
           foreach ($params[$fieldName] as $value) {
             if (filter_var($value, $setting['validate_filter'], $options) === FALSE) {
-              throw new Exception("{$settingName} :  One of the values of {$fieldName} is not in a valid format");
+              throw new Exception("{$settingName}: One of the values of {$fieldName} is not in a valid format");
             }
           }
         }
@@ -200,7 +200,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanel extends CRM_CiviAwards_DAO_AwardReview
       if (empty($setting['is_array']) && !empty($setting['validate_filter'])) {
         $options = isset($setting['options']) ? ['options' => $setting['options']] : NULL;
         if (filter_var($params[$fieldName], $setting['validate_filter'], $options) === FALSE) {
-          throw new Exception("{$settingName} :  {$fieldName} is not in a valid format");
+          throw new Exception("{$settingName}: {$fieldName} is not in a valid format");
         }
       }
     }

--- a/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
+++ b/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
@@ -113,4 +113,78 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     AwardReviewPanelFabricator::fabricate($params);
   }
+
+  public function testCreateThrowsExceptionWhenRestrictedStatusIsEmptyAndApplicationStatusIsRestricted() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3],
+        'anonymize_application' => 0,
+        'is_application_status_restricted' => 1
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings: restricted_application_status is required'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenIsApplicationStatusRestrictedNotPresent() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3],
+        'anonymize_application' => 0,
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings: is_application_status_restricted is required'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenRestrictedStatusVisibilitySettingContainsNonInteger() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3],
+        'anonymize_application' => 0,
+        'is_application_status_restricted' => 1,
+        'restricted_application_status' => [1,3,'Sample'],
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'Visibility Settings: One of the values of restricted_application_status is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateIsSuccessFulWhenAllPArametersAreInExpectedFormat() {
+    $params = [
+      'visibility_settings' => [
+        'application_status' => [1,3],
+        'anonymize_application' => 0,
+        'is_application_status_restricted' => 1,
+        'restricted_application_status' => [1,3],
+      ],
+      'contact_settings' => [
+        'exclude_groups' => [1, 3],
+        'include_groups' => [5],
+        'relationship' => [
+          'contact_id' => [1, 3],
+          'relationship_type_id' => 1,
+          'is_a_to_b' => 1
+        ]
+      ]
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $this->assertNotEmpty($awardPanel->id);
+  }
 }

--- a/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
+++ b/tests/phpunit/CRM/CiviAwards/BAO/AwardReviewPanelTest.php
@@ -16,7 +16,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Contact Settings :  One of the values of exclude_groups is not in a valid format'
+      'Contact Settings: One of the values of exclude_groups is not in a valid format'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -31,7 +31,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Contact Settings :  exclude_groups should be an array'
+      'Contact Settings: exclude_groups should be an array'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -46,7 +46,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Contact Settings :  One of the values of include_groups is not in a valid format'
+      'Contact Settings: One of the values of include_groups is not in a valid format'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -61,7 +61,92 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Contact Settings :  include_groups should be an array'
+      'Contact Settings: include_groups should be an array'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenRelationshipContactArrayContainsNonInteger() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => [1,3],
+        'relationship' => [
+          [
+            'contact_id' => [1, 'Contact'],
+            'relationship_type_id' => 1
+          ]
+        ]
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'relationship: One of the values of contact_id is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenRelationshipContactIsNotAnArray() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => [1, 3],
+        'relationship' => [
+          [
+            'contact_id' => 2,
+            'relationship_type_id' => 1
+          ]
+        ]
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'relationship: contact_id should be an array'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenRelationshipTypeIdIsNotAnInteger() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => [1,3],
+        'relationship' => [
+          [
+            'contact_id' => [1, 3],
+            'relationship_type_id' => 'Sample'
+          ]
+        ]
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'relationship: relationship_type_id is not in a valid format'
+    );
+
+    AwardReviewPanelFabricator::fabricate($params);
+  }
+
+  public function testCreateThrowsExceptionWhenRelationshipAToBIsNotInExpectedFormat() {
+    $params = [
+      'contact_settings' => [
+        'exclude_groups' => [1, 3],
+        'relationship' => [
+          [
+            'contact_id' => [1, 3],
+            'relationship_type_id' => 1,
+            'is_a_to_b' => 'Sample'
+          ]
+        ]
+      ]
+    ];
+
+    $this->setExpectedException(
+      'Exception',
+      'relationship: is_a_to_b is not in a valid format'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -77,7 +162,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Visibility Settings :  One of the values of application_tags is not in a valid format'
+      'Visibility Settings: One of the values of application_tags is not in a valid format'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -93,7 +178,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Visibility Settings :  One of the values of application_status is not in a valid format'
+      'Visibility Settings: One of the values of application_status is not in a valid format'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -108,7 +193,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
 
     $this->setExpectedException(
       'Exception',
-      'Visibility Settings :  anonymize_application is required'
+      'Visibility Settings: anonymize_application is required'
     );
 
     AwardReviewPanelFabricator::fabricate($params);
@@ -165,7 +250,7 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
     AwardReviewPanelFabricator::fabricate($params);
   }
 
-  public function testCreateIsSuccessFulWhenAllPArametersAreInExpectedFormat() {
+  public function testCreateIsSuccessFulWhenAllParametersAreInExpectedFormat() {
     $params = [
       'visibility_settings' => [
         'application_status' => [1,3],
@@ -177,9 +262,16 @@ class CRM_CiviAwards_BAO_AwardReviewPanelTest extends BaseHeadlessTest {
         'exclude_groups' => [1, 3],
         'include_groups' => [5],
         'relationship' => [
-          'contact_id' => [1, 3],
-          'relationship_type_id' => 1,
-          'is_a_to_b' => 1
+          [
+            'contact_id' => [1, 3],
+            'relationship_type_id' => 1,
+            'is_a_to_b' => 1
+          ],
+          [
+            'contact_id' => [1, 3],
+            'relationship_type_id' => 4,
+            'is_a_to_b' => 0
+          ]
         ]
       ]
     ];


### PR DESCRIPTION
## Overview
When creating a panel, the Award Manager needs to be able to specify whether a review panel can change the 'status' of an applicant and if so to which status they can change to. This PR adds two extra fields to the list of parameters accepted by the Award Panel BAO when creating an Award Panel to make this possible.

## Before
- There are no parameters to support the Award Manager to be able to specify whether a review panel can change the 'status' of an application or not.

## After
Two parameters fields that can be sent from the AwardPanel create API were added to support this functionality: 
- is_application_status_restricted:  _Boolean_
- restricted_application_status:  _Array of status Id's_
