### PR TITLE
RSE-1116: Fix success message text for award submissions

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -152,8 +152,8 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    */
   private function getErrorMessage($fields) {
     if (empty($fields)) {
-      return 'There are no review fields assigned to this award type. 
-        Please add Review Fields by editing the the Award Type located under the 
+      return 'There are no review fields assigned to this award type.
+        Please add Review Fields by editing the the Award Type located under the
         Overview dropdown in Award Dashboard.';
     }
 
@@ -201,8 +201,8 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
     try {
       civicrm_api3('Profile', 'submit', $profileFields);
-      $status = $this->_action == CRM_Core_Action::ADD ? 'Added' : 'Updated';
-      CRM_Core_Session::setStatus(ts("The review has been {$status} successfully"), 'Success', 'success');
+      $status = $this->_action == CRM_Core_Action::ADD ? 'Submitted' : 'Updated';
+      CRM_Core_Session::setStatus(ts('The review has been ' . strtolower($status) . ' successfully.'), ts('Review ' . $status), 'success');
     }
     catch (Exception $e) {
       CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');


### PR DESCRIPTION
## Overview
As a part of this PR success and updated  success text value is changed to match designs.
https://projects.invisionapp.com/d/main?origin=v7#/console/19802243/418400657/inspect?scrollOffset=788

## Before
<img width="514" alt="Screenshot 2020-06-16 at 2 57 47 PM" src="https://user-images.githubusercontent.com/3340537/84757774-2cf5d700-afe2-11ea-93e3-95552247bb0e.png">


## After
<img width="516" alt="Screenshot 2020-06-16 at 2 57 22 PM" src="https://user-images.githubusercontent.com/3340537/84757782-3121f480-afe2-11ea-82fc-4734be2ef782.png">


## Technical Details
The response text has been updated and same text has been consumed by JS at SSP end to show it in the popup. See [FE PR](https://github.com/compucorp/ssp_bootstrap/pull/11).