### PR TITLE
RSE-1172: Award Review Form Changes for SSP

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -13,7 +13,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
   /**
    * URL for accessing review form from SSP.
    */
-  const SSP_REVIEW_URL = 'civicrm/award-review-ssp';
+  const SSP_REVIEW_URL = 'civicrm/ssp/awardreview';
 
   /**
    * URL for accessing review form from civicrm.

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -90,13 +90,13 @@
       {* End if error message *}
 
       {* Form fields section Starts *}
-      {foreach from=$elementNames item=elementName}
+      {foreach from=$elementData item=element}
         <div class="form-group {$form_group_class}">
-          <label class="{$form_group_label_class}">{$form.$elementName.label}</label>
+          <label class="{$form_group_label_class}">{$form[$element.name].label}</label>
           {if $isReviewFromSsp}
-            <div class="ssp-form-control-description text-muted"> Lorem ipsum dolor sit. Sit dolor ipsum lorem porem. </div>
+            <div class="ssp-form-control-description text-muted"> {$element.help_post} </div>
           {/if}
-          <div class="{$form_group_field_class}">{$form.$elementName.html}</div>
+          <div class="{$form_group_field_class}">{$form[$element.name].html}</div>
           <div class="clear"></div>
         </div>
       {/foreach}

--- a/xml/Menu/civiawards.xml
+++ b/xml/Menu/civiawards.xml
@@ -7,10 +7,10 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
-    <path>civicrm/award-review-ssp</path>
+    <path>civicrm/ssp/awardreview</path>
     <page_callback>CRM_CiviAwards_Form_AwardReview</page_callback>
     <title>Award Review</title>
-    <access_arguments>access applicant portal</access_arguments>
+    <access_arguments>access awards panel portal</access_arguments>
     <is_public>true</is_public>
   </item>
   <item>


### PR DESCRIPTION
## Overview
This PR makes some changes to the Award review form for SSP.
The following changes are made:

- Changed the award review form url to use `civicrm/ssp/awardreview`
- Changed permission used by above URL to `CiviAwards: Access awards panel portal`
- Check that logged in contact belongs to a panel on the Award before being able to add a review.
- Fetch form prefix fields to be displayed on the award form fields.

## Before
- These changes were not yet done.

## After
- These changes were implemented.

When User tries to add a review for an award he is not panel member of.
<img width="1051" alt="Warning  CaseLatest 2020-06-22 12-01-29" src="https://user-images.githubusercontent.com/6951813/85280514-2d79ec00-b480-11ea-8ee8-33ae63784b5f.png">
