### PR TITLE
RSE-1222: Improve GitHub Workflow Action Regarding Extensions that CiviAward Depends On

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,6 +10,8 @@ jobs:
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+      GITHUB_BASE_REF: ${{ github.base_ref }}
+      GITHUB_HEAD_REF: ${{ github.head_ref }}
 
     services:
       mysql:
@@ -35,12 +37,29 @@ jobs:
         with:
             path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards
 
-      - name: Installing CiviAwards and its dependencies
+      - name: Download CiviAwards dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.civicase.git
-          cv en shoreditch civicase civiawards
+          git clone --depth 1 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
+
+      - name: Switch Civicase Branch
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase
+        run: |
+          if [[ $(git ls-remote --heads origin ${GITHUB_HEAD_REF}) ]]
+          then
+              git checkout ${GITHUB_HEAD_REF}
+          elif [[ $(git ls-remote --heads origin ${GITHUB_BASE_REF}) ]]
+          then
+              git checkout ${GITHUB_BASE_REF}
+          fi
+        shell: bash
+
+      - name: Install CiviAwards and its dependencies
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          cv en shoreditch civicase
+          cv en civiawards
 
       - name: Run JS unit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards


### PR DESCRIPTION
## Problem
When working on Tasks that require same Epic branches on CiviCase and CiviAwards that involves the introduction of some new functionality in CiviCase that CiviAwards depend on, when creating a PR with the Awards tech task branch to the Epic branch and in the process of enabling CiviAwards in the Unit test workflow, the installation process may fail due to the fact that it is the master branch of Civicase that is installed and not the Epic branch that contains the code needed for the Awards installation to proceed smoothly

## Solution
The github workflow for unit tests is updated such that when installing the Civicase extension, which is the main dependency for CiviAwards, the source branch for the CiviAwards PR is first checked to see if that branch exists in CiviCase repo, if it does, we switch to this branch, if not, we check if the destination branch also exists in CiviCase repo, if none of these conditions are met, CiviCase gets installed on the default master branch
