### PR TITLE
DRU-190: Show error message for ssp awards review application pages where application is deleted

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -170,6 +170,11 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $hasSubmittedReview = $this->userAlreadySubmittedReview();
     $canNotViewReview = $isViewAction && $this->isReviewFromSsp() && !$this->isReviewOwner();
 
+    if ($this->isReviewFromSsp() && $this->isCaseApplicationDeleted()) {
+      $action = $isViewAction ? 'view' : 'submit';
+      return "You cannot $action a review for a deleted application.";
+    }
+
     if ($this->isReviewFromSsp() && $hasSubmittedReview && $isAddAction) {
       return 'You have already submitted a review for this Award and you cannot add another review';
     }
@@ -684,6 +689,22 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     ]);
 
     return $result['count'] > 0;
+  }
+
+  /**
+   * Checks if Case Application is deleted.
+   *
+   * @return bool
+   *   Bool value.
+   */
+  private function isCaseApplicationDeleted() {
+    $result = civicrm_api3('Case', 'get', [
+      'sequential' => 1,
+      'id' => $this->caseId,
+      'is_deleted' => 0,
+    ]);
+
+    return empty($result['values']) ? TRUE : FALSE;
   }
 
 }


### PR DESCRIPTION
## Overview

This PR fixes issue with SSP Awards Review application page where if the review panel member has direct URL of review application page or view submitted review page they can submit/view reviews for the applications which were in deleted state but we should rather show an error message "You cannot submit review for a deleted application." on add review page and "You cannot view review for a deleted application." on view submitted review page.

## Before
Case application is deleted from backend but if review panel member has direct URL they can access and add reviews.
![image](https://user-images.githubusercontent.com/2689257/89759620-2ed2a700-db08-11ea-893e-0930f6e361ac.png)

View submitted review page
![image](https://user-images.githubusercontent.com/2689257/89772909-7cf3a480-db20-11ea-82fa-a109ecf16b05.png)

## After
![image](https://user-images.githubusercontent.com/2689257/89770819-ee315880-db1c-11ea-9680-e07ea9e28934.png)

![image](https://user-images.githubusercontent.com/2689257/89772947-8f6dde00-db20-11ea-9393-9e86e7d0406f.png)

## Technical Details

- Added check for Case application "is_deleted" field for SSP review forms and return error message.