### PR TITLE
RSE-1199: Add AwardDetail.getInstanceCategories API

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -15,6 +15,23 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
    *   Array of Case Types indexed by Id.
    */
   public static function getApplicantManagementCaseTypes() {
+    $applicantManagementCategories = self::getApplicantManagementCaseCategories();
+    if (empty($applicantManagementCategories)) {
+      return [];
+    }
+
+    $result = civicrm_api3('CaseType', 'get', [
+      'return' => ['title', 'id'],
+      'case_type_category' => ['IN' => $applicantManagementCategories],
+    ]);
+
+    return array_column($result['values'], 'title', 'id');
+  }
+
+  /**
+   * Returns the case categories for the applicant management instance.
+   */
+  public static function getApplicantManagementCaseCategories() {
     $instance = civicrm_api3('CaseCategoryInstance', 'get', [
       'instance_id' => self::APPLICATION_MANAGEMENT_NAME,
     ]);
@@ -23,13 +40,7 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
       return [];
     }
 
-    $applicantManagementCategories = array_column($instance['values'], 'category_id');
-    $result = civicrm_api3('CaseType', 'get', [
-      'return' => ['title', 'id'],
-      'case_type_category' => ['IN' => $applicantManagementCategories],
-    ]);
-
-    return array_column($result['values'], 'title', 'id');
+    return array_column($instance['values'], 'category_id');
   }
 
 }

--- a/CRM/CiviAwards/Setup/CreateAwardTypeOptionGroup.php
+++ b/CRM/CiviAwards/Setup/CreateAwardTypeOptionGroup.php
@@ -47,7 +47,7 @@ class CRM_CiviAwards_Setup_CreateAwardTypeOptionGroup {
     foreach ($optionValues as $optionValue) {
       CRM_Core_BAO_OptionValue::ensureOptionValueExists([
         'option_group_id' => $this->awardOptionGroupName,
-        'name' => $optionValues,
+        'name' => $optionValue,
         'label' => ucfirst($optionValue),
         'is_active' => TRUE,
         'is_reserved' => TRUE,

--- a/CRM/CiviAwards/Test/Fabricator/CaseCategory.php
+++ b/CRM/CiviAwards/Test/Fabricator/CaseCategory.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Class CRM_CiviAwards_Test_Fabricator_CaseCategory.
+ */
+class CRM_CiviAwards_Test_Fabricator_CaseCategory {
+
+  /**
+   * Fabricates a Case Category.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return mixed
+   *   API result.
+   */
+  public static function fabricate(array $params = []) {
+    $params = self::mergeDefaultParams($params);
+    $result = civicrm_api3('OptionValue', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+  /**
+   * Merges default parameters.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   API result.
+   */
+  private static function mergeDefaultParams(array $params) {
+    $defaultParams = [
+      'option_group_id' => 'case_type_categories',
+    ];
+
+    return array_merge($defaultParams, $params);
+  }
+
+}

--- a/api/v3/AwardDetail.php
+++ b/api/v3/AwardDetail.php
@@ -106,3 +106,20 @@ function getParameterValue(array $params, $parameterName) {
 
   return $params[$parameterName];
 }
+
+/**
+ * AwardDetail.getInstanceCategories API.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor.
+ */
+function civicrm_api3_award_detail_getinstancecategories(array $params) {
+  $applicantManagementCategories = CRM_CiviAwards_Helper_CaseTypeCategory::getApplicantManagementCaseCategories();
+  $caseTypeCategories = CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate');
+  $categoryDetails = array_intersect_key($caseTypeCategories, array_flip($applicantManagementCategories));
+
+  return civicrm_api3_create_success($categoryDetails);
+}

--- a/tests/phpunit/Api/v3/AwardDetailTest.php
+++ b/tests/phpunit/Api/v3/AwardDetailTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_Case_BAO_CaseType as CaseType;
+
+/**
+ * Class api_v3_AwardDetailTest.
+ *
+ * @group headless
+ */
+class Api_v3_AwardDetailTest extends BaseHeadlessTest {
+
+  /**
+   * Test AwardDetail.getInstanceCategories API.
+   */
+  public function testGetInstanceCategoriesReturnsCorrectResults() {
+    $caseTypeCategory1 = CaseCategoryFabricator::fabricate(['name' => 'category1']);
+    $caseTypeCategory2 = CaseCategoryFabricator::fabricate(['name' => 'category2']);
+    CaseCategoryFabricator::fabricate(['name' => 'category3']);
+
+    $this->addCategoryToApplicantManagement($caseTypeCategory1['name']);
+    $this->addCategoryToApplicantManagement($caseTypeCategory2['name']);
+
+    $result = civicrm_api3('AwardDetail', 'getinstancecategories');
+
+    // There are three case categories belonging to the Award Instance
+    // The Awards category added on setup, CaseTypeCategory1 and
+    // CaseTypeCategory2 all belongs to the Applicant Management
+    // Instance.
+    $caseTypeCategories = array_flip(CaseType::buildOptions('case_type_category', 'validate'));
+    $expectedValue = [
+      $caseTypeCategories[CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME] => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      $caseTypeCategory1['value'] => $caseTypeCategory1['name'],
+      $caseTypeCategory2['value'] => $caseTypeCategory2['name'],
+    ];
+
+    $this->assertEquals($expectedValue, $result['values']);
+  }
+
+  /**
+   * Adds the case category to applicant management Instance.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   */
+  private function addCategoryToApplicantManagement($caseCategoryName) {
+    $params = [
+      'category_id' => $caseCategoryName,
+      'instance_id' => CaseTypeCategoryHelper::APPLICATION_MANAGEMENT_NAME,
+    ];
+    civicrm_api3('CaseCategoryInstance', 'create', $params);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds an API that will return the case categories that are of the Applicant Management Category Instance.

## Before
- This API is not present

## After
The AwardDetail.getInstanceCategories is added

```php
Sample Request and Response
civicrm_api3('AwardDetail', 'getinstancecategories');

{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": {
        "2": "Awards",
        "3": "Awards Project"
    }
}

```