### PR TITLE
RSE-1311: Fix SSP review and view applications pages to show correct CaseTags

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -529,6 +529,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $result = civicrm_api3('EntityTag', 'get', [
       'sequential' => 1,
       'entity_table' => 'civicrm_case',
+      'entity_id' => $this->caseId,
       'api.Tag.getsingle' => ['id' => "\$value.tag_id"],
     ]);
 


### PR DESCRIPTION
## Overview

This PR fix issue with SSP Review Application and View submitted application forms where we were showing all Tags related to Civicrm Case entity rather than showing all those tags which are added to specific Case application.

## Before
![casetags_before](https://user-images.githubusercontent.com/2689257/93879635-ad228b80-fcf9-11ea-8da3-616ea3116505.gif)

## After
![casetags_after](https://user-images.githubusercontent.com/2689257/93879645-b3186c80-fcf9-11ea-8e6e-fb2faf351da4.gif)

## Technical Details

- Added `entity_id` param check to load only tags specific for case application id.