### PR TITLE
RSE-1299: Fix contact display name on SSP review application form to respect anonymization

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -466,6 +466,18 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
    *   Contact display name.
    */
   private function getCaseContactDisplayName() {
+    if ($this->isReviewFromSsp()) {
+      // Alter display name of contact to "Anonymous [case-id]" if award
+      // ssp review panel has anonymize_application set to true.
+      $userID = CRM_Core_Session::getLoggedInContactID();
+      $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
+      $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
+      $contactAccess = $contactAccessService->getReviewAccess($userID, $this->caseId, $awardPanelContact);
+      if (!empty($contactAccess) && $contactAccess['anonymize_application']) {
+        return 'Anonymous ' . $this->caseId;
+      }
+    }
+
     $result = civicrm_api3('CaseContact', 'get', [
       'sequential' => 1,
       'case_id' => $this->caseId,


### PR DESCRIPTION
## Overview

This PR implements Anonymizing Contact Display name on SSP review case application form and view submitted case application form where if the awards review panel is marked with "Anonymise Contacts for this Panel" we shouldn't show Contact Display name of that case application instead we need to show "Anonymous [Case ID]" as display name to awards review panel member while reviewing that case application.

## Before
![image](https://user-images.githubusercontent.com/2689257/92759377-4cb45580-f3ad-11ea-9c91-89ae71b1feb5.png)

![image](https://user-images.githubusercontent.com/2689257/92759422-576eea80-f3ad-11ea-852c-ad9a6d4d4e39.png)

## After
![image](https://user-images.githubusercontent.com/2689257/92925571-534bd700-f458-11ea-9d55-c63fa4ccf3ad.png)

## Technical Details

- Add check for SSP review application form to check if that case application has "Anonymize Application" param to true and if yes return "Anonymous [case-id]" as display name