### PR TITLE
RSE-1201: Remove "Edit review" functionality

### DIFF
--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
@@ -67,9 +67,6 @@
                   <a ng-click="handleViewReviewActivity(reviewActivity)">
                     {{ ts('View') }}
                   </a>
-                  <a ng-click="handleEditReviewActivity(reviewActivity)">
-                    {{ ts('Edit') }}
-                  </a>
                   <a ng-click="handleDeleteReviewActivity(reviewActivity)">
                     {{ ts('Delete') }}
                   </a>

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -36,7 +36,6 @@
 
     $scope.handleAddReviewActivity = handleAddReviewActivity;
     $scope.handleViewReviewActivity = handleViewReviewActivity;
-    $scope.handleEditReviewActivity = handleEditReviewActivity;
     $scope.handleDeleteReviewActivity = handleDeleteReviewActivity;
     $scope.trustAsHtml = $sce.trustAsHtml;
 
@@ -126,24 +125,6 @@
       });
 
       loadForm(formUrl)
-        .on(CRM_FORM_SUCCESS_EVENT, loadReviewActivities);
-    }
-
-    /**
-     * Opens a form to edit the given review. It refreshes the list of reviews after
-     * successfully saving the form.
-     *
-     * @param {object} reviewActivity the review to edit.
-     */
-    function handleEditReviewActivity (reviewActivity) {
-      var formUrl = getCrmUrl(REVIEW_FORM_URL, {
-        action: 'update',
-        id: reviewActivity.id,
-        reset: 1
-      });
-
-      loadForm(formUrl)
-        .on(CRM_FORM_LOAD_EVENT, popupTitleDecodeEntities)
         .on(CRM_FORM_SUCCESS_EVENT, loadReviewActivities);
     }
 

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -171,32 +171,6 @@
         });
       });
 
-      describe('when editing a review', () => {
-        beforeEach(() => {
-          expectedUrl = getCrmUrl(REVIEW_FORM_URL, {
-            action: 'update',
-            id: selectedReview.id,
-            reset: 1
-          });
-
-          $scope.handleEditReviewActivity(selectedReview);
-        });
-
-        it('calls the form to edit the selected review', () => {
-          expect(CRM.loadForm).toHaveBeenCalledWith(expectedUrl);
-        });
-
-        describe('when saving the form', () => {
-          beforeEach(() => {
-            mockedFormElement.trigger(CRM_FORM_SUCCESS_EVENT);
-          });
-
-          it('reloads the reviews', () => {
-            expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
-          });
-        });
-      });
-
       describe('when deleting a review', () => {
         beforeEach(() => {
           $scope.handleDeleteReviewActivity(selectedReview);


### PR DESCRIPTION
## Overview
As part of the PR, the Edit Review Activity feature has been removed from the Review tab of Case Details, as once a review is submitted, it cannot be edited.

## Before


## After

## Technical Details
