### PR TITLE
CPS-192: Release v1.0.0-beta.2

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     <url desc="Support">http://FIXME</url>
   </urls>
-  <releaseDate>2020-04-03</releaseDate>
-  <version>1.0.0-beta.1</version>
+  <releaseDate>2020-04-28</releaseDate>
+  <version>1.0.0-beta.2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 28th April, 2020

**New Features**
- Allow an Award manager to specify whether a review panel can change the 'status' of an applicant and if so to which status they can change to.

**Improvements**
- Show meaningful error message when trying to add a review and no review fields are available for the award
- Word replacement translation for the word "Client" to "Applicant" in relevant places

**Bug Fixes**
- Fixed issue with status filter is not working for "Closed" award statuses