### PR TITLE
RSE-1066: Add word replacements for clients

### DIFF
--- a/config/word_replacement/awards_category.php
+++ b/config/word_replacement/awards_category.php
@@ -6,8 +6,14 @@
  */
 
 return [
+  'a Case' => 'an Application',
+  'a case' => 'an application',
+  'Case client' => 'Applicant',
+  'Case clients' => 'Applicants',
   'Case' => 'Application',
   'Cases' => 'Applications',
   'case' => 'application',
   'cases' => 'applications',
+  'Client' => 'Applicant',
+  'client' => 'applicant',
 ];


### PR DESCRIPTION
## Overview
This PR updates the word replacement configuration file so it replaces the word "client" for "applicant". We have also made so when we display "a case" we replace it as "an application".

Please refer to https://github.com/compucorp/uk.co.compucorp.civicase/pull/443 to see the technical changes that made this replacement possible.

## Before & After

<table>
  <thead>
    <tr>
      <th></th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>Case Details People's tab</th>
      <td><img src="https://user-images.githubusercontent.com/1642119/79819332-c2b11500-8357-11ea-8b84-3d43a24f4a23.png" /></td>
      <td><img src="https://user-images.githubusercontent.com/1642119/79818771-9648c900-8356-11ea-8553-0903dbf0e644.png" /></td>
    </tr>
    <tr>
      <th>Activity Feed</th>
      <td><img src="https://user-images.githubusercontent.com/1642119/79819024-27b83b00-8357-11ea-8236-36713c16c18d.png" /></td>
      <td><img src="https://user-images.githubusercontent.com/1642119/79818786-9ea10400-8356-11ea-963d-63b94b99cd90.png" /></td>
    </tr>
    <tr>
      <th>Case Panel on Awards Tab</th>
      <td><img src="https://user-images.githubusercontent.com/1642119/79819073-3999de00-8357-11ea-98f3-da3ea3fee98d.png" /></td>
      <td><img src="https://user-images.githubusercontent.com/1642119/79818793-a19bf480-8356-11ea-8057-ee4f3a7d9e4d.png" /></td>
    </tr>
    <tr>
      <th>Case Client warning message</th>
      <td><img src="https://user-images.githubusercontent.com/1642119/79820087-6d760300-8359-11ea-8ddb-5a81d97de707.png" /></td>
      <td><img src="https://user-images.githubusercontent.com/1642119/79820088-6e0e9980-8359-11ea-8ab5-58e1972bc05e.png" /></td>
    </tr>
  </tbody>
</table>

*Note:* not all places have been included here, but all changes that must be done have been documented under [RSE-1065](https://compucorp.atlassian.net/browse/RSE-1065)

## Technical Details

We have updated the `config/word_replacement/awards_category.php` file and apart from changing `client` to `applicant` we have also changed the following changes:

* `a case` to `an application`. Previously this was being translated as `a application`, which is not correct. We have added this before other translations so it prioritises it.
* `case client` to `applicant` because it was previously being translated to `application applicant` and it was redundant.