### PR TITLE
RSE-1118: Fix Permission Issues When Administering An Award

### DIFF
--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -2,11 +2,10 @@
 
 use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-use CRM_CiviAwards_Helper_CaseTypeCategory as CaseAwardHelper;
-use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * Class CRM_Civicase_Hook_APIPermissions_alterPermissions.
+ * APIPermissions Class for Awards.
  */
 class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
 
@@ -23,19 +22,11 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
    *   The API permissions.
    */
   public function run($entity, $action, array &$params, array &$permissions) {
-    $permissionService = new CaseCategoryPermission();
-    $caseCategoryPermissions = $permissionService->get(CaseAwardHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
-    $permissions['award_detail']['get'] = [
-      [
-        $caseCategoryPermissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
-        $caseCategoryPermissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name'],
-        $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name'],
-      ],
-    ];
     $awardCreatePermission = [
       ['administer CiviCase', 'create/edit awards'],
     ];
     $permissions['award_detail']['create'] = $permissions['award_detail']['update'] = $awardCreatePermission;
+    $permissions['award_detail']['get'] = $awardCreatePermission;
     $permissions['award_manager']['get'] = $awardCreatePermission;
     $permissions['award_review_panel']['get'] = $awardCreatePermission;
     $permissions['award_review_panel']['create'] = $awardCreatePermission;
@@ -70,13 +61,17 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
    *   Whether to modify API permission or not.
    */
   private function modifyCaseTypeApiPermission($entity, $action, array &$params) {
-    $isCaseTypeCreateOrEdit = $entity == 'case_type' && in_array($action, ['create', 'update']);
+    $isCaseTypeCreateOrEdit = $entity == 'case_type' && in_array($action, [
+      'create',
+      'update',
+    ]);
     if (!$isCaseTypeCreateOrEdit) {
       return FALSE;
     }
 
     $caseCategoryName = $this->getCaseCategoryNameForCaseTypeWhenActionIsCreateOrEdit($params);
-    if ($caseCategoryName == CaseAwardHelper::AWARDS_CASE_TYPE_CATEGORY_NAME) {
+    $instanceName = CaseCategoryHelper::getInstanceName($caseCategoryName);
+    if ($instanceName == CaseTypeCategoryHelper::APPLICATION_MANAGEMENT_NAME) {
       return TRUE;
     }
 

--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_CiviAwards_Service_ApplicantManagementMenu.
+ * Applicant Management Menu class.
  */
 class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Service_CaseCategoryMenu {
 
@@ -28,7 +28,7 @@ class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Servic
         'label' => ts('Manage Applications'),
         'name' => "manage_{$caseTypeCategoryName}_applications",
         'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
-        'permission' => 'access my awards and activities,access all awards and activities',
+        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
     ];


### PR DESCRIPTION
## Overview
When a new category of instance type application management is created and the Award manager for that category tries to edit/create an Award, there is a permission error when calling the CaseType.get API.
There is also an issue with the Manage Application menu not being visible for the Award manager for the applicant management case type category. 

## Before
The issues described above exists.

## After
- The permission for the CaseType.get API is only is modified for only when the case category is Awards. This logic is changed to check if the instance type for the case type category is of Applicant Management.
- Also the Permissions for AwardDetail.get is adjusted to be consistent with what is currently used for the AwardDetail.create and update API for consistency.
- There is an issue with the Manage Application menu not being visible for the Award manager for the applicant type category. This was due to the fact that dynamic permission was not used for this menu item. This was fixed also.

