### PR TITLE
RSE-841: Display tag colours on award review form header

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -386,9 +386,9 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $caseTags = [];
     foreach ($result['values'] as $caseTag) {
       $caseTag = [
-        'id'               => $caseTag['api.Tag.getsingle']['id'],
-        'parent_id'        => $caseTag['api.Tag.getsingle']['parent_id'],
-        'name'             => $caseTag['api.Tag.getsingle']['name'],
+        'id' => $caseTag['api.Tag.getsingle']['id'],
+        'parent_id' => $caseTag['api.Tag.getsingle']['parent_id'],
+        'name' => $caseTag['api.Tag.getsingle']['name'],
         'background_color' => !empty($caseTag['api.Tag.getsingle']['color']) ? $caseTag['api.Tag.getsingle']['color'] : '#ffffff',
       ];
       $caseTag['color'] = $this->getTextColor($caseTag['background_color']);
@@ -401,28 +401,17 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   /**
    * Get Case tags list.
    *
-   * @param string $format
-   *   (Optional) Output format, defaults to plain text.
-   *
    * @return string
-   *   Case tags list.
+   *   HTML code of Case tags as badge list.
    */
-  private function getCaseTags($format = 'plain') {
-    switch ($format) {
-      case 'badge':
-        $res = [];
-        foreach ($this->caseTags as $caseTag) {
-          $res[] = '<span class="crm-tag-item" style="background-color: ' . $caseTag['background_color'] . '; color: ' . $caseTag['color'] . '">' . $caseTag['name'] . '</span>';
-        }
-
-        $res = implode(' ', $res);
-        break;
-
-      default:
-        $res = implode(', ', array_column($this->caseTags, 'name'));
+  private function getCaseTags() {
+    $res = [];
+    foreach ($this->caseTags as $caseTag) {
+      $res[] = '<span class="crm-tag-item" style="background-color: ' . $caseTag['background_color'] . '; color: ' . $caseTag['color'] . '">'
+        . $caseTag['name'] . '</span>';
     }
 
-    return $res;
+    return implode(' ', $res);
   }
 
   /**
@@ -460,7 +449,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   private function getPageTitle() {
     $title = $this->caseContactDisplayName . ' - ' . $this->caseTypeName;
     if ($this->caseTags) {
-      $title = $title . ' &nbsp; ' . $this->getCaseTags('badge');
+      $title = $title . ' &nbsp; ' . $this->getCaseTags();
     }
 
     return $title;

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -461,7 +461,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   private function getPageTitle() {
     $title = $this->caseContactDisplayName . ' - ' . $this->caseTypeName;
     if ($this->caseTags) {
-      $title = $title . ' - ' . $this->getCaseTags();
+      $title = $title . ' &nbsp; ' . $this->getCaseTags('badge');
     }
 
     return $title;

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -408,7 +408,17 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    */
   private function getCaseTags($format = 'plain') {
     switch ($format) {
-      default: $res = implode(', ', array_column($this->caseTags, 'name'));
+      case 'badge':
+        $res = [];
+        foreach ($this->caseTags as $caseTag) {
+          $res[] = '<span class="crm-tag-item" style="background-color: ' . $caseTag['background_color'] . '">' . $caseTag['name'] . '</span>';
+        }
+
+        $res = implode(' ', $res);
+        break;
+
+      default:
+        $res = implode(', ', array_column($this->caseTags, 'name'));
     }
 
     return $res;

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -191,7 +191,6 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
     $this->assign('caseContactDisplayName', $this->getCaseContactDisplayName());
     $this->assign('caseTypeName', $this->caseTypeName);
-    $this->assign('caseTags', $this->getCaseTags());
     $this->assign('isViewAction', $isViewAction);
 
     if ($isViewAction) {

--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -386,12 +386,14 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
     $caseTags = [];
     foreach ($result['values'] as $caseTag) {
-      $caseTags[] = [
+      $caseTag = [
         'id'               => $caseTag['api.Tag.getsingle']['id'],
         'parent_id'        => $caseTag['api.Tag.getsingle']['parent_id'],
         'name'             => $caseTag['api.Tag.getsingle']['name'],
         'background_color' => !empty($caseTag['api.Tag.getsingle']['color']) ? $caseTag['api.Tag.getsingle']['color'] : '#ffffff',
       ];
+      $caseTag['color'] = $this->getTextColor($caseTag['background_color']);
+      $caseTags[] = $caseTag;
     }
 
     return $caseTags;
@@ -411,7 +413,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       case 'badge':
         $res = [];
         foreach ($this->caseTags as $caseTag) {
-          $res[] = '<span class="crm-tag-item" style="background-color: ' . $caseTag['background_color'] . '">' . $caseTag['name'] . '</span>';
+          $res[] = '<span class="crm-tag-item" style="background-color: ' . $caseTag['background_color'] . '; color: ' . $caseTag['color'] . '">' . $caseTag['name'] . '</span>';
         }
 
         $res = implode(' ', $res);
@@ -422,6 +424,32 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     }
 
     return $res;
+  }
+
+  /**
+   * Returns contrasting text color for given background color.
+   *
+   * @param string $bgColor
+   *   Background color in hex format (e.g: #ffffff).
+   *
+   * @return string
+   *   Text color suitable for background color in hex format (e.g: #000000).
+   *   Returns black text color for light background and white text color
+   *   for dark background.
+   */
+  private function getTextColor($bgColor) {
+    // Ensure that the color code will have # in the beginning.
+    if (strpos($bgColor, '#') === FALSE) {
+      $bgColor = '#' . $bgColor;
+    }
+
+    // Calculate background color luminance.
+    list($r, $g, $b) = sscanf($bgColor, "#%02x%02x%02x");
+    $luminance = 1 - (0.299 * $r + 0.587 * $g + 0.114 * $b) / 255;
+    // Calculate text color.
+    $color = $luminance < 0.5 ? '#000000' : '#ffffff';
+
+    return $color;
   }
 
   /**

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -1,4 +1,4 @@
-(function (_, angular, confirm, loadForm, setLoadingStatus, getCrmUrl) {
+(function (_, $, angular, confirm, loadForm, setLoadingStatus, getCrmUrl) {
   var module = angular.module('civiawards');
 
   module.directive('civiawardsReviewsCaseTabContent', function () {
@@ -27,6 +27,7 @@
    */
   function civiawardsReviewsCaseTabContentController ($q, $scope, $sce, crmApi, reviewsActivityTypeName,
     reviewScoringFieldsGroupName, ts) {
+    var CRM_FORM_LOAD_EVENT = 'crmFormLoad';
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
     var REVIEW_FORM_URL = 'civicrm/awardreview';
 
@@ -142,6 +143,7 @@
       });
 
       loadForm(formUrl)
+        .on(CRM_FORM_LOAD_EVENT, popupTitleDecodeEntities)
         .on(CRM_FORM_SUCCESS_EVENT, loadReviewActivities);
     }
 
@@ -157,7 +159,29 @@
         reset: 1
       });
 
-      loadForm(formUrl);
+      loadForm(formUrl)
+        .on(CRM_FORM_LOAD_EVENT, popupTitleDecodeEntities);
+    }
+
+    /**
+     * Converts HTML entities in popup title to their corresponding characters.
+     */
+    function popupTitleDecodeEntities () {
+      $('.ui-dialog-title').each(function () {
+        $(this).html(htmlEntitiesDecode($(this).html()));
+      });
+    }
+
+    /**
+     * Convert HTML entities to their corresponding characters.
+     *
+     * @param {string} string
+     *   The input string.
+     * @returns {string}
+     *   Returns the decoded string.
+     */
+    function htmlEntitiesDecode (string) {
+      return string.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;nbsp;/g, '&nbsp;');
     }
 
     /**
@@ -204,4 +228,4 @@
       });
     }
   }
-})(CRM._, angular, CRM.confirm, CRM.loadForm, CRM.status, CRM.url);
+})(CRM._, CRM.$, angular, CRM.confirm, CRM.loadForm, CRM.status, CRM.url);

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -165,9 +165,16 @@
 
     /**
      * Converts HTML entities in popup title to their corresponding characters.
+     *
+     * @param {object} event
+     *   Event object.
+     * @param {object} data
+     *   Loaded form data.
      */
-    function popupTitleDecodeEntities () {
-      $('.ui-dialog-title').each(function () {
+    function popupTitleDecodeEntities (event, data) {
+      var $popup = $(event.target).closest('.ui-dialog');
+
+      $popup.find('.ui-dialog-title').each(function () {
         $(this).html(htmlEntitiesDecode($(this).html()));
       });
     }

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -269,7 +269,7 @@
             mockedFormElement.trigger(CRM_FORM_LOAD_EVENT);
           });
 
-          it('case tags in popup title are html objects', () => {
+          it('displays the tags with background and text color', () => {
             expect(mockedFormElement.find('.crm-tag-item').length).toBe(1);
           });
         });

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -239,6 +239,43 @@
       });
     });
 
+    describe('check popup title processing when viewing a review', () => {
+      let mockedFormElement, selectedReview;
+      const CRM_FORM_LOAD_EVENT = 'crmFormLoad';
+
+      beforeEach(() => {
+        mockedFormElement = $('<div class="ui-dialog">\n' +
+          '  <div class="ui-dialog-titlebar">\n' +
+          '    <span class="ui-dialog-title">View Review - Demo - Award &amp;nbsp; &lt;span class="crm-tag-item" style="background-color: #652881; color: #ffffff"&gt;Tag&lt;/span&gt;</span>\n' +
+          '  </div>\n' +
+          '  <div class="ui-dialog-content">\n' +
+          '  </div>\n' +
+          '</div>');
+        selectedReview = _.chain(ReviewActivitiesMockData)
+          .first()
+          .cloneDeep()
+          .value();
+
+        CRM.loadForm.and.returnValue(mockedFormElement);
+      });
+
+      describe('when clicking the View review menu link', () => {
+        beforeEach(() => {
+          $scope.handleViewReviewActivity(selectedReview);
+        });
+
+        describe('after the form has been loaded', () => {
+          beforeEach(() => {
+            mockedFormElement.trigger(CRM_FORM_LOAD_EVENT);
+          });
+
+          it('case tags in popup title are html objects', () => {
+            expect(mockedFormElement.find('.crm-tag-item').length).toBe(1);
+          });
+        });
+      });
+    });
+
     /**
      * @returns {object} the mocked response for the Activity.Get api action.
      */


### PR DESCRIPTION
## Overview
There is **Award review** form which displays case tags in the title, but they are being displayed as normal text. This PR makes them displayed like colored badges.
*View review* and *Edit review* form popups are affected.

## Before
![image](https://user-images.githubusercontent.com/39520000/84415408-64980400-ac1b-11ea-9840-d901c159e687.png)

## After
![image](https://user-images.githubusercontent.com/39520000/84415299-3dd9cd80-ac1b-11ea-90ac-0b671d5ef3f7.png)

## Technical Details
### Back-end
The `CRM_CiviAwards_Form_AwardReview` class was updated to return colored tags:
1. As now we need to store some more data for case tags (not only name) we renamed `getCaseTags()` to `loadCaseTags()`.
2. The `getCaseTags()` method now returns list of tags in desired format: `plain` (plain text - as it previously was) or `badge` (html - colored badges).
3. As case tag data contain background color, but does not contain text color the `getTextColor()` method was added to return suitable text color for given background color.

### Front-end
By default html in popup title looks like plain text:
![image](https://user-images.githubusercontent.com/39520000/84414226-5dbcc180-ac1a-11ea-9871-b53ed83b810b.png)

So to workaround this (to make it possible to display colored tags in the title) we updated the `reviews-case-tab-content.directive.js`:
1. The `popupTitleDecodeEntities()` with helper `htmlEntitiesDecode()` function are added.
2. When popup is loaded (`loadForm().on('crmFormLoad')` event is used) the `popupTitleDecodeEntities()` is called now to decode html and display colored tags. See `handleViewReviewActivity()` and `handleEditReviewActivity()`.