### PR TITLE
RSE-1216: Text changes on the SSP awards form pages

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -239,7 +239,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     try {
       civicrm_api3('Profile', 'submit', $profileFields);
       $status = $this->_action == CRM_Core_Action::ADD ? 'Submitted' : 'Updated';
-      CRM_Core_Session::setStatus(ts('The review has been ' . strtolower($status) . ' successfully.'), ts('Review ' . $status), 'success');
+      CRM_Core_Session::setStatus(ts('Your review has been ' . strtolower($status) . ' successfully.'), ts('Review ' . $status), 'success');
     }
     catch (Exception $e) {
       CRM_Core_Session::setStatus(ts('An error occurred'), 'Error', 'error');

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -39,11 +39,7 @@
         <div class="form-group {$form_group_class}">
           {if $isReviewFromSsp}
             <h1 class="header-pager">
-              {if $isViewAction}
-                {$sourceContactName}
-              {else}
-                {$form.source_contact_id.html}
-              {/if}
+              {$caseContactDisplayName}
             </h1>
             <div class="ssp-details-page-section__sub-heading">
               <span class="ssp-applicant-card__award ssp-text-large">{$caseTypeName}</span>


### PR DESCRIPTION
## Overview
As a part of this PR, text and label changes are done on the awards pages

## Submitted popup text
#### Before
<img width="636" alt="Screenshot 2020-07-07 at 7 33 04 PM" src="https://user-images.githubusercontent.com/3340537/86795567-522eb000-c08b-11ea-9513-e663e22d02b8.png">

#### After
<img width="733" alt="Screenshot 2020-07-07 at 7 31 39 PM" src="https://user-images.githubusercontent.com/3340537/86795580-56f36400-c08b-11ea-9bcd-a79c9c0a65da.png">

## Form heading title
#### Before
![title issue - before](https://user-images.githubusercontent.com/3340537/86795631-64105300-c08b-11ea-89b0-ddb4240811f4.gif)

#### After
![title issue - after](https://user-images.githubusercontent.com/3340537/86795653-6a063400-c08b-11ea-9c98-d3486b437a73.gif)

## Technical Details
* Change text in the `AwardReview.php` to match the design - https://projects.invisionapp.com/d/main#/console/19802243/418400657/preview
* Change the headline for SSP pages to use case contact name from source contact name.
