### PR TITLE
RSE-647 - Award Custom Fields Functionality

### DIFF
--- a/CRM/CiviAwards/Form/AwardCustomField.php
+++ b/CRM/CiviAwards/Form/AwardCustomField.php
@@ -1,0 +1,75 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Class CRM_CiviAwards_Form_AwardCustomField.
+ */
+class CRM_CiviAwards_Form_AwardCustomField extends CRM_Civicase_Form_CaseCategoryTypeCustomField {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    $awardId = CRM_Utils_Request::retrieve('entityId', 'Positive', $this, TRUE);
+    if (!$this->isValidAwardType($awardId)) {
+      CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');
+    }
+
+    $this->assign('invalidAwardType', TRUE);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $this->addButtons(
+      [
+        [
+          'type' => 'upload',
+          'name' => ts('Save'),
+          'class' => 'award-custom-field',
+          'isDefault' => TRUE,
+        ],
+      ]
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function getEntityType() {
+    return CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME . "Type";
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    parent::postProcess();
+
+    $url = CRM_Utils_System::url('civicrm/award/customfield', [
+      'entityId' => $this->entityId,
+      'reset' => 1,
+    ]);
+
+    $session = CRM_Core_Session::singleton();
+    $session->pushUserContext($url);
+  }
+
+  /**
+   * Checks if the award case type is valid.
+   *
+   * @param int $awardTypeId
+   *   Award Type Id.
+   *
+   * @return bool
+   *   Checks if award is valid or not.
+   */
+  private function isValidAwardType($awardTypeId) {
+    $awardCaseTypes = CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes();
+
+    return !empty($awardCaseTypes[$awardTypeId]);
+  }
+
+}

--- a/CRM/CiviAwards/Form/AwardCustomField.php
+++ b/CRM/CiviAwards/Form/AwardCustomField.php
@@ -13,10 +13,10 @@ class CRM_CiviAwards_Form_AwardCustomField extends CRM_Civicase_Form_CaseCategor
   public function preProcess() {
     $awardId = CRM_Utils_Request::retrieve('entityId', 'Positive', $this, TRUE);
     if (!$this->isValidAwardType($awardId)) {
-      CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');
+      $this->assign('invalidAwardType', TRUE);
     }
 
-    $this->assign('invalidAwardType', TRUE);
+    parent::preProcess();
   }
 
   /**

--- a/CRM/CiviAwards/Setup/AddAwardCaseTypeCustomGroupSupport.php
+++ b/CRM/CiviAwards/Setup/AddAwardCaseTypeCustomGroupSupport.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends as CaseCategoryCaseTypeCustomFieldExtends;
+
+/**
+ * Class CRM_CiviAwards_Setup_AddAwardCaseTypeCustomGroupSupport.
+ */
+class CRM_CiviAwards_Setup_AddAwardCaseTypeCustomGroupSupport {
+
+  const AWARD_CASE_TYPE_CG_LABEL = 'Award Case Type';
+
+  /**
+   * Add Award Case Type as a valid Entity that a custom group can extend.
+   */
+  public function apply() {
+    $caseCategoryCaseTypeCustomFieldExtends = new CaseCategoryCaseTypeCustomFieldExtends();
+    $caseCategoryCaseTypeCustomFieldExtends->create(
+      CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      self::AWARD_CASE_TYPE_CG_LABEL,
+      'CRM_CiviAwards_Helper_CaseTypeCategory::getAwardCaseTypes;'
+    );
+  }
+
+}

--- a/CRM/CiviAwards/Uninstall/RemoveCustomGroupSupportForAwardType.php
+++ b/CRM/CiviAwards/Uninstall/RemoveCustomGroupSupportForAwardType.php
@@ -1,0 +1,19 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends as CaseCategoryCaseTypeCustomFieldExtends;
+
+/**
+ * Class CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardType.
+ */
+class CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardType {
+
+  /**
+   * Deletes the Award Type option from the CG Extends option values.
+   */
+  public function apply() {
+    $caseCategoryCaseTypeCustomFieldExtends = new CaseCategoryCaseTypeCustomFieldExtends();
+    $caseCategoryCaseTypeCustomFieldExtends->delete(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -2,12 +2,15 @@
 
 use CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption as CreateAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_ProcessAwardsCategoryForCustomGroupSupport as ProcessAwardsCategoryForCustomGroupSupport;
+use CRM_CiviAwards_Setup_AddAwardCaseTypeCustomGroupSupport as AddAwardCaseTypeCustomGroupSupport;
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup as CreateAwardTypeOptionGroup;
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 use CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField as DeleteApplicantReviewCustomField;
 use CRM_CiviAwards_Setup_AddAwardsCategoryWordReplacement as AddAwardsCategoryWordReplacement;
 use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardsCategory as RemoveCustomGroupSupportForAwardsCategory;
+use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardType as RemoveCustomGroupSupportForAwardType;
+
 use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
 
 /**
@@ -29,6 +32,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     $steps = [
       new CreateAwardsCaseCategoryOption(),
       new ProcessAwardsCategoryForCustomGroupSupport(),
+      new AddAwardCaseTypeCustomGroupSupport(),
       new CreateAwardTypeOptionGroup(),
       new CreateApplicantReviewActivityType(),
       new AddAwardsCategoryWordReplacement(),
@@ -66,6 +70,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new DeleteAwardsCaseCategoryOption(),
       new RemoveCustomGroupSupportForAwardsCategory(),
       new DeleteApplicantReviewCustomField(),
+      new RemoveCustomGroupSupportForAwardType(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/Upgrader/Steps/Step1002.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1002.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_CiviAwards_Setup_AddAwardCaseTypeCustomGroupSupport as AddAwardCaseTypeCustomGroupSupport;
+
+/**
+ * Upgrader that adds custom group support for Award Case Type.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1002 {
+
+  /**
+   * Adds Custom Group support for Award Case Type.
+   *
+   * @return bool
+   *   returns value.
+   */
+  public function apply() {
+    $step = new AddAwardCaseTypeCustomGroupSupport();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/templates/CRM/CiviAwards/Form/AwardCustomField.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardCustomField.tpl
@@ -1,0 +1,11 @@
+{if $invalidAwardType}
+    <p class="alert alert-warning">
+        Invalid Award Type
+    </p>
+{else}
+    <div class="crm-block crm-form-block crm-case-custom-form-block">
+        {include file="CRM/Custom/Form/CustomData.tpl" skipTitle=0}
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+    </div>
+{/if}
+

--- a/xml/Menu/civiawards.xml
+++ b/xml/Menu/civiawards.xml
@@ -7,6 +7,12 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/award/customfield</path>
+    <page_callback>CRM_CiviAwards_Form_AwardCustomField</page_callback>
+    <title>Award Custom Fields</title>
+    <access_arguments>create/edit awards</access_arguments>
+  </item>
+  <item>
     <path>civicrm/award/a</path>
     <page_callback>CRM_CiviAwards_Page_AwardAngular</page_callback>
     <access_arguments>create/edit awards</access_arguments>


### PR DESCRIPTION
## Overview
This PR adds a form that allows to create/edit custom fields for an award case type and adds the functionality for the creation of custom group sets for award case types.

## Before
- These functionalities does not exist.

## After
- The Award Custom Fields form extends the base class form `CRM_Civicase_Form_CaseCategoryTypeCustomField` which allows it to add the custom fields defined for an award for create/edit.
- The `AddAwardCaseTypeCustomGroupSupport` class was created to add the Award Case Type as an entity that can be extended for custom group sets. These makes the Award Case type available as an option on the page for adding Custom group sets.

![Award Custom](https://user-images.githubusercontent.com/6951813/81555931-58512a80-9381-11ea-8906-a76ed634dbb2.gif)


<img width="1260" alt="Administer AwardType Custom Fields  CaseLatest 2020-05-11 12-10-00" src="https://user-images.githubusercontent.com/6951813/81555964-6737dd00-9381-11ea-8e73-2e0521611125.png">

