### PR TITLE
RSE-1115: HTML format and class tweaks to achieve design layout

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -248,6 +248,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
     $this->assign('caseContactDisplayName', $this->getCaseContactDisplayName());
     $this->assign('caseTypeName', $this->caseTypeName);
+    $this->assign('caseTags', $this->caseTags);
     $this->assign('isViewAction', $isViewAction);
     $this->assign('isReviewFromSsp', $this->isReviewFromSsp());
 

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -1,55 +1,55 @@
-<div id="bootstrap-theme">
-  <div class="civiawards__review-activity crm-form-block">
-    <div class="panel panel-default">
-      <div class="panel-body">
-        <div class="form-group row">
-          {if $errorMessage}
-            <p class="alert alert-warning">
-              {$errorMessage}
-            </p>
-          {/if}
-          {if $isViewAction}
-            <div class="col-sm-5">
-              <label for="source_contact_id">
-                {ts}Added By{/ts}
-              </label>
-            </div>
-            <div class="col-sm-7">
-                {if !$isReviewFromSsp }
-              <a
-                class="view-contact no-popup"
-                href=
-                "{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
-                title="{ts}View Contact{/ts}"
-              >
-                {$sourceContactName}
-              </a>
-              {else}
-                {$sourceContactName}
-              {/if}
-            </div>
-          {/if}
-          {if !$isViewAction}
-            <div class="col-sm-5">
-              {$form.source_contact_id.label}
-            </div>
-            <div class="col-sm-7">
-              {$form.source_contact_id.html}
-            </div>
-          {/if}
-          <div class="clear"></div>
-        </div>
-        {foreach from=$elementNames item=elementName}
-          <div class="form-group row">
-            <div class="col-sm-5">{$form.$elementName.label}</div>
-            <div class="col-sm-7">{$form.$elementName.html}</div>
-            <div class="clear"></div>
-          </div>
-        {/foreach}
-      </div>
-      <div class="crm-submit-buttons panel-footer clearfix">
-        {include file="CRM/common/formButtons.tpl" location="bottom"}
-      </div>
-    </div>
+{if !$errorMessage}
+  <div class="ssp-well-prefix">
+    <a href="/ssp/awards/review-applications"><i class="fa fa-arrow-left"></i> Back to All Applications</a>
   </div>
+{/if}
+<div class="civiawards__review-activity well">
+  {if $errorMessage}
+    <p class="alert alert-warning">
+      {$errorMessage}
+    </p>
+    <div class="clearfix">
+      <a class="btn btn-primary pull-right" href="/ssp/awards/review-applications"> Back to all Applications </a>
+    </div>
+  {/if}
+  <h1 class="page-header">
+    {if $isViewAction}
+      {if !$isReviewFromSsp }
+        <a
+          class="view-contact no-popup"
+          href=
+          "{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
+          title="{ts}View Contact{/ts}"
+        >
+          {$sourceContactName}
+        </a>
+      {else}
+        {$sourceContactName}
+      {/if}
+    {/if}
+    {if !$isViewAction}
+      {$form.source_contact_id.html}
+    {/if}
+  </h1>
+  {if !$errorMessage}
+  <div class="ssp-details-page-section__sub-heading">
+    <span class="ssp-applicant-card__award ssp-text-large">Dummy Award</span>
+    <span>
+      <span class="label label-primary" style="background-color: #f3e11b">Lorem ipsum</span>
+      <span class="label label-primary" style="background-color: #d73737"> Dolor sit </span> </span>
+    </div>
+  {/if}
+  {foreach from=$elementNames item=elementName}
+    <div class="form-group">
+      <label class="control-label" for="edit-name">{$form.$elementName.label}</label>
+      <div class="ssp-form-control-description text-muted"> Lorem ipsum dolor sit. Sit dolor ipsum lorem porem. </div>
+      {$form.$elementName.html}
+    </div>
+  {/foreach}
+  {if !$errorMessage && !$isViewAction}
+    <div class="clearfix">
+      <button type="submit" class="btn btn-primary default validate pull-right"> Submit Application </button>
+      <a class="btn btn-default pull-left" href="/ssp/awards/review-applications"> Cancel </a>
+    </div>
+  {/if}
 </div>

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -46,11 +46,11 @@
               {/if}
             </h1>
             <div class="ssp-details-page-section__sub-heading">
-              <span class="ssp-applicant-card__award ssp-text-large">Dummy Award</span>
+              <span class="ssp-applicant-card__award ssp-text-large">{$caseTypeName}</span>
               <span>
-                <span class="label label-primary" style="background-color: #f3e11b">Lorem ipsum</span>
-                <span class="label label-primary" style="background-color: #d73737"> Dolor sit </span>
-              </span>
+                {foreach from=$caseTags item=caseTag}
+                  <span class="label label-primary" style="background-color: {$caseTag.background_color}">{$caseTag.name}</span>
+                {/foreach}
             </div>
           {else}
             {* View Mode *}

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -1,55 +1,133 @@
-{if !$errorMessage}
+{if $isReviewFromSsp}
+  {assign var='container_attributes' value=''}
+  {assign var='wrapper_class' value='well'}
+  {assign var='form_group_class' value=''}
+  {assign var='form_group_label_class' value='control-label'}
+  {assign var='form_group_field_class' value=''}
+{else}
+  {assign var='container_attributes' value='id="bootstrap-theme"'}
+  {assign var='wrapper_class' value='crm-form-block'}
+  {assign var='form_group_class' value='row'}
+  {assign var='form_group_label_class' value='col-sm-5'}
+  {assign var='form_group_field_class' value='col-sm-7'}
+{/if}
+
+{if !$errorMessage && $isReviewFromSsp}
   <div class="ssp-well-prefix">
     <a href="/ssp/awards/review-applications"><i class="fa fa-arrow-left"></i> Back to All Applications</a>
   </div>
 {/if}
-<div class="civiawards__review-activity well">
-  {if $errorMessage}
-    <p class="alert alert-warning">
-      {$errorMessage}
-    </p>
-    <div class="clearfix">
-      <a class="btn btn-primary pull-right" href="/ssp/awards/review-applications"> Back to all Applications </a>
-    </div>
-  {/if}
-  <h1 class="page-header">
-    {if $isViewAction}
-      {if !$isReviewFromSsp }
-        <a
-          class="view-contact no-popup"
-          href=
-          "{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
-          title="{ts}View Contact{/ts}"
-        >
-          {$sourceContactName}
-        </a>
+
+<div {$container_attributes}>
+  <div class="civiawards__review-activity clearfix {$wrapper_class}">
+    {if !$isReviewFromSsp}
+      <div class="panel panel-default">
+        <div class="panel-body">
+    {/if}
+      {* Show error mode *}
+      {if $errorMessage}
+        <p class="alert alert-warning">
+          {$errorMessage}
+        </p>
+        {if $isReviewFromSsp}
+          <div class="clearfix">
+            <a class="btn btn-primary pull-right" href="/ssp/awards/review-applications"> Back to all Applications </a>
+          </div>
+        {/if}
+      {* Show data mode *}
       {else}
-        {$sourceContactName}
+        <div class="form-group {$form_group_class}">
+          {if $isReviewFromSsp}
+            <h1 class="header-pager">
+              {if $isViewAction}
+                {$sourceContactName}
+              {else}
+                {$form.source_contact_id.html}
+              {/if}
+            </h1>
+            <div class="ssp-details-page-section__sub-heading">
+              <span class="ssp-applicant-card__award ssp-text-large">Dummy Award</span>
+              <span>
+                <span class="label label-primary" style="background-color: #f3e11b">Lorem ipsum</span>
+                <span class="label label-primary" style="background-color: #d73737"> Dolor sit </span>
+              </span>
+            </div>
+          {else}
+            {* View Mode *}
+            {if $isViewAction}
+              <div class="{$form_group_label_class}">
+                <label for="source_contact_id">
+                  {ts}Added By{/ts}
+                </label>
+              </div>
+              <div class="{$form_group_field_class}">
+                {if !$isReviewFromSsp }
+                  <a
+                    class="view-contact no-popup"
+                    href=
+                    "{crmURL p="civicrm/contact/view" q="reset=1&cid=`$sourceContactId`"}"
+                    title="{ts}View Contact{/ts}"
+                  >
+                    {$sourceContactName}
+                  </a>
+                {else}
+                  {$sourceContactName}
+                {/if}
+              </div>
+            {/if} {*  End view mode *}
+            {* Edit Mode *}
+            {if !$isViewAction}
+              <div class="{$form_group_label_class}">
+                {$form.source_contact_id.label}
+              </div>
+              <div class="{$form_group_field_class}">
+                {$form.source_contact_id.html}
+              </div>
+            {/if} {* End Edit mode *}
+          {/if} {* End reviewBySSPUser *}
+        </div>
       {/if}
+      {* End if error message *}
+
+      {* Form fields section Starts *}
+      {foreach from=$elementNames item=elementName}
+        <div class="form-group {$form_group_class}">
+          <label class="{$form_group_label_class}">{$form.$elementName.label}</label>
+          {if $isReviewFromSsp}
+            <div class="ssp-form-control-description text-muted"> Lorem ipsum dolor sit. Sit dolor ipsum lorem porem. </div>
+          {/if}
+          <div class="{$form_group_field_class}">{$form.$elementName.html}</div>
+          <div class="clear"></div>
+        </div>
+      {/foreach}
+      {* Form fields section Ends *}
+
+      {* Form action section Starts *}
+      {if !$errorMessage}
+        {if $isReviewFromSsp}
+          {if !$isViewAction}
+            <div class="clearfix">
+              <button type="submit" class="btn btn-primary default validate pull-right"> Submit Application </button>
+              <a class="btn btn-default pull-left" href="/ssp/awards/review-applications"> Cancel </a>
+            </div>
+          {else}
+            <button disabled="true" class="btn btn-primary default validate pull-right">
+              <i class="fas fa-check"></i>
+              Review Submitted
+            </button >
+          {/if}
+        {else}
+          <div class="crm-submit-buttons panel-footer clearfix">
+            {include file="CRM/common/formButtons.tpl" location="bottom"}
+          </div>
+        {/if}
+      {/if}
+      {* Form action section Ends *}
+
+    {if !$isReviewFromSsp }
+        </div>
+      </div>
     {/if}
-    {if !$isViewAction}
-      {$form.source_contact_id.html}
-    {/if}
-  </h1>
-  {if !$errorMessage}
-  <div class="ssp-details-page-section__sub-heading">
-    <span class="ssp-applicant-card__award ssp-text-large">Dummy Award</span>
-    <span>
-      <span class="label label-primary" style="background-color: #f3e11b">Lorem ipsum</span>
-      <span class="label label-primary" style="background-color: #d73737"> Dolor sit </span> </span>
-    </div>
-  {/if}
-  {foreach from=$elementNames item=elementName}
-    <div class="form-group">
-      <label class="control-label" for="edit-name">{$form.$elementName.label}</label>
-      <div class="ssp-form-control-description text-muted"> Lorem ipsum dolor sit. Sit dolor ipsum lorem porem. </div>
-      {$form.$elementName.html}
-    </div>
-  {/foreach}
-  {if !$errorMessage && !$isViewAction}
-    <div class="clearfix">
-      <button type="submit" class="btn btn-primary default validate pull-right"> Submit Application </button>
-      <a class="btn btn-default pull-left" href="/ssp/awards/review-applications"> Cancel </a>
-    </div>
-  {/if}
+  </div>
 </div>
+


### PR DESCRIPTION
## Overview
As a part of this PR basic bootstrap classes and HTML is implemented in order to match it closely with the designs. 
Related FE PR [here](https://github.com/compucorp/ssp_bootstrap/pull/10)

## Before
<img width="974" alt="Screenshot 2020-06-11 at 6 31 37 PM" src="https://user-images.githubusercontent.com/3340537/84388249-df5c2180-ac11-11ea-97f7-cf5040382b3f.png">

## After
#### Form
<img width="949" alt="Screenshot 2020-06-11 at 6 31 05 PM" src="https://user-images.githubusercontent.com/3340537/84388262-e5520280-ac11-11ea-9a12-1fe52b951485.png">

#### Form Submission
<img width="1495" alt="Screenshot 2020-06-16 at 12 40 51 PM" src="https://user-images.githubusercontent.com/3340537/84743427-8f91a780-afcf-11ea-83d3-de4ff611cdec.png">

##### Civicrm
<img width="1154" alt="Screenshot 2020-06-16 at 12 44 12 PM" src="https://user-images.githubusercontent.com/3340537/84743469-a33d0e00-afcf-11ea-9b37-576fdbe320fe.png">

#### Error
<img width="938" alt="Screenshot 2020-06-11 at 6 36 52 PM" src="https://user-images.githubusercontent.com/3340537/84388948-036c3280-ac13-11ea-9472-64e8277805e1.png">

## Technical Details
* Custom civicrm classes are removed and bootstrap classes are used to achieve out of the box styles.
* Also, replaced core civicrm action buttons HTML with bootstrap action buttons in order to improve UI.
* The UI mentioned in the after screenshot can be achieved by some extra css overrides done for civicrm in `ssp_bootstrap` [theme here](https://github.com/compucorp/ssp_bootstrap/pull/10).

## Comments
This HTML contains dummy data for form prefix field. This is done in order to assist BE with development. So, they just need to extract the value from the DB and update it in the HTML template.

## Update
In [this commit](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/100/commits/8fcf32187841347972a175b2e4d650642857aa88), the placeholder HTML for awards name and application tags are updated with actual value. While implementing this it has been found out that `caseTags` variable only holds the name of the application tag and not the color. To fix this, `$caseTags` variable processing is updated and datatype has been changed from `String` to `Array` which contains `name` and `color` as key. 
 And to fix its implication, this function which was consuming it's string value (`getPageTitle`) is updated to work with `array` now as this array is processed and `name` key is extracted to retain its original value.
