### PR TITLE
RSE-1141: Hide 'Statuses' field In Review Panel popup when related checkbox is unticked

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
@@ -132,7 +132,7 @@
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" ng-show="model.currentReviewPanel.visibilitySettings.isApplicationStatusRestricted">
           <label class="col-sm-6 control-label">
             Statuses
           </label>


### PR DESCRIPTION
## Overview
On *Configure Award* page (like `/civicrm/award/a/#/awards/5`) we can create / edit a *Review Panel* - this form is opened in a popup. And there is a **Statuses** field which is always visible regardless of whether related **Panel can change the status of an application?** checkbox is ticked or not.

Actually this checkbox works - it enables / disables the field, but UI doesn’t indicate any difference when the checkbox is ticked and not ticked. It gives an impression to the user that they can select statuses even if the checkbox is not ticked, when in reality they aren’t allowed to do so.

In this PR we are changing the behavior: now select field would be shown / hidden depending on the checkbox.

## Before
![Peek 2020-06-12 18-24](https://user-images.githubusercontent.com/39520000/84520287-fc5d2700-acdb-11ea-9ecd-c570187afb22.gif)

## After
![Peek 2020-06-12 18-34](https://user-images.githubusercontent.com/39520000/84520277-f9623680-acdb-11ea-9e65-82519de86b6b.gif)

## Technical Details
Just added `ng-show` to the field wrapper.