### PR TITLE
RSE-1132: Award Review Form Changes

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -11,6 +11,16 @@ use CRM_CiviAwards_BAO_AwardDetail as AwardDetail;
 class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
   /**
+   * URL for accessing review form from SSP.
+   */
+  const SSP_REVIEW_URL = 'civicrm/award-review-ssp';
+
+  /**
+   * URL for accessing review form from civicrm.
+   */
+  const CIVICRM_REVIEW_URL = 'civicrm/awardreview';
+
+  /**
    * Case ID.
    *
    * @var int
@@ -198,7 +208,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');
     }
 
-    $awardPath = $this->isReviewFromSsp() ? 'civicrm/award-review-ssp' : 'civicrm/awardreview';
+    $awardPath = $this->isReviewFromSsp() ? self::SSP_REVIEW_URL : self::CIVICRM_REVIEW_URL;
     $url = CRM_Utils_System::url($awardPath, [
       'action' => 'view',
       'id' => $activityId,
@@ -554,7 +564,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    *   From SSP portal or not.
    */
   private function isReviewFromSsp() {
-    return CRM_Utils_System::currentPath() == 'civicrm/award-review-ssp';
+    return CRM_Utils_System::currentPath() == self::SSP_REVIEW_URL;
   }
 
   /**

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -25,6 +25,13 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   private $activityId;
 
   /**
+   * Activity details.
+   *
+   * @var array
+   */
+  private $activity;
+
+  /**
    * Profile Id.
    *
    * @var int
@@ -87,6 +94,10 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function preProcess() {
+    if (!in_array($this->_action, [CRM_Core_Action::ADD, CRM_Core_Action::VIEW])) {
+      throw new Exception('Action not supported!');
+    }
+
     if ($this->_action & CRM_Core_Action::ADD) {
       $this->caseId = CRM_Utils_Request::retrieve('case_id', 'Positive', $this);
     }
@@ -110,14 +121,46 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       $this->profileId, FALSE, CRM_Core_Action::ADD, NULL,
       NULL, FALSE, NULL, FALSE, NULL, CRM_Core_Permission::CREATE, 'weight'
     );
-    $shouldDisplayMissingFieldsError = empty($fields);
 
-    if ($shouldDisplayMissingFieldsError) {
-      $this->displayMissingFieldsError();
+    $error = $this->getErrorMessage($fields);
+    if ($error) {
+      $this->displayErrorMessage($error);
     }
     else {
       $this->displayReviewForm($fields);
     }
+  }
+
+  /**
+   * Returns the error messages for the form if any.
+   *
+   * @param array|null $fields
+   *   Form fields.
+   *
+   * @return string
+   *   Error message.
+   */
+  private function getErrorMessage($fields) {
+    if (empty($fields)) {
+      return 'There are no review fields assigned to this award type. 
+        Please add Review Fields by editing the the Award Type located under the 
+        Overview dropdown in Award Dashboard.';
+    }
+
+    $isViewAction = $this->_action & CRM_Core_Action::VIEW;
+    $isAddAction = $this->_action & CRM_Core_Action::ADD;
+    $hasSubmittedReview = $this->userAlreadySubmittedReview();
+    $canNotViewReview = $isViewAction && $this->isReviewFromSsp() && !$this->isReviewOwner();
+
+    if ($hasSubmittedReview && $isAddAction) {
+      return 'You have already submitted a review for this Award and you can not add another review';
+    }
+
+    if ($canNotViewReview) {
+      return 'You can only view the reviews that you have added!';
+    }
+
+    return NULL;
   }
 
   /**
@@ -155,8 +198,9 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');
     }
 
-    $url = CRM_Utils_System::url('civicrm/awardreview', [
-      'action' => 'update',
+    $awardPath = $this->isReviewFromSsp() ? 'civicrm/award-review-ssp' : 'civicrm/awardreview';
+    $url = CRM_Utils_System::url($awardPath, [
+      'action' => 'view',
       'id' => $activityId,
       'reset' => 1,
     ]);
@@ -165,12 +209,15 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   }
 
   /**
-   * Displays an error message when no review fields have been configured.
+   * Displays an error message when there are errors for the form.
+   *
+   * @param string $errorMessage
+   *   Error message.
    */
-  private function displayMissingFieldsError() {
+  private function displayErrorMessage($errorMessage) {
     CRM_Utils_System::setTitle(E::ts('Warning'));
 
-    $this->assign('displayMissingFieldsError', TRUE);
+    $this->assign('errorMessage', $errorMessage);
 
     $this->addButtons([
       [
@@ -193,6 +240,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $this->assign('caseTypeName', $this->caseTypeName);
     $this->assign('caseTags', $this->caseTags);
     $this->assign('isViewAction', $isViewAction);
+    $this->assign('isReviewFromSsp', $this->isReviewFromSsp());
 
     if ($isViewAction) {
       $this->assign('sourceContactId', $this->activity['source_contact_id']);
@@ -213,12 +261,17 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE);
     }
 
-    if ($this->_action & CRM_Core_Action::VIEW) {
+    if ($isViewAction) {
       foreach ($this->_elements as $element) {
         if (in_array($element->_attributes['name'], $elementNames)) {
           $element->freeze();
         }
       }
+    }
+
+    if (!$isViewAction && $this->isReviewFromSsp()) {
+      $sourceContact = $this->getElement('source_contact_id');
+      $sourceContact->freeze();
     }
 
     $this->profileFields = $elementNames;
@@ -492,6 +545,42 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       'id' => $this->activityId,
       'source_contact_id' => $values['source_contact_id'],
     ]);
+  }
+
+  /**
+   * Checks if this form was loaded from SSP portal.
+   *
+   * @return bool
+   *   From SSP portal or not.
+   */
+  private function isReviewFromSsp() {
+    return CRM_Utils_System::currentPath() == 'civicrm/award-review-ssp';
+  }
+
+  /**
+   * Checks if logged in user is the owner of review activity.
+   *
+   * @return bool
+   *   Whether owner or not.
+   */
+  private function isReviewOwner() {
+    return $this->activity['source_contact_id'] == CRM_Core_Session::getLoggedInContactID();
+  }
+
+  /**
+   * Checks if the user has already submitted a review for the Award.
+   *
+   * @return bool
+   *   Bool value.
+   */
+  private function userAlreadySubmittedReview() {
+    $result = civicrm_api3('Activity', 'get', [
+      'activity_type_id' => 'Applicant Review',
+      'case_id' => $this->caseId,
+      'source_contact_id' => "user_contact_id",
+    ]);
+
+    return $result['count'] > 0;
   }
 
 }

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -11,5 +11,7 @@
         <!--Drupal expects function names like civiawards_civicrm_pre_process but civi can have-->
         <!--civiawards_civicrm_preProcess which is valid for civi.-->
         <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+        <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+        <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
     </rule>
 </ruleset>

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -3,10 +3,10 @@
     <div class="panel panel-default">
       <div class="panel-body">
         <div class="form-group row">
-          {if $displayMissingFieldsError}
-            <p class="alert alert-warning">There are no review fields assigned to this award type.
-            Please add Review Fields by editing the the Award
-            Type located under the Overview dropdown in Award Dashboard.</p>
+          {if $errorMessage}
+            <p class="alert alert-warning">
+              {$errorMessage}
+            </p>
           {/if}
           {if $isViewAction}
             <div class="col-sm-5">
@@ -15,13 +15,18 @@
               </label>
             </div>
             <div class="col-sm-7">
+                {if !$isReviewFromSsp }
               <a
                 class="view-contact no-popup"
-                href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
+                href=
+                "{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
                 title="{ts}View Contact{/ts}"
               >
                 {$sourceContactName}
               </a>
+              {else}
+                {$sourceContactName}
+              {/if}
             </div>
           {/if}
           {if !$isViewAction}
@@ -43,9 +48,6 @@
         {/foreach}
       </div>
       <div class="crm-submit-buttons panel-footer clearfix">
-        {if $isViewAction}
-          <a href="{crmURL p='civicrm/awardreview' q=$editUrlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil"></i> {ts}Edit{/ts}</span></a>
-        {/if}
         {include file="CRM/common/formButtons.tpl" location="bottom"}
       </div>
     </div>

--- a/xml/Menu/civiawards.xml
+++ b/xml/Menu/civiawards.xml
@@ -3,8 +3,15 @@
   <item>
     <path>civicrm/awardreview</path>
     <page_callback>CRM_CiviAwards_Form_AwardReview</page_callback>
-    <title>AwardReview</title>
+    <title>Award Review</title>
     <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/award-review-ssp</path>
+    <page_callback>CRM_CiviAwards_Form_AwardReview</page_callback>
+    <title>Award Review</title>
+    <access_arguments>access applicant portal</access_arguments>
+    <is_public>true</is_public>
   </item>
   <item>
     <path>civicrm/award/a</path>


### PR DESCRIPTION
## Overview
We need to be able to use the Award Review form from within SSP (Currently only accessible within Civicrm) so that a review panel member can add review for an award.
Below are the changes we need to make to the awards review form, both general changes and SSP specific changes:

**SSP Specific changes**
- The review form for SSP must not be themed with shoreditch styles
- A user from SSP can not view the review another panel member left on an Award, i.e user should able to view only own reviews

**General Changes**
- Once a user has reviewed an Award, the review cannot be edited again.
- A user can only leave a single review for an Award.


## Before
These changes were not made.

## After
The changes described in the overview section was implemented

| Award Review (Civicrm)  | Award Review (SSP) |
| ------------- | ------------- |
| <img width="1217" alt="View Review - Benefit Specialist Benefit - Award Type  CaseLatest 2020-06-08 10-23-55" src="https://user-images.githubusercontent.com/6951813/84015539-ea922180-a973-11ea-98b4-a4fd69c9e6be.png">| <img width="1052" alt="View Review - Benefit Specialist Benefit - Award Type  CaseLatest 2020-06-08 10-25-04" src="https://user-images.githubusercontent.com/6951813/84015711-2af19f80-a974-11ea-9a38-da4d966cbd43.png">|
| <img width="1223" alt="Add Review  CaseLatest 2020-06-08 10-27-05" src="https://user-images.githubusercontent.com/6951813/84015869-62f8e280-a974-11ea-86e1-1b9ec48ae6b6.png">|<img width="1073" alt="Add Review  CaseLatest 2020-06-08 10-30-29" src="https://user-images.githubusercontent.com/6951813/84016002-93d91780-a974-11ea-92fd-f2285c848648.png">|
| <img width="1216" alt="Warning  CaseLatest 2020-06-08 10-45-39" src="https://user-images.githubusercontent.com/6951813/84016507-4c06c000-a975-11ea-8c17-8fadba25f45c.png">|<img width="1054" alt="Warning  CaseLatest 2020-06-08 10-29-46" src="https://user-images.githubusercontent.com/6951813/84016256-ed414680-a974-11ea-949d-dc78ba6f62a5.png">|
| Can view other reviews|<img width="1049" alt="Warning  CaseLatest 2020-06-08 10-47-23" src="https://user-images.githubusercontent.com/6951813/84016694-8a03e400-a975-11ea-8bb8-aa5a1f3286bb.png">|

## Technical Details
To achieve what was described in the overview:

- A new menu path was created that points to the review form class, this path uses a permission that a Drupal SSP user will have access to and also has the `is_public` property to be true so that Shoreditch styles are not loaded for this path.
- When the form is accessed via SSP, the user does not have access to Civicrm API so fields like the `Added by` field that uses the entity API to fetch contacts was disabled for the SSP user, also links to the Civicrm contact page for the Added by contact was also removed as the SSP user will not have civicrm contact access.
- The Edit action was disabled in the Award review form, so only the Add and View actions are active.

## Comments
A PHP lint error resulting from a new rule in the Drupal Coder rule set was excluded. Please see this [PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/483) for more details
