### PR TITLE
RSE-1226: Disable fields for review in view mode

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -318,9 +318,12 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $elementNames = array_keys($elementData);
     if ($isViewAction) {
       foreach ($this->_elements as $element) {
+        // This check eliminates checkbox and radio buttons as
+        // freeze should not be called on those elements.
         if (in_array($element->_attributes['name'], $elementNames)) {
           $element->freeze();
         }
+        $this->disableField($element);
       }
     }
 
@@ -357,6 +360,35 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     }
 
     CRM_Utils_System::setTitle(E::ts($pageTitle));
+  }
+
+  /**
+   * Disable field.
+   *
+   * @param HTML_QuickForm_element $element
+   *   Form element object.
+   */
+  private function disableField(HTML_QuickForm_element $element) {
+    if ($element instanceof HTML_QuickForm_group) {
+      foreach ($element->_elements as $elem) {
+        $this->setDisableAttribute($elem);
+      }
+      return;
+    }
+
+    $this->setDisableAttribute($element);
+  }
+
+  /**
+   * Set disabled attribute on form element.
+   *
+   * @param HTML_QuickForm_element $element
+   *   Form element object.
+   */
+  private function setDisableAttribute(HTML_QuickForm_element $element) {
+    $attributes = $element->getAttributes();
+    $attributes['disabled'] = TRUE;
+    $element->setAttributes($attributes);
   }
 
   /**


### PR DESCRIPTION
## Overview
When a user opens a review in view mode all fields should be disabled as it did not make sense to let the user edit the fields when there is no option for saving the form in view mode

## Before
Text and select fields were already disabled but attachment, radio, checkboxes fields were not disabled
![8d3bb2ce-ec8a-4f46-9584-8ebcd3cdeee9](https://user-images.githubusercontent.com/68388745/91176104-39da2980-e6fb-11ea-9d00-228eabb09e56.png)


## After
No matter what the type of a field is, it will be disabled in view mode
![Screenshot from 2020-08-25 17-51-20](https://user-images.githubusercontent.com/68388745/91176430-b240ea80-e6fb-11ea-9a24-1e3bd8b36536.png)

## Technical Details
Freeze function was being called for form fields in view mode to disable the form fields which was not supported by radio, checkbox and file fields so in addition to the freeze method the disabled attribute is also added for each form field's attributes list in view mode