### PR TITLE
RSE-1138: Exclude Groups Should Take Precedence For Panel Contacts Logic

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0-chrome
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+        - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+
+      - name: Build Drupal site
+        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: actions/checkout@v2
+        with:
+            path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards
+
+      - name: Installing CiviAwards and its dependencies
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.civicase.git
+          cv en shoreditch civicase civiawards
+
+      - name: Run JS unit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards
+        run: |
+          npm install
+          npx gulp test
+
+      - name: Run phpunit tests
+        if: ${{ always() }}
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards
+        run: phpunit5

--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -28,10 +28,14 @@ class CRM_CiviAwards_Service_AwardPanelContact {
 
     $includeGroups = isset($awardContactSettings['include_groups']) ? $awardContactSettings['include_groups'] : [];
     $excludeGroups = isset($awardContactSettings['exclude_groups']) ? $awardContactSettings['exclude_groups'] : [];
-    $groupContacts = [];
+    $includeGroupContacts = [];
+    $excludeGroupContacts = [];
 
     if (!empty($includeGroups)) {
-      $groupContacts = $this->getGroupContacts($includeGroups, $excludeGroups, $filterContacts);
+      $includeGroupContacts = $this->getContactsForGroup($includeGroups, $filterContacts);
+    }
+    if (!empty($excludeGroups)) {
+      $excludeGroupContacts = $this->getContactsForGroup($excludeGroups, $filterContacts);
     }
 
     $relationshipContacts = [];
@@ -46,7 +50,9 @@ class CRM_CiviAwards_Service_AwardPanelContact {
       }
     }
 
-    return $this->mergeAllRelatedContacts($groupContacts, $relationshipContacts);
+    $panelContacts = $this->mergeAllRelatedContacts($includeGroupContacts, $relationshipContacts);
+
+    return array_diff_key($panelContacts, $excludeGroupContacts);
   }
 
   /**

--- a/ang/test/karma.conf.js
+++ b/ang/test/karma.conf.js
@@ -64,15 +64,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessBrowser'],
     customLaunchers: {
-      ChromeHeadless: {
-        base: 'Chrome',
+      ChromeHeadlessBrowser: {
+        base: 'ChromeHeadless',
         flags: [
-          '--headless',
-          '--disable-gpu',
-          // Without a remote debugging port, Google Chrome exits immediately.
-          '--remote-debugging-port=9222'
+          '--no-sandbox',
+          '--disable-dev-shm-usage'
         ]
       }
     }

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -11,5 +11,7 @@
         <!--Drupal expects function names like civiawards_civicrm_pre_process but civi can have-->
         <!--civiawards_civicrm_preProcess which is valid for civi.-->
         <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+        <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+        <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
     </rule>
 </ruleset>


### PR DESCRIPTION
## Overview

**Scenario:**

- Create a group called group A
- Contact x should be included in group A
- Contact x should be included in a relationship A

- Create an award
- Add a panel to the award
- Include the relationship A that the contact belongs on the Panel
- Exclude group A
- Save award

**Expected behaviour:**
Contact x should be excluded from panel in SSP

**Actual results:**
Contact x is included in panel in SSP

![Panel_Config](https://user-images.githubusercontent.com/6951813/84382039-eec37680-abe1-11ea-95e9-8db3591056cb.png)


## Before
The scenario described in the overview exists.

## After
When a contact belongs to a relationship and belongs to a group that is excluded in a Panel. The contact is not returned as a panel member and is excluded.

<img width="1240" alt="CiviCRM API v3  CaseLatest 2020-06-11 16-39-55" src="https://user-images.githubusercontent.com/6951813/84407176-60abb800-ac02-11ea-8481-9ad4b74fc09a.png">


## Comments
- This PR also adds the git workflow for unit tests so that PHP and JS tests are ran when a PR is made.
- A PHP linter error was also fixed by excluding a newly introduced ruleset that is conflicting with our code. See more info [here](https://github.com/compucorp/uk.co.compucorp.civicase/pull/483) 