### PR TITLE
RSE-1083: Fix Issues With AwardPanel GetContactAccess API

### DIFF
--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -15,7 +15,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   Contact Id.
    * @param int $awardId
    *   Award Id.
-   * @param AwardReviewPanelContact $awardPanelContact
+   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
    *   Award Panel contact service.
    *
    * @return array|void
@@ -33,6 +33,10 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
       if (!empty($awardPanelContact->get($awardPanelId, [$contactId]))) {
         $visibilitySettings[] = $this->getAwardVisibilitySettings($awardPanelId);
       }
+    }
+
+    if (empty($visibilitySettings)) {
+      throw new Exception("This contact does not have any access to the panels on this Award");
     }
 
     return $this->processVisibilitySettings($visibilitySettings);

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -54,18 +54,31 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
   private function processVisibilitySettings(array $visibilitySettings) {
     $applicationTags = [];
     $applicationStatus = [];
+    $statusToMoveTo = [];
     $anonymizeApplication = TRUE;
+    $hasAllTagsAccess = FALSE;
+    $hasAllStatusAccess = FALSE;
 
     foreach ($visibilitySettings as $visibilitySetting) {
       if (isset($visibilitySetting['application_tags'])) {
         $applicationTags = array_merge($applicationTags, $visibilitySetting['application_tags']);
+        if (empty($visibilitySetting['application_tags'])) {
+          $hasAllTagsAccess = TRUE;
+        }
       }
       if (isset($visibilitySetting['application_status'])) {
         $applicationStatus = array_merge($applicationStatus, $visibilitySetting['application_status']);
+        if (empty($visibilitySetting['application_status'])) {
+          $hasAllStatusAccess = TRUE;
+        }
       }
 
       if (isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0) {
         $anonymizeApplication = FALSE;
+      }
+
+      if (!empty($visibilitySetting['is_application_status_restricted'])) {
+        $statusToMoveTo = array_merge($statusToMoveTo, $visibilitySetting['restricted_application_status']);
       }
     }
     $applicationTags = array_unique($applicationTags);
@@ -74,9 +87,10 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     sort($applicationTags);
 
     return [
-      'application_tags' => $applicationTags,
-      'application_status' => $applicationStatus,
+      'application_tags' => $hasAllTagsAccess ? [] : $applicationTags,
+      'application_status' => $hasAllStatusAccess ? [] : $applicationStatus,
       'anonymize_application' => $anonymizeApplication,
+      'status_to_move_to' => $statusToMoveTo,
     ];
   }
 

--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -100,8 +100,8 @@ class CRM_CiviAwards_Service_AwardPanelContact {
    *   Relationship type Id.
    * @param bool $isAToB
    *   If relationship is a to b or not.
-   * @param int $contactId
-   *   Contact Id linked to the relationship.
+   * @param array $contactId
+   *   Contact Ids linked to the relationship.
    * @param array $filterContacts
    *   If present, filters the results to return only for
    *   contacts present in filter contacts.
@@ -109,13 +109,13 @@ class CRM_CiviAwards_Service_AwardPanelContact {
    * @return array
    *   Relationship contacts.
    */
-  private function getRelationshipContacts($relationshipTypeId, $isAToB, $contactId, array $filterContacts = []) {
+  private function getRelationshipContacts($relationshipTypeId, $isAToB, array $contactId, array $filterContacts = []) {
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
     $contactTable = CRM_Contact_BAO_Contact::getTableName();
     $contactEmailTable = CRM_Core_BAO_Email::getTableName();
     $relationshipJoinCondition = $isAToB ? 'ON r.contact_id_a = c.id' : 'ON r.contact_id_b = c.id';
-    $contactCondition = $isAToB ? 'AND r.contact_id_b = %1' : 'AND r.contact_id_a = %1';
+    $contactCondition = $isAToB ? 'AND r.contact_id_b IN (%1)' : 'AND r.contact_id_a IN (%1)';
     $filterContactCondition = $filterContacts ? 'AND c.id IN(' . implode(', ', $filterContacts) . ')' : '';
 
     $query = "
@@ -137,7 +137,7 @@ class CRM_CiviAwards_Service_AwardPanelContact {
     ";
 
     $params = [
-      1 => [$contactId, 'Integer'],
+      1 => [implode(',', $contactId), 'CommaSeparatedIntegers'],
       2 => [$relationshipTypeId, 'Integer'],
       3 => [date('Y-m-d'), 'String'],
     ];

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -6,10 +6,15 @@ use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
 use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
 
 /**
+ * CRM_CiviAwards_Service_AwardApplicationContactAccessTest.
+ *
  * @group headless
  */
 class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadlessTest {
 
+  /**
+   * Test Get Throws Exception When No AwardPanels Exist For Award.
+   */
   public function testGetThrowsExceptionWhenNoAwardPanelsExistForAward() {
     $caseType = CaseTypeFabricator::fabricate();
     $applicationContactAccess = new ApplicationContactAccess();
@@ -23,7 +28,47 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact);
   }
 
-  public function testGetReturnsTheContactAccessForAContact() {
+  /**
+   * Test Get Throws Exception When No Contact Does Belong To Any Award Panels.
+   */
+  public function testGetThrowsExceptionWhenNoContactDoesBelongToAnyAwardPanels() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $applicationContactAccess = new ApplicationContactAccess();
+    $contactId = 1;
+    $awardPanelContact = new AwardPanelContact();
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
+    ];
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $this->setExpectedException(
+      'Exception',
+      'This contact does not have any access to the panels on this Award'
+    );
+    $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact);
+  }
+
+  /**
+   * Test Get Returns The Contact Access For A Contact.
+   */
+  public function testGetReturnsTheContactAccessForContact() {
     $caseType = CaseTypeFabricator::fabricate();
     $applicationContactAccess = new ApplicationContactAccess();
     $contactId = 1;
@@ -32,19 +77,21 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
-          'application_tags' => [1,2],
-          'application_status' => [5,6],
-          'anonymize_application' => 0
-        ]
+          'application_tags' => [1, 2],
+          'application_status' => [5, 6],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 0,
+        ],
       ],
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
-          'application_tags' => [6,8],
-          'application_status' => [9,3],
-          'anonymize_application' => 1
-        ]
-      ]
+          'application_tags' => [6, 8],
+          'application_status' => [9, 3],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
     ];
     $awardPanel = [];
     foreach ($params as $param) {
@@ -52,18 +99,21 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
-    // anonymize application will be false overral because more permission takes precedence over less
-    // less permissions.
-
+    // Anonymize application will be false overral because more permission takes
+    // precedence over less less permissions.
     $expectedResult = [
-      'application_tags' => [1,2,6,8],
-      'application_status' => [3,5,6,9],
-      'anonymize_application' => FALSE
+      'application_tags' => [1, 2, 6, 8],
+      'application_status' => [3, 5, 6, 9],
+      'anonymize_application' => FALSE,
+      'status_to_move_to' => [],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
   }
 
+  /**
+   * Test Anonymize Application Returns True For Contact When True.
+   */
   public function testAnonymizeApplicationReturnsTrueForContactWhenItIsSetToBeTrue() {
     $caseType = CaseTypeFabricator::fabricate();
     $applicationContactAccess = new ApplicationContactAccess();
@@ -73,15 +123,17 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
-          'anonymize_application' => 1
-        ]
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
       ],
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
-          'anonymize_application' => 1
-        ]
-      ]
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
     ];
     $awardPanel = [];
     foreach ($params as $param) {
@@ -92,12 +144,77 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $expectedResult = [
       'application_tags' => [],
       'application_status' => [],
-      'anonymize_application' => TRUE
+      'anonymize_application' => TRUE,
+      'status_to_move_to' => [],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
   }
 
+  /**
+   * Test Visibility Settings Returns Items With Higher Values.
+   */
+  public function testVisibilitySettingsReturnsItemsWithHigherValuesWhenMoreThanOneAwardPanel() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $applicationContactAccess = new ApplicationContactAccess();
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_tags' => [],
+          'application_status' => [],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_tags' => [6, 8],
+          'application_status' => [9, 3],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
+    ];
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    // Anonymize application will be false overral because more permission takes
+    // precedence over less less permissions.
+    // Application status will return empty because empty means contact can
+    // filter all statuses and this has higher value.
+    // Application tags will return empty because empty means contact can filter
+    // all tags and this has higher value.
+    // Status to move to is a bit different because by default contact is not
+    // able to move to any So will be 2.
+    $expectedResult = [
+      'application_tags' => [],
+      'application_status' => [],
+      'anonymize_application' => FALSE,
+      'status_to_move_to' => [2],
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
+  }
+
+  /**
+   * Returns Award Panel Object for Contact.
+   *
+   * @param object $awardPanel
+   *   Award Panel.
+   * @param int $contactId
+   *   Contact Id.
+   *
+   * @return object
+   *   Award Panel Contact.
+   */
   private function getAwardPanelContactObject($awardPanel, $contactId) {
     $awardPanelContact = $this->prophesize(AwardPanelContact::class);
     foreach ($awardPanel as $awardPanel) {
@@ -106,4 +223,5 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     return $awardPanelContact->reveal();
   }
+
 }


### PR DESCRIPTION
## Overview
This PR fixes a couple of issues with the AwardReviewPanel.GetContactAccess API.


## Before
- Some issues exist

## After
Issues Fixed:
- Return an exception `This contact does not have any access to the panels on this Award` when the API is called and the contact does not have access to any panel on the award rather than return results.
- Add the `status_to_move_to` as part of the return parameters. These are the allowed statuses that the panel contacts can move an application to. An empty array means that the applications cannot be moved by the panel.
- Fix an issue with when merging application tags and statuses for award panels: An empty status setting means that the panel member can filter all statuses, so if there are two panels and one panel setting allows to filter all statuses and the other panel allows to filter one status, the overrall permission should be that the panel contact should be able to view all statuses. Same issue is fixed for tags.
- Fix an issue where the parameter allowed by the AwardPanelContact getRelationshipContacts method now accepts an array as relationship contacts rather than an integer.
- Fix broken tests, add new tests.
