### PR TITLE
RSE-1140: Change Operator Between Applicant Status And Tags Field in Review Panel to `AND`

### DIFF
--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -23,16 +23,11 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    */
   public function get($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
     $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
-    $tags = array_keys($visibilitySettings['tags']);
-    $tags = in_array('all', $tags) ? [] : $tags;
-    $status = array_keys($visibilitySettings['status']);
-    $status = in_array('all', $status) ? [] : $status;
-    sort($status);
-    sort($tags);
-    return [
-      'application_tags' => $tags,
-      'application_status' => $status,
-    ];
+    foreach ($visibilitySettings as &$visibilitySetting) {
+      unset($visibilitySetting['status_to_move_to'], $visibilitySetting['anonymize_application']);
+    }
+
+    return $visibilitySettings;
   }
 
   /**
@@ -70,135 +65,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
   }
 
   /**
-   * Returns the review access a contact has to the Award Application.
-   *
-   * Basically returns the statuses that a contact can move an application
-   * to and if the data for the application should be anonymized or not.
-   *
-   * @param int $contactId
-   *   Contact Id.
-   * @param int $applicationId
-   *   Award Id.
-   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
-   *   Award Panel contact service.
-   *
-   * @return array
-   *   Review access array.
-   */
-  public function getReviewAccess($contactId, $applicationId, AwardReviewPanelContact $awardPanelContact) {
-    $applicationDetails = $this->getApplicationDetails($applicationId);
-    $awardId = $applicationDetails['case_type_id'];
-    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
-
-    $caseTags = !empty($applicationDetails['tag_id']) ? array_keys($applicationDetails['tag_id']) : [];
-    $caseStatus = $applicationDetails['status_id'];
-
-    $caseStatusAccess = !empty($visibilitySettings['status'][$caseStatus]['status_to_move_to']) ?
-      $visibilitySettings['status'][$caseStatus]['status_to_move_to'] : [];
-    $allCaseStatusAccess = !empty($visibilitySettings['status']['all']['status_to_move_to']) ?
-      $visibilitySettings['status']['all']['status_to_move_to'] : [];
-    $allCaseTagAccess = !empty($visibilitySettings['tags']['all']['status_to_move_to']) ?
-      $visibilitySettings['tags']['all']['status_to_move_to'] : [];
-    $caseTagAccess = [];
-    $caseTagAnonymization = TRUE;
-
-    foreach ($caseTags as $tag) {
-      $statusToMoveTo = !empty($visibilitySettings['tags'][$tag]['status_to_move_to']) ? $visibilitySettings['tags'][$tag]['status_to_move_to'] : [];
-      $caseTagAccess = array_merge($caseTagAccess, $statusToMoveTo);
-    }
-
-    $statusToMoveApplicationTo = array_merge($caseStatusAccess, $allCaseStatusAccess, $caseTagAccess);
-    if (!empty($caseTags)) {
-      $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $allCaseTagAccess);
-      $caseTagAnonymization = $this->getCaseTagsAnonymization($visibilitySettings, $caseTags);
-    }
-    $caseStatusAnonymization = $this->getCaseStatusAnonymization($visibilitySettings, [$caseStatus]);
-    $statusToMoveApplicationTo = array_unique($statusToMoveApplicationTo);
-    sort($statusToMoveApplicationTo);
-
-    return [
-      'anonymize_application' => $caseTagAnonymization && $caseStatusAnonymization ? TRUE : FALSE,
-      'status_to_move_to' => $statusToMoveApplicationTo,
-    ];
-  }
-
-  /**
-   * Gets anonymization value for case status or case tags data.
-   *
-   * @param array $visibilitySettings
-   *   Visibility settings.
-   * @param array $data
-   *   Data array to get anonymization data for.
-   * @param string $key
-   *   Visibility key: tags or status.
-   *
-   * @return bool
-   *   Anonymization value.
-   */
-  private function getAnonymizationForReview(array $visibilitySettings, array $data, $key) {
-    $anonymizeApplication = TRUE;
-    foreach ($data as $value) {
-      if ($anonymizeApplication === TRUE) {
-        $anonymizeApplication = $this->getReviewAnonymizationValue($visibilitySettings, $value, $key);
-      }
-    }
-    $allDataAnonymization = $this->getReviewAnonymizationValue($visibilitySettings, 'all', $key);
-
-    return $anonymizeApplication && $allDataAnonymization ? TRUE : FALSE;
-  }
-
-  /**
-   * Gets anonymization value for case tags data.
-   *
-   * @param array $visibilitySettings
-   *   Visibility settings.
-   * @param array $caseTags
-   *   Data array to get anonymization data for.
-   *
-   * @return bool
-   *   Anonymization value.
-   */
-  private function getCaseTagsAnonymization(array $visibilitySettings, array $caseTags) {
-    return $this->getAnonymizationForReview($visibilitySettings, $caseTags, 'tags');
-  }
-
-  /**
-   * Gets anonymization value for case status data.
-   *
-   * @param array $visibilitySettings
-   *   Visibility settings.
-   * @param array $caseStatus
-   *   Data array to get anonymization data for.
-   *
-   * @return bool
-   *   Anonymization value.
-   */
-  private function getCaseStatusAnonymization(array $visibilitySettings, array $caseStatus) {
-    return $this->getAnonymizationForReview($visibilitySettings, $caseStatus, 'status');
-  }
-
-  /**
-   * Gets review anonymization value.
-   *
-   * @param array $visibilitySettings
-   *   Visibility settings.
-   * @param mixed $value
-   *   Case status or tag value.
-   * @param string $key
-   *   Visibility key: tags or status.
-   *
-   * @return bool|mixed
-   *   Anonymization value.
-   */
-  private function getReviewAnonymizationValue(array $visibilitySettings, $value, $key) {
-    if (isset($visibilitySettings[$key][$value]['anonymize_application'])) {
-      return $visibilitySettings[$key][$value]['anonymize_application'];
-    }
-
-    return TRUE;
-  }
-
-  /**
    * Returns the Award ID given an application ID.
    *
    * @param int $applicationId
@@ -231,101 +97,62 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   The contact access to the Award applications.
    */
   private function processVisibilitySettings(array $visibilitySettings) {
-    $tags = [];
-    $status = [];
+    $response = [];
     foreach ($visibilitySettings as $visibilitySetting) {
-      if (isset($visibilitySetting['application_tags']) && empty($visibilitySetting['application_tags'])) {
-        $tagKey = 'all';
-        $this->setVisibilityData($tags, $tagKey, $visibilitySetting);
-      }
-      elseif (!empty($visibilitySetting['application_tags'])) {
-        foreach ($visibilitySetting['application_tags'] as $tagKey) {
-          $this->setVisibilityData($tags, $tagKey, $visibilitySetting);
-        }
-      }
-
-      if (isset($visibilitySetting['application_status']) && empty($visibilitySetting['application_status'])) {
-        $statusKey = 'all';
-        $this->setVisibilityData($status, $statusKey, $visibilitySetting);
-      }
-      elseif (!empty($visibilitySetting['application_status'])) {
-        foreach ($visibilitySetting['application_status'] as $statusKey) {
-          $this->setVisibilityData($status, $statusKey, $visibilitySetting);
-        }
-      }
+      $response[] = [
+        'application_tags' => isset($visibilitySetting['application_tags']) ? $visibilitySetting['application_tags'] : [],
+        'application_status' => isset($visibilitySetting['application_status']) ? $visibilitySetting['application_status'] : [],
+        'status_to_move_to' => !empty($visibilitySetting['is_application_status_restricted']) ? $visibilitySetting['restricted_application_status'] : [],
+        'anonymize_application' => isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0 ? FALSE : TRUE,
+      ];
     }
 
-    return [
-      'tags' => $tags,
-      'status' => $status,
-    ];
+    return $response;
   }
 
   /**
-   * Sets visibility data for status or tag.
+   * Returns the review access a contact has to the Award Application.
    *
-   * @param array $data
-   *   Data array to set visivility data to.
-   * @param mixed $key
-   *   Array key.
-   * @param array $visibilitySetting
-   *   Visibility setting for award panel.
-   */
-  private function setVisibilityData(array &$data, $key, array $visibilitySetting) {
-    $this->initializeArray($data, $key);
-    $data[$key]['status_to_move_to'] = $this->getRestrictedStatus($data[$key]['status_to_move_to'], $visibilitySetting);
-    $data[$key]['anonymize_application'] = $data[$key]['anonymize_application'] === FALSE ? FALSE : $this->getAnonymization($visibilitySetting);
-  }
-
-  /**
-   * Create an entry for the key in the array if not present.
+   * Basically returns the statuses that a contact can move an application
+   * to and if the data for the application should be anonymized or not.
    *
-   * @param array $data
-   *   Array to initialize data in.
-   * @param mixed $key
-   *   Key to initialize data for.
-   */
-  private function initializeArray(array &$data, $key) {
-    if (!isset($data[$key]['status_to_move_to'])) {
-      $data[$key]['status_to_move_to'] = [];
-    }
-
-    if (!isset($data[$key]['anonymize_application'])) {
-      $data[$key]['anonymize_application'] = TRUE;
-    }
-  }
-
-  /**
-   * Gets anonymization from visibility setting.
-   *
-   * @param array $visibilitySetting
-   *   Visibility setting for award panel.
-   *
-   * @return bool
-   *   Return anonymization.
-   */
-  private function getAnonymization(array $visibilitySetting) {
-    if (isset($visibilitySetting['anonymize_application']) && $visibilitySetting['anonymize_application'] == 0) {
-      return FALSE;
-    }
-
-    return TRUE;
-  }
-
-  /**
-   * Returns restricted status data.
-   *
-   * @param mixed $oldValue
-   *   Old value.
-   * @param array $visibilitySetting
-   *   Visibility setting for award panel.
+   * @param int $contactId
+   *   Contact Id.
+   * @param int $applicationId
+   *   Award Id.
+   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
+   *   Award Panel contact service.
    *
    * @return array
-   *   New value for restricted status.
+   *   Review access array.
    */
-  private function getRestrictedStatus($oldValue, array $visibilitySetting) {
-    return array_merge($oldValue, !empty($visibilitySetting['is_application_status_restricted']) ?
-      $visibilitySetting['restricted_application_status'] : []);
+  public function getReviewAccess($contactId, $applicationId, AwardReviewPanelContact $awardPanelContact) {
+    $applicationDetails = $this->getApplicationDetails($applicationId);
+    $awardId = $applicationDetails['case_type_id'];
+    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
+
+    $caseTags = !empty($applicationDetails['tag_id']) ? array_keys($applicationDetails['tag_id']) : [];
+    $caseStatus = [$applicationDetails['status_id']];
+    $statusToMoveApplicationTo = [];
+    $anonymization = TRUE;
+
+    foreach ($visibilitySettings as $visibilitySetting) {
+      $caseStatusMatch = array_intersect($visibilitySetting['application_status'], $caseStatus) || empty($visibilitySetting['application_status']);
+      $caseTagMatch = !empty($caseTags) && (array_intersect($visibilitySetting['application_tags'], $caseTags) || empty($visibilitySetting['application_tags']));
+
+      if ($caseStatusMatch && $caseTagMatch) {
+        $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $visibilitySetting['status_to_move_to']);
+        $anonymization = $visibilitySetting['anonymize_application'] === FALSE ? FALSE : $anonymization;
+      }
+    }
+
+    $statusToMoveApplicationTo = array_unique($statusToMoveApplicationTo);
+    sort($statusToMoveApplicationTo);
+
+    return [
+      'anonymize_application' => $anonymization,
+      'status_to_move_to' => $statusToMoveApplicationTo,
+    ];
   }
 
   /**

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -93,39 +93,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
           'is_application_status_restricted' => 0,
         ],
       ],
-    ];
-    $awardPanel = [];
-    foreach ($params as $param) {
-      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
-    }
-
-    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
-    // Anonymize application will be false overral because more permission takes
-    // precedence over less less permissions.
-    $expectedResult = [
-      'application_tags' => [1, 2, 6, 8],
-      'application_status' => [3, 5, 6, 9],
-    ];
-
-    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
-  }
-
-  /**
-   * Test Anonymize Application Returns True For Contact When True.
-   */
-  public function testAnonymizeApplicationReturnsTrueForContactWhenItIsSetToBeTrue() {
-    $caseType = CaseTypeFabricator::fabricate();
-    $applicationContactAccess = new ApplicationContactAccess();
-    $contactId = 1;
-
-    $params = [
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'anonymize_application' => 1,
-          'is_application_status_restricted' => 0,
-        ],
-      ],
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
@@ -141,72 +108,34 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
     $expectedResult = [
-      'application_tags' => [],
-      'application_status' => [],
+      [
+        'application_tags' => [1, 2],
+        'application_status' => [5, 6],
+      ],
+      [
+        'application_tags' => [6, 8],
+        'application_status' => [9, 3],
+      ],
+      [
+        'application_tags' => [],
+        'application_status' => [],
+      ],
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
   }
 
   /**
-   * Test Visibility Settings Returns Items With Higher Values.
+   * Test Get Review Access When Panel Setting Is For All Case tags.
    */
-  public function testVisibilitySettingsReturnsItemsWithHigherValuesWhenMoreThanOneAwardPanel() {
-    $caseType = CaseTypeFabricator::fabricate();
-    $applicationContactAccess = new ApplicationContactAccess();
-    $contactId = 1;
-
-    $params = [
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_tags' => [],
-          'application_status' => [],
-          'anonymize_application' => 0,
-          'is_application_status_restricted' => 1,
-          'restricted_application_status' => [2],
-        ],
-      ],
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_tags' => [6, 8],
-          'application_status' => [9, 3],
-          'anonymize_application' => 1,
-          'is_application_status_restricted' => 0,
-        ],
-      ],
-    ];
-    $awardPanel = [];
-    foreach ($params as $param) {
-      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
-    }
-
-    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
-    // Anonymize application will be false overral because more permission takes
-    // precedence over less less permissions.
-    // Application status will return empty because empty means contact can
-    // filter all statuses and this has higher value.
-    // Application tags will return empty because empty means contact can filter
-    // all tags and this has higher value.
-    // Status to move to is a bit different because by default contact is not
-    // able to move to any So will be 2.
-    $expectedResult = [
-      'application_tags' => [],
-      'application_status' => [],
-    ];
-
-    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
-  }
-
-  /**
-   * Test Get Review Access When Case Has No Tags.
-   */
-  public function testGetReviewAccessForContactAndCaseHasNoTags() {
+  public function testGetReviewAccessForContactAndPanelSettingIsForAllCaseTags() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
-    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $caseData = CaseFabricator::fabricateWithTags(
+      ['Tag 1', 'Tag 2'],
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
     $contactId = 1;
 
     $params = [
@@ -246,7 +175,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
 
-    // Panel 1 and Panel 3 meets the case status criteria.
+    // Panel 1 and Panel 3 meets the case status and tags criteria.
     // So Contact will view combined status to move to for both panels
     // Since anonymization is not restricted in Panel 3, Contact will be able
     // to view unanonymized data.
@@ -255,13 +184,13 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
   }
 
   /**
-   * Test Get Review Access When Case Has Tags.
+   * Test Get Review Access When Panel Setting Is For Specific Case tags.
    */
-  public function testGetReviewAccessForContactAndCaseHasTags() {
+  public function testGetReviewAccessForContactAndAndPanelSettingIsForSpecificCaseTags() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
@@ -298,7 +227,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       [
         'case_type_id' => $caseType['id'],
         'visibility_settings' => [
-          'application_status' => [3, 4],
+          'application_status' => [$caseStatus],
           'application_tags' => [$tag1Id, $tag2Id],
           'anonymize_application' => 0,
           'is_application_status_restricted' => 1,
@@ -326,7 +255,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     // Panel 1, Panel 3, Panel 4 meets the case status and case tags criteria.
     // So Contact will view combined status to move to for the panels
     // Since anonymization is not restricted in Panel 3 & 4, Contact will
-    // be abl to view unanonymized data.
+    // be able to view unanonymized data.
     $expectedResult = [
       'status_to_move_to' => [1, 2, 5, 8, 9],
       'anonymize_application' => FALSE,
@@ -336,13 +265,16 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   }
 
   /**
-   * Tes When Case Has No Tags And Contact Cannot View Anonymised.
+   * Test When Panel Setting Is For All Tags And Contact Cannot View Anonymised.
    */
-  public function testGetReviewAccessForContactAndCaseHasNoTagsAndContactCanNotViewAnonymisedData() {
+  public function testGetReviewAccessForContactAndPanelSettingIsForAllTagsAndContactCanNotViewAnonymisedData() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
-    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $caseData = CaseFabricator::fabricateWithTags(
+      ['Tag 1', 'Tag 2'],
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
     $contactId = 1;
 
     $params = [
@@ -373,71 +305,12 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
 
-    // Panel 1 and Panel 2 meets the case status criteria.
+    // Panel 1 and Panel 2 meets the case status and tag criteria.
     // So Contact will view combined status to move to for both panels
     // Since anonymization is restricted in all panels, Contact will not be able
     // to view unanonymized data.
     $expectedResult = [
       'status_to_move_to' => [1, 2, 5],
-      'anonymize_application' => TRUE,
-    ];
-
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
-  }
-
-  /**
-   * Test When Case Has No Tags And Contact Can View Anonymised.
-   */
-  public function testGetReviewAccessForContactAndCaseHasTagsAndContactCanNotViewAnonymisedData() {
-    $caseType = CaseTypeFabricator::fabricate();
-    $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
-    $caseData = CaseFabricator::fabricateWithTags(
-      ['Tag 1', 'Tag 2'],
-      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
-    );
-
-    $tag1Id = $caseData['tags']['0']['id'];
-    $tag2Id = $caseData['tags']['1']['id'];
-
-    $contactId = 1;
-
-    $params = [
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_status' => [$caseStatus],
-          'application_tags' => [$tag1Id],
-          'anonymize_application' => 1,
-          'is_application_status_restricted' => 1,
-          'restricted_application_status' => [1],
-        ],
-      ],
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_status' => [3, 4],
-          'application_tags' => [$tag1Id, $tag2Id],
-          'anonymize_application' => 1,
-          'is_application_status_restricted' => 1,
-          'restricted_application_status' => [8, 9],
-        ],
-      ],
-    ];
-
-    $awardPanel = [];
-    foreach ($params as $param) {
-      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
-    }
-
-    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
-
-    // Panel 1, Panel 2, meets the case status and case tags criteria.
-    // So Contact will view combined status to move to for the panels
-    // Since anonymization is restricted in all panels, Contact will not be able
-    // to view unanonymized data.
-    $expectedResult = [
-      'status_to_move_to' => [1, 8, 9],
       'anonymize_application' => TRUE,
     ];
 
@@ -451,7 +324,10 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
-    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $caseData = CaseFabricator::fabricateWithTags(
+      ['Tag 1', 'Tag 2'],
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
     $contactId = 1;
 
     $params = [
@@ -501,17 +377,19 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
   }
 
   /**
-   * Test ALL Tags Access Is Not Applied When Case Has No Tags.
+   * Test Contact Cannot Move to Status When Case Has No Tags.
    */
-  public function testAllTagsAccessForPanelIsNotAppliedWhenCaseHasNoTags() {
+  public function testContactIsNotAbleToMoveToAnyStatusWhenCaseHasNoTags() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
-    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
+    $caseData = CaseFabricator::fabricate(
+      ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
+    );
     $contactId = 1;
 
     $params = [
@@ -543,60 +421,15 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
 
-    // Only Panel 2 meets the case status criteria.
-    // Case has not tags therefore, panel 1 does not meet the criteria.
-    $expectedResult = [
-      'status_to_move_to' => [2, 5],
-      'anonymize_application' => FALSE,
-    ];
-
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
-  }
-
-  /**
-   * Test Anonymization logic for all tags when case has no tags.
-   */
-  public function testAnonymisationLogicWhenCaseHasNoTagsAndAllTagsInAccessInPanelAllowsApplicationToBeNonAnonymised() {
-    $caseType = CaseTypeFabricator::fabricate();
-    $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
-    $case = CaseFabricator::fabricate(['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]);
-    $contactId = 1;
-
-    $params = [
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_status' => [3],
-          'application_tags' => [],
-          'anonymize_application' => 0,
-          'is_application_status_restricted' => 0,
-        ],
-      ],
-      [
-        'case_type_id' => $caseType['id'],
-        'visibility_settings' => [
-          'application_status' => [$caseStatus],
-          'anonymize_application' => 1,
-          'is_application_status_restricted' => 0,
-        ],
-      ],
-    ];
-
-    $awardPanel = [];
-    foreach ($params as $param) {
-      $awardPanel[] = AwardReviewPanelFabricator::fabricate($param);
-    }
-
-    $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
-
-    // Application should be anonymised.
+    // No panel meets this criteria as the case has no tags and since there is
+    // `AND` operator between the status and case tags, it is compulsory for
+    // a case to have at least a tag.
     $expectedResult = [
       'status_to_move_to' => [],
       'anonymize_application' => TRUE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $case['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['id'], $awardPanelContact));
   }
 
   /**


### PR DESCRIPTION
## Overview
Currently the operator between the case status and the case tags field when configuring a panel is the `OR` operator, i.e the panel member can view an application in a specific status or having a specific tag. However this is not correct as the specification states that the operator should be an `AND`. This PR makes that change.

<img width="1280" alt="Configure Award - Award Type  CaseLatest 2020-07-06 12-10-26" src="https://user-images.githubusercontent.com/6951813/86587593-cf6dfe00-bf81-11ea-9128-1fe8431002e6.png">



## Before
The operator between the Case Status and Case tags field is an `OR` 

## After
The operator between the Case Status and Case tags field is now an `AND`.
This change however brings some changes to the response of the  AwardReviewPanel.getContactAccess API.
Instead of returning an aggregated value for the application status and application tags for all panels, these values are now returned per panel since the application that a user has access to has to be fetched on a per panel basis.


```php
Sample Call and Response

$result = civicrm_api3('AwardReviewPanel', 'getcontactaccess', [
  'contact_id' => 7,
  'award_id' => 4,
]);

{

    "is_error": 0,
    "version": 3,
    "count": 3,
    "values": [
        {
            "application_tags": [],
            "application_status": [
                "1"
            ]
        },
        {
            "application_tags": [],
            "application_status": [
                "3"
            ]
        },
        {
            "application_tags": [
                "7"
            ],
            "application_status": [
                "3"
            ]
        }
    ]
}


```

The `AwardReveiewPanel.getReviewAcess` request and response remains the same.