### PR TITLE
RSE-1139: Add AwardReveiewPanel.getReviewAcess API

### DIFF
--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -100,6 +100,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     $allCaseTagAccess = !empty($visibilitySettings['tags']['all']['status_to_move_to']) ?
       $visibilitySettings['tags']['all']['status_to_move_to'] : [];
     $caseTagAccess = [];
+    $caseTagAnonymization = TRUE;
 
     foreach ($caseTags as $tag) {
       $statusToMoveTo = !empty($visibilitySettings['tags'][$tag]['status_to_move_to']) ? $visibilitySettings['tags'][$tag]['status_to_move_to'] : [];
@@ -109,8 +110,8 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     $statusToMoveApplicationTo = array_merge($caseStatusAccess, $allCaseStatusAccess, $caseTagAccess);
     if (!empty($caseTags)) {
       $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $allCaseTagAccess);
+      $caseTagAnonymization = $this->getCaseTagsAnonymization($visibilitySettings, $caseTags);
     }
-    $caseTagAnonymization = $this->getCaseTagsAnonymization($visibilitySettings, $caseTags);
     $caseStatusAnonymization = $this->getCaseStatusAnonymization($visibilitySettings, [$caseStatus]);
     $statusToMoveApplicationTo = array_unique($statusToMoveApplicationTo);
     sort($statusToMoveApplicationTo);

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -22,6 +22,33 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   The contact access to the Award applications.
    */
   public function get($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
+    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
+    $tags = array_keys($visibilitySettings['tags']);
+    $tags = in_array('all', $tags) ? [] : $tags;
+    $status = array_keys($visibilitySettings['status']);
+    $status = in_array('all', $status) ? [] : $status;
+    sort($status);
+    sort($tags);
+    return [
+      'application_tags' => $tags,
+      'application_status' => $status,
+    ];
+  }
+
+  /**
+   * Returns the visibility settings the contact has for the Award.
+   *
+   * @param int $contactId
+   *   Contact Id.
+   * @param int $awardId
+   *   Award Id.
+   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
+   *   Award Panel contact service.
+   *
+   * @return array
+   *   Visibility settings.
+   */
+  private function getContactVisibilitySettings($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
     $awardPanels = $this->getAwardPanels($awardId);
 
     if (empty($awardPanels)) {
@@ -39,11 +66,162 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
       throw new Exception("This contact does not have any access to the panels on this Award");
     }
 
-    return $this->processVisibilitySettings($visibilitySettings);
+    return $visibilitySettings;
   }
 
   /**
-   * Processes the contact visibility results.
+   * Returns the review access a contact has to the Award Application.
+   *
+   * Basically returns the statuses that a contact can move an application
+   * to and if the data for the application should be anonymized or not.
+   *
+   * @param int $contactId
+   *   Contact Id.
+   * @param int $applicationId
+   *   Award Id.
+   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
+   *   Award Panel contact service.
+   *
+   * @return array
+   *   Review access array.
+   */
+  public function getReviewAccess($contactId, $applicationId, AwardReviewPanelContact $awardPanelContact) {
+    $applicationDetails = $this->getApplicationDetails($applicationId);
+    $awardId = $applicationDetails['case_type_id'];
+    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
+
+    $caseTags = !empty($applicationDetails['tag_id']) ? array_keys($applicationDetails['tag_id']) : [];
+    $caseStatus = $applicationDetails['status_id'];
+
+    $caseStatusAccess = !empty($visibilitySettings['status'][$caseStatus]['status_to_move_to']) ?
+      $visibilitySettings['status'][$caseStatus]['status_to_move_to'] : [];
+    $allCaseStatusAccess = !empty($visibilitySettings['status']['all']['status_to_move_to']) ?
+      $visibilitySettings['status']['all']['status_to_move_to'] : [];
+    $allCaseTagAccess = !empty($visibilitySettings['tags']['all']['status_to_move_to']) ?
+      $visibilitySettings['tags']['all']['status_to_move_to'] : [];
+    $caseTagAccess = [];
+
+    foreach ($caseTags as $tag) {
+      $statusToMoveTo = !empty($visibilitySettings['tags'][$tag]['status_to_move_to']) ? $visibilitySettings['tags'][$tag]['status_to_move_to'] : [];
+      $caseTagAccess = array_merge($caseTagAccess, $statusToMoveTo);
+    }
+
+    $statusToMoveApplicationTo = array_merge($caseStatusAccess, $allCaseStatusAccess, $caseTagAccess);
+    if (!empty($caseTags)) {
+      $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $allCaseTagAccess);
+    }
+    $caseTagAnonymization = $this->getCaseTagsAnonymization($visibilitySettings, $caseTags);
+    $caseStatusAnonymization = $this->getCaseStatusAnonymization($visibilitySettings, [$caseStatus]);
+    $statusToMoveApplicationTo = array_unique($statusToMoveApplicationTo);
+    sort($statusToMoveApplicationTo);
+
+    return [
+      'anonymize_application' => $caseTagAnonymization && $caseStatusAnonymization ? TRUE : FALSE,
+      'status_to_move_to' => $statusToMoveApplicationTo,
+    ];
+  }
+
+  /**
+   * Gets anonymization value for case status or case tags data.
+   *
+   * @param array $visibilitySettings
+   *   Visibility settings.
+   * @param array $data
+   *   Data array to get anonymization data for.
+   * @param string $key
+   *   Visibility key: tags or status.
+   *
+   * @return bool
+   *   Anonymization value.
+   */
+  private function getAnonymizationForReview(array $visibilitySettings, array $data, $key) {
+    $anonymizeApplication = TRUE;
+    foreach ($data as $value) {
+      if ($anonymizeApplication === TRUE) {
+        $anonymizeApplication = $this->getReviewAnonymizationValue($visibilitySettings, $value, $key);
+      }
+    }
+    $allDataAnonymization = $this->getReviewAnonymizationValue($visibilitySettings, 'all', $key);
+
+    return $anonymizeApplication && $allDataAnonymization ? TRUE : FALSE;
+  }
+
+  /**
+   * Gets anonymization value for case tags data.
+   *
+   * @param array $visibilitySettings
+   *   Visibility settings.
+   * @param array $caseTags
+   *   Data array to get anonymization data for.
+   *
+   * @return bool
+   *   Anonymization value.
+   */
+  private function getCaseTagsAnonymization(array $visibilitySettings, array $caseTags) {
+    return $this->getAnonymizationForReview($visibilitySettings, $caseTags, 'tags');
+  }
+
+  /**
+   * Gets anonymization value for case status data.
+   *
+   * @param array $visibilitySettings
+   *   Visibility settings.
+   * @param array $caseStatus
+   *   Data array to get anonymization data for.
+   *
+   * @return bool
+   *   Anonymization value.
+   */
+  private function getCaseStatusAnonymization(array $visibilitySettings, array $caseStatus) {
+    return $this->getAnonymizationForReview($visibilitySettings, $caseStatus, 'status');
+  }
+
+  /**
+   * Gets review anonymization value.
+   *
+   * @param array $visibilitySettings
+   *   Visibility settings.
+   * @param mixed $value
+   *   Case status or tag value.
+   * @param string $key
+   *   Visibility key: tags or status.
+   *
+   * @return bool|mixed
+   *   Anonymization value.
+   */
+  private function getReviewAnonymizationValue(array $visibilitySettings, $value, $key) {
+    if (isset($visibilitySettings[$key][$value]['anonymize_application'])) {
+      return $visibilitySettings[$key][$value]['anonymize_application'];
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Returns the Award ID given an application ID.
+   *
+   * @param int $applicationId
+   *   Application ID.
+   *
+   * @return mixed|null
+   *   Award ID.
+   */
+  private function getApplicationDetails($applicationId) {
+    try {
+      $result = civicrm_api3('Case', 'getsingle', [
+        'return' => ['tag_id', 'case_type_id', 'status_id'],
+        'id' => $applicationId,
+      ]);
+
+      return $result;
+    }
+    catch (Exception $e) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Processes the contact visibility settings results.
    *
    * @param array $visibilitySettings
    *   Visibility settings.
@@ -52,46 +230,101 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   The contact access to the Award applications.
    */
   private function processVisibilitySettings(array $visibilitySettings) {
-    $applicationTags = [];
-    $applicationStatus = [];
-    $statusToMoveTo = [];
-    $anonymizeApplication = TRUE;
-    $hasAllTagsAccess = FALSE;
-    $hasAllStatusAccess = FALSE;
-
+    $tags = [];
+    $status = [];
     foreach ($visibilitySettings as $visibilitySetting) {
-      if (isset($visibilitySetting['application_tags'])) {
-        $applicationTags = array_merge($applicationTags, $visibilitySetting['application_tags']);
-        if (empty($visibilitySetting['application_tags'])) {
-          $hasAllTagsAccess = TRUE;
-        }
+      if (isset($visibilitySetting['application_tags']) && empty($visibilitySetting['application_tags'])) {
+        $tagKey = 'all';
+        $this->setVisibilityData($tags, $tagKey, $visibilitySetting);
       }
-      if (isset($visibilitySetting['application_status'])) {
-        $applicationStatus = array_merge($applicationStatus, $visibilitySetting['application_status']);
-        if (empty($visibilitySetting['application_status'])) {
-          $hasAllStatusAccess = TRUE;
+      elseif (!empty($visibilitySetting['application_tags'])) {
+        foreach ($visibilitySetting['application_tags'] as $tagKey) {
+          $this->setVisibilityData($tags, $tagKey, $visibilitySetting);
         }
       }
 
-      if (isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0) {
-        $anonymizeApplication = FALSE;
+      if (isset($visibilitySetting['application_status']) && empty($visibilitySetting['application_status'])) {
+        $statusKey = 'all';
+        $this->setVisibilityData($status, $statusKey, $visibilitySetting);
       }
-
-      if (!empty($visibilitySetting['is_application_status_restricted'])) {
-        $statusToMoveTo = array_merge($statusToMoveTo, $visibilitySetting['restricted_application_status']);
+      elseif (!empty($visibilitySetting['application_status'])) {
+        foreach ($visibilitySetting['application_status'] as $statusKey) {
+          $this->setVisibilityData($status, $statusKey, $visibilitySetting);
+        }
       }
     }
-    $applicationTags = array_unique($applicationTags);
-    $applicationStatus = array_unique($applicationStatus);
-    sort($applicationStatus);
-    sort($applicationTags);
 
     return [
-      'application_tags' => $hasAllTagsAccess ? [] : $applicationTags,
-      'application_status' => $hasAllStatusAccess ? [] : $applicationStatus,
-      'anonymize_application' => $anonymizeApplication,
-      'status_to_move_to' => $statusToMoveTo,
+      'tags' => $tags,
+      'status' => $status,
     ];
+  }
+
+  /**
+   * Sets visibility data for status or tag.
+   *
+   * @param array $data
+   *   Data array to set visivility data to.
+   * @param mixed $key
+   *   Array key.
+   * @param array $visibilitySetting
+   *   Visibility setting for award panel.
+   */
+  private function setVisibilityData(array &$data, $key, array $visibilitySetting) {
+    $this->initializeArray($data, $key);
+    $data[$key]['status_to_move_to'] = $this->getRestrictedStatus($data[$key]['status_to_move_to'], $visibilitySetting);
+    $data[$key]['anonymize_application'] = $data[$key]['anonymize_application'] === FALSE ? FALSE : $this->getAnonymization($visibilitySetting);
+  }
+
+  /**
+   * Create an entry for the key in the array if not present.
+   *
+   * @param array $data
+   *   Array to initialize data in.
+   * @param mixed $key
+   *   Key to initialize data for.
+   */
+  private function initializeArray(array &$data, $key) {
+    if (!isset($data[$key]['status_to_move_to'])) {
+      $data[$key]['status_to_move_to'] = [];
+    }
+
+    if (!isset($data[$key]['anonymize_application'])) {
+      $data[$key]['anonymize_application'] = TRUE;
+    }
+  }
+
+  /**
+   * Gets anonymization from visibility setting.
+   *
+   * @param array $visibilitySetting
+   *   Visibility setting for award panel.
+   *
+   * @return bool
+   *   Return anonymization.
+   */
+  private function getAnonymization(array $visibilitySetting) {
+    if (isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Returns restricted status data.
+   *
+   * @param mixed $oldValue
+   *   Old value.
+   * @param array $visibilitySetting
+   *   Visibility setting for award panel.
+   *
+   * @return array
+   *   New value for restricted status.
+   */
+  private function getRestrictedStatus($oldValue, array $visibilitySetting) {
+    return array_merge($oldValue, !empty($visibilitySetting['is_application_status_restricted']) ?
+      $visibilitySetting['restricted_application_status'] : []);
   }
 
   /**

--- a/CRM/CiviAwards/Test/Fabricator/Case.php
+++ b/CRM/CiviAwards/Test/Fabricator/Case.php
@@ -1,0 +1,83 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Class CRM_CiviAwards_Test_Fabricator_Case.
+ */
+class CRM_CiviAwards_Test_Fabricator_Case {
+
+  /**
+   * Fabricate Case.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return mixed
+   *   Api result.
+   */
+  public static function fabricate(array $params = []) {
+    $params = self::mergeDefaultParams($params);
+    $result = civicrm_api3('Case', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+  /**
+   * Merges default parmeters.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   Api result.
+   */
+  private static function mergeDefaultParams(array $params) {
+    $contact = ContactFabricator::fabricate();
+    $name = uniqid();
+    $defaultParams = [
+      'subject' => $name,
+      'contact_id' => $contact['id'],
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+
+  /**
+   * Fabricate case with tags.
+   *
+   * @param array $tags
+   *   Case Tags.
+   * @param array $caseParams
+   *   Case Parameters.
+   *
+   * @return array
+   *   Results.
+   */
+  public static function fabricateWithTags(array $tags, array $caseParams) {
+    $case = self::fabricate($caseParams);
+    $tagsData = [];
+
+    foreach ($tags as $tag) {
+      $tagEntity = civicrm_api3('Tag', 'create', [
+        'name' => $tag,
+      ]);
+      $tagsData[] = $tagEntity;
+
+      // We need to flush this so that an exception will not be thrown that
+      // Tag ID value is not a valid option.
+      CRM_Core_PseudoConstant::flush();
+      civicrm_api3('EntityTag', 'create', [
+        'tag_id' => $tagEntity['id'],
+        'entity_table' => 'civicrm_case',
+        'entity_id' => $case['id'],
+      ]);
+    }
+
+    return [
+      'case' => $case,
+      'tags' => $tagsData,
+    ];
+  }
+
+}

--- a/CRM/CiviAwards/Test/Fabricator/CaseType.php
+++ b/CRM/CiviAwards/Test/Fabricator/CaseType.php
@@ -1,22 +1,61 @@
 <?php
 
+/**
+ * Class CRM_CiviAwards_Test_Fabricator_CaseType.
+ */
 class CRM_CiviAwards_Test_Fabricator_CaseType {
 
-  public static function fabricate($params = []) {
+  /**
+   * Fabricates a Case Type.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return mixed
+   *   API result.
+   */
+  public static function fabricate(array $params = []) {
     $params = self::mergeDefaultParams($params);
     $result = civicrm_api3('CaseType', 'create', $params);
 
     return array_shift($result['values']);
   }
 
-  private static function mergeDefaultParams($params) {
+  /**
+   * Merges default parameters.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   API result.
+   */
+  private static function mergeDefaultParams(array $params) {
     $name = uniqid();
     $defaultParams = [
       'name' => $name,
       'title' => $name,
       'is_active' => 1,
+      'definition' => ['activitySets' => self::getActivitySets()],
     ];
 
     return array_merge($defaultParams, $params);
   }
+
+  /**
+   * Get Activity sets.
+   *
+   * @return array
+   *   Results.
+   */
+  private static function getActivitySets() {
+    return [
+      [
+        'timeline' => TRUE,
+        'name' => 'standard_timeline',
+        'label' => 'Standard Timeline',
+      ],
+    ];
+  }
+
 }

--- a/api/v3/AwardReviewPanel.php
+++ b/api/v3/AwardReviewPanel.php
@@ -49,6 +49,49 @@ function civicrm_api3_award_review_panel_getcontactaccess(array $params) {
 }
 
 /**
+ * AwardReviewPanel.getReviewAccess API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_award_review_panel_getreviewaccess_spec(array &$spec) {
+  $spec['contact_id'] = [
+    'title' => 'Contact ID',
+    'description' => 'Award Panel Contact ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName' => 'CRM_Contact_DAO_Contact',
+    'FKApiName' => 'Contact',
+  ];
+
+  $spec['application_id'] = [
+    'title' => 'Application ID',
+    'description' => 'Application ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+    'FKClassName' => 'CRM_Case_BAO_Case',
+    'FKApiName' => 'Case',
+  ];
+}
+
+/**
+ * AwardReviewPanel.getReviewAccess API.
+ *
+ * @param array $params
+ *   Parameters.
+ *
+ * @return array
+ *   API result descriptor.
+ */
+function civicrm_api3_award_review_panel_getreviewaccess(array $params) {
+  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
+  $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
+  $contactAccess = $contactAccessService->getReviewAccess($params['contact_id'], $params['application_id'], $awardPanelContact);
+
+  return civicrm_api3_create_success($contactAccess);
+}
+
+/**
  * AwardReviewPanel.create API.
  *
  * @param array $params

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_CiviAwards_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_CiviAwards_Test_Fabricator_Case as CaseFabricator;
 use CRM_CiviAwards_Service_AwardApplicationContactAccess as ApplicationContactAccess;
 use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
 use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
@@ -196,6 +197,360 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
+  }
+
+  /**
+   * Test Get Review Access When Case Has No Tags.
+   */
+  public function testGetReviewAccessForContactAndCaseHasNoTags() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3, 4],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [6, 7],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus, 2],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2, 5],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Panel 1 and Panel 3 meets the case status criteria.
+    // So Contact will view combined status to move to for both panels
+    // Since anonymization is not restricted in Panel 3, Contact will be able
+    // to view unanonymized data.
+    $expectedResult = [
+      'status_to_move_to' => [1, 2, 5],
+      'anonymize_application' => FALSE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+  }
+
+  /**
+   * Test Get Review Access When Case Has Tags.
+   */
+  public function testGetReviewAccessForContactAndCaseHasTags() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $caseData = CaseFabricator::fabricateWithTags(
+      ['Tag 1', 'Tag 2'],
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
+
+    $tag1Id = $caseData['tags']['0']['id'];
+    $tag2Id = $caseData['tags']['1']['id'];
+
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'application_tags' => [$tag1Id],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3, 4],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [6, 7],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3, 4],
+          'application_tags' => [$tag1Id, $tag2Id],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [8, 9],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus, 2],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2, 5],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Panel 1, Panel 3, Panel 4 meets the case status and case tags criteria.
+    // So Contact will view combined status to move to for the panels
+    // Since anonymization is not restricted in Panel 3 & 4, Contact will
+    // be abl to view unanonymized data.
+    $expectedResult = [
+      'status_to_move_to' => [1, 2, 5, 8, 9],
+      'anonymize_application' => FALSE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+  }
+
+  /**
+   * Tes When Case Has No Tags And Contact Cannot View Anonymised.
+   */
+  public function testGetReviewAccessForContactAndCaseHasNoTagsAndContactCanNotViewAnonymisedData() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus, 2],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2, 5],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Panel 1 and Panel 2 meets the case status criteria.
+    // So Contact will view combined status to move to for both panels
+    // Since anonymization is restricted in all panels, Contact will not be able
+    // to view unanonymized data.
+    $expectedResult = [
+      'status_to_move_to' => [1, 2, 5],
+      'anonymize_application' => TRUE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+  }
+
+  /**
+   * Test When Case Has No Tags And Contact Can View Anonymised.
+   */
+  public function testGetReviewAccessForContactAndCaseHasTagsAndContactCanNotViewAnonymisedData() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $caseData = CaseFabricator::fabricateWithTags(
+      ['Tag 1', 'Tag 2'],
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
+
+    $tag1Id = $caseData['tags']['0']['id'];
+    $tag2Id = $caseData['tags']['1']['id'];
+
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'application_tags' => [$tag1Id],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3, 4],
+          'application_tags' => [$tag1Id, $tag2Id],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [8, 9],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Panel 1, Panel 2, meets the case status and case tags criteria.
+    // So Contact will view combined status to move to for the panels
+    // Since anonymization is restricted in all panels, Contact will not be able
+    // to view unanonymized data.
+    $expectedResult = [
+      'status_to_move_to' => [1, 8, 9],
+      'anonymize_application' => TRUE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+  }
+
+  /**
+   * Test Get Review Access When Panel Has All Tags And Status Enabled.
+   */
+  public function testGetReviewAccessForContactWhenContactBelongsToPanelWhereAllTagsAndStatusIsAllowed() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [],
+          'application_tags' => [],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1, 3, 6],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3, 4],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [6, 7],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2, 5],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Panel 1 and Panel 3 meets the case status criteria.
+    // So Contact will view combined status to move to for both panels
+    // Since anonymization is not restricted in Panel 3, Contact will be able
+    // to view unanonymized data.
+    $expectedResult = [
+      'status_to_move_to' => [1, 2, 3, 5, 6],
+      'anonymize_application' => FALSE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+  }
+
+  /**
+   * Test ALL Tags Access Is Not Applied When Case Has No Tags.
+   */
+  public function testAllTagsAccessForPanelIsNotAppliedWhenCaseHasNoTags() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3],
+          'application_tags' => [],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [1, 3, 6],
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 1,
+          'restricted_application_status' => [2, 5],
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Only Panel 2 meets the case status criteria.
+    // Case has not tags therefore, panel 1 does not meet the criteria.
+    $expectedResult = [
+      'status_to_move_to' => [2, 5],
+      'anonymize_application' => FALSE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
   }
 
   /**

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -104,8 +104,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $expectedResult = [
       'application_tags' => [1, 2, 6, 8],
       'application_status' => [3, 5, 6, 9],
-      'anonymize_application' => FALSE,
-      'status_to_move_to' => [],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
@@ -144,8 +142,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $expectedResult = [
       'application_tags' => [],
       'application_status' => [],
-      'anonymize_application' => TRUE,
-      'status_to_move_to' => [],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
@@ -197,8 +193,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $expectedResult = [
       'application_tags' => [],
       'application_status' => [],
-      'anonymize_application' => FALSE,
-      'status_to_move_to' => [2],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -554,6 +554,52 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   }
 
   /**
+   * Test Anonymization logic for all tags when case has no tags.
+   */
+  public function testAnonymisationLogicWhenCaseHasNoTagsAndAllTagsInAccessInPanelAllowsApplicationToBeNonAnonymised() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $caseStatus = 1;
+    $applicationContactAccess = new ApplicationContactAccess();
+    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $contactId = 1;
+
+    $params = [
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [3],
+          'application_tags' => [],
+          'anonymize_application' => 0,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
+      [
+        'case_type_id' => $caseType['id'],
+        'visibility_settings' => [
+          'application_status' => [$caseStatus],
+          'anonymize_application' => 1,
+          'is_application_status_restricted' => 0,
+        ],
+      ],
+    ];
+
+    $awardPanel = [];
+    foreach ($params as $param) {
+      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
+    }
+
+    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+
+    // Application should be anonymised.
+    $expectedResult = [
+      'status_to_move_to' => [],
+      'anonymize_application' => TRUE,
+    ];
+
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+  }
+
+  /**
    * Returns Award Panel Object for Contact.
    *
    * @param object $awardPanel


### PR DESCRIPTION
## Overview
The AwardReveiewPanel.getContactAccess API currently returns the application case tags and statuses that a contact has access to based on the panels the contact belongs to for the Award. This API also returns the statuses that the contact is able to move the applications to and if the data should be anonymised or not.

However it is not enough to determine the statuses that the contact is able to move the applications to from this `AwardReveiewPanel.getContactAccess` API because these can change based on the particular application under consideration.

Therefore this PR introduces a new `AwardReveiewPanel.getReviewAcess` API which accepts the Application ID as one of its parameters and will return the statuses that the contact can move this application to and if the application should be anonymised or not. The aggregated status to move to and anonymised permission is gotten from compounding the access the contact has based on the panels the contacts belongs to that meets the application criteria.

## Before
- The AwardReveiewPanel.getReviewAcess does not exist.

## After
- AwardReveiewPanel.getReviewAcess is created.

```
Sample Call and Response

$result = civicrm_api3('AwardReviewPanel', 'getreviewaccess', 
[  'contact_id' => 7,  'application_id' => 6,]);


{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": {
        "anonymize_application": false,
        "status_to_move_to": [
            "1",
            "3"
        ]
    }
}
```

The `anonymize_application` and `status_to_move_to` was removed from the response values for the `AwardReveiewPanel.getContactAccess`

```php
Sample Call and Response

$result = civicrm_api3('AwardReviewPanel', 'getcontactaccess', [
  'contact_id' => 7,
  'award_id' => 4,
]);

{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": {
        "application_tags": [],
        "application_status": [
            1,
            3
        ]
    }
}
```

In summary the `AwardReveiewPanel.getContactAccess` returns the tags and statuses of the applications that the contact can view while the `AwardReveiewPanel.getReviewAcess` returns the statuses that the contact can move a particular application to and if the application should be anonymised or not.

## Comments
Fixed an issue with anonymization permissions for Cases with tags being ran even when the Case has no tags. Fixed this issue and added a test for the bug.
