### PR TITLE
RSE-1248: Fix bug in getreviewaccessapi

### DIFF
--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -138,7 +138,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 
     foreach ($visibilitySettings as $visibilitySetting) {
       $caseStatusMatch = array_intersect($visibilitySetting['application_status'], $caseStatus) || empty($visibilitySetting['application_status']);
-      $caseTagMatch = (empty($visibilitySetting['application_tags']) || (!empty($caseTags) && array_intersect($visibilitySetting['application_tags'], $caseTags)));
+      $caseTagMatch = empty($visibilitySetting['application_tags']) || (!empty($caseTags) && array_intersect($visibilitySetting['application_tags'], $caseTags));
 
       if ($caseStatusMatch && $caseTagMatch) {
         $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $visibilitySetting['status_to_move_to']);

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -138,7 +138,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 
     foreach ($visibilitySettings as $visibilitySetting) {
       $caseStatusMatch = array_intersect($visibilitySetting['application_status'], $caseStatus) || empty($visibilitySetting['application_status']);
-      $caseTagMatch = !empty($caseTags) && (array_intersect($visibilitySetting['application_tags'], $caseTags) || empty($visibilitySetting['application_tags']));
+      $caseTagMatch = (empty($visibilitySetting['application_tags']) || (!empty($caseTags) && array_intersect($visibilitySetting['application_tags'], $caseTags)));
 
       if ($caseStatusMatch && $caseTagMatch) {
         $statusToMoveApplicationTo = array_merge($statusToMoveApplicationTo, $visibilitySetting['status_to_move_to']);

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -4,7 +4,7 @@ use CRM_CiviAwards_BAO_AwardReviewPanel as AwardReviewPanel;
 use CRM_CiviAwards_Service_AwardPanelContact as AwardReviewPanelContact;
 
 /**
- * Class CRM_CiviAwards_Service_AwardApplicationContactAccess.
+ * Class for handling access of a contact to an application.
  */
 class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -381,9 +381,9 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   }
 
   /**
-   * Test Contact Cannot Move to Status When Case Has No Tags.
+   * Test Contact Can Move to Status When Case And Panel Both Has No Tags.
    */
-  public function testContactIsNotAbleToMoveToAnyStatusWhenCaseHasNoTags() {
+  public function testContactIsAbleToMoveToRelevantStatusWhenCaseHasNoTagsAndPanelTagsIsEmpty() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
     $applicationContactAccess = new ApplicationContactAccess();
@@ -421,9 +421,8 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
 
-    // No panel meets this criteria as the case has no tags and since there is
-    // `AND` operator between the status and case tags, it is compulsory for
-    // a case to have at least a tag.
+    // If a case has no tags it is accessible by panel user
+    // when panel also does not contain any tags.
     $expectedResult = [
       'status_to_move_to' => [2, 5],
       'anonymize_application' => FALSE,

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -7,7 +7,7 @@ use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
 use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
 
 /**
- * CRM_CiviAwards_Service_AwardApplicationContactAccessTest.
+ * Class to test handling access of a contact to an application.
  *
  * @group headless
  */
@@ -425,8 +425,8 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     // `AND` operator between the status and case tags, it is compulsory for
     // a case to have at least a tag.
     $expectedResult = [
-      'status_to_move_to' => [],
-      'anonymize_application' => TRUE,
+      'status_to_move_to' => [2, 5],
+      'anonymize_application' => FALSE,
     ];
 
     $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['id'], $awardPanelContact));


### PR DESCRIPTION
## Overview
The applications which do not have any tag attached to them are now visible to review panel users if panel does not contain any tag.

## Before
If there is a review panel attached to an award that does not include any tags then the user belonging to that panel did not have visibility of the applications which do not have any tag attached to it.

## After
If there is a review panel attached to an award that does not include any tags then the user belonging to that panel is now able to see all the applications regardless of whether the application contains any tags or not.

## Technical Details
The logic that was responsible for checking the tags matching had a glitch in it. The condition was not catering the situation where application has empty tags. So the logic was changed to if there are no tags defined in the review panel then the applications without any tags will be accessible to the user