### PR TITLE
RSE-1197: Add Applicant Management Instance Menu Class and Option Value

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -6,6 +6,7 @@
 class CRM_CiviAwards_Helper_CaseTypeCategory {
 
   const AWARDS_CASE_TYPE_CATEGORY_NAME = 'awards';
+  const APPLICATION_MANAGEMENT_NAME = 'applicant_management';
 
   /**
    * Returns the case types for the awards category.

--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Class CRM_CiviAwards_Service_ApplicantManagementMenu.
+ */
+class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Service_CaseCategoryMenu {
+
+  /**
+   * Creates the Sub Menus for the Applicant Management Instance.
+   *
+   * @param string $caseTypeCategoryName
+   *   Case category name.
+   * @param array $permissions
+   *   Permissions.
+   * @param int $caseCategoryMenuId
+   *   Menu ID.
+   */
+  protected function createCaseCategorySubmenus($caseTypeCategoryName, array $permissions, $caseCategoryMenuId) {
+    $submenus = [
+      [
+        'label' => ts('Dashboard'),
+        'name' => "{$caseTypeCategoryName}_dashboard",
+        'url' => "/civicrm/case/a/?case_type_category={$caseTypeCategoryName}#/case?case_type_category={$caseTypeCategoryName}",
+        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('Manage Applications'),
+        'name' => "manage_{$caseTypeCategoryName}_applications",
+        'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
+        'permission' => 'access my awards and activities,access all awards and activities',
+        'permission_operator' => 'OR',
+      ],
+    ];
+
+    foreach ($submenus as $i => $item) {
+      $item['weight'] = $i;
+      $item['parent_id'] = $caseCategoryMenuId;
+      $item['is_active'] = 1;
+      civicrm_api3('Navigation', 'create', $item);
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Service/ApplicantManagementUtils.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementUtils.php
@@ -1,0 +1,20 @@
+<?php
+
+use CRM_CiviAwards_Service_ApplicantManagementMenu as ApplicantManagementMenu;
+
+/**
+ * Class CRM_CiviAwards_Service_ApplicantManagementUtils.
+ */
+class CRM_CiviAwards_Service_ApplicantManagementUtils extends CRM_Civicase_Service_CaseCategoryInstanceUtils {
+
+  /**
+   * Returns the menu object for the applicant management instance.
+   *
+   * @return \CRM_Civicase_Service_CaseCategoryMenu
+   *   Menu object.
+   */
+  public function getMenuObject() {
+    return new ApplicantManagementMenu();
+  }
+
+}

--- a/CRM/CiviAwards/Setup/CreateApplicantManagementOption.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantManagementOption.php
@@ -1,0 +1,58 @@
+<?php
+
+use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategory;
+
+/**
+ * Class CreateApplicantManagementOption.
+ */
+class CRM_CiviAwards_Setup_CreateApplicantManagementOption {
+
+  /**
+   * Creates the Applicant management option and sets instance type for Awards.
+   */
+  public function apply() {
+    $this->createApplicantManagementOption();
+    $this->setInstanceTypeForAwardsCategory();
+  }
+
+  /**
+   * Creates the Applicant management option value.
+   */
+  private function createApplicantManagementOption() {
+    $categoryInstance = new CaseCategoryInstanceSupport();
+    $categoryInstance->createCaseCategoryInstanceOptionGroup();
+
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(
+      [
+        'option_group_id' => CaseCategoryInstanceSupport::INSTANCE_OPTION_GROUP,
+        'name' => CaseTypeCategory::APPLICATION_MANAGEMENT_NAME,
+        'label' => 'Applicant Management',
+        'grouping' => 'CRM_CiviAwards_Service_ApplicantManagementUtils',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+      ]
+    );
+  }
+
+  /**
+   * Sets the instance type for the awards case type category.
+   */
+  private function setInstanceTypeForAwardsCategory() {
+    $params = [
+      'category_id' => CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      'instance_id' => CaseTypeCategory::APPLICATION_MANAGEMENT_NAME,
+    ];
+
+    $result = civicrm_api3('CaseCategoryInstance', 'get', [
+      'category_id' => CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    if ($result['count'] == 1) {
+      return;
+    }
+
+    civicrm_api3('CaseCategoryInstance', 'create', $params);
+  }
+
+}

--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -1,5 +1,8 @@
 <?php
 
+use CRM_CiviAwards_Service_ApplicantManagementMenu as ApplicantManagementMenu;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
 /**
  * Creates the menu items for Civi Awards.
  */
@@ -9,74 +12,8 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
    * Creates the Awards menu items.
    */
   public function apply() {
-    $this->createMenuItems();
-  }
-
-  /**
-   * Creates Awards Main menu.
-   */
-  private function createMenuItems() {
-    $result = civicrm_api3('Navigation', 'get', ['name' => 'awards']);
-
-    if ($result['count'] > 0) {
-      return;
-    }
-
-    $casesWeight = CRM_Core_DAO::getFieldValue(
-      'CRM_Core_DAO_Navigation',
-      'Cases',
-      'weight',
-      'name'
-    );
-
-    $params = [
-      'label' => ts('Awards'),
-      'name' => 'awards',
-      'permission_operator' => 'OR',
-      'is_active' => 1,
-      'permission' => 'access my awards and activities,access all awards and activities',
-      'icon' => 'crm-i fa-folder-open-o',
-    ];
-    $menu = civicrm_api3('Navigation', 'create', $params);
-
-    civicrm_api3('Navigation', 'create', [
-      'id' => $menu['id'],
-      'weight' => $casesWeight + 1,
-    ]);
-    $this->createSubmenus($menu['id']);
-  }
-
-  /**
-   * Creates sub menu items.
-   *
-   * @param int $parentMenuId
-   *   The id for the parent menu containing the sub menu items.
-   */
-  private function createSubmenus($parentMenuId) {
-    $submenus = [
-      [
-        'label' => ts('Dashboard'),
-        'name' => 'awards_dashboard',
-        'url' => '/civicrm/case/a/?case_type_category=awards#/case?case_type_category=awards',
-        'permission' => 'access my awards and activities,access all awards and activities',
-        'permission_operator' => 'OR',
-      ],
-      [
-        'label' => ts('Manage Applications'),
-        'name' => 'manage_awards_applications',
-        'url' => 'civicrm/case/a/?case_type_category=awards#/case/list?cf=%7B%22case_type_category%22:%22awards%22%7D',
-        'permission' => 'access my awards and activities,access all awards and activities',
-        'permission_operator' => 'OR',
-      ],
-    ];
-
-    foreach ($submenus as $i => $item) {
-      $item['weight'] = $i;
-      $item['parent_id'] = $parentMenuId;
-      $item['is_active'] = 1;
-
-      civicrm_api3('Navigation', 'create', $item);
-    }
+    $applicationMenu = new ApplicantManagementMenu();
+    $applicationMenu->createItems(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
   }
 
 }

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_CiviAwards_Setup_CreateAwardsCaseCategoryOption as CreateAwardsCaseCategoryOption;
+use CRM_CiviAwards_Setup_CreateApplicantManagementOption as CreateApplicantManagementOption;
 use CRM_CiviAwards_Setup_ProcessAwardsCategoryForCustomGroupSupport as ProcessAwardsCategoryForCustomGroupSupport;
 use CRM_CiviAwards_Setup_DeleteAwardsCaseCategoryOption as DeleteAwardsCaseCategoryOption;
 use CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup as CreateAwardTypeOptionGroup;
@@ -30,6 +31,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new CreateAwardsCaseCategoryOption(),
       new ProcessAwardsCategoryForCustomGroupSupport(),
       new CreateAwardTypeOptionGroup(),
+      new CreateApplicantManagementOption(),
       new CreateApplicantReviewActivityType(),
       new AddAwardsCategoryWordReplacement(),
       new CreateAwardsMenus(),

--- a/CRM/CiviAwards/Upgrader/Steps/Step1002.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1002.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateApplicantManagementOption as CreateApplicantManagementOption;
+
+/**
+ * Creates the Applicant management option value.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1002 {
+
+  /**
+   * Creates the Applicant management option value.
+   *
+   * @return bool
+   *   return value.
+   */
+  public function apply() {
+    $step = new CreateApplicantManagementOption();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR depends on https://github.com/compucorp/uk.co.compucorp.civicase/pull/515, The Applicant Management option value which is an option value of the Case Category Instance type option group was added in this PR. Also the menu class for the Applicant management Instance was added.

## Before
- The Applicant management Menu class and option value was not added.

## After
- The Applicant management Menu class and option value was added.

## Technical Details
- As explained in https://github.com/compucorp/uk.co.compucorp.civicase/pull/515, each Case category instance will have it's own menu class which will be responsible for creating menu Items for a case category belonging to a case category instance. The `ApplicantManagementMenu` class was added to create/update/delete menu items for case categories for this instance. The class uses most of the methods in the base `CRM_Civicase_Service_CaseCategoryMenu` class and only overrides the `createCaseCategorySubmenus` method.
- The Applicant Management option value was also added so that this option can be available on the Create case type category screen.

## Comments
PHP unit Tests are failing for Awards because the Awards extension expects the CaseCategory Entity to be present and this is not present on master and it is the master version of civicase is installed for test. There are some discussion around how to fix this and will be fixed in later PR's