### PR TITLE
RSE-1393: Change Award Manager field label

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://github.com/compucorp/uk.co.compucorp.civiawards/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civiawards/workflows/Tests/badge.svg)
+
 # CiviAwards
 
 ## Is CiviAwards for me?

--- a/ang/civiawards/award-creation/directives/basic-details-form.directive.html
+++ b/ang/civiawards/award-creation/directives/basic-details-form.directive.html
@@ -40,12 +40,12 @@
   </div>
   <div class="form-group">
     <label class="col-sm-3 control-label required-mark">
-      Award Manager
+      Manager
     </label>
     <div class="col-sm-5">
       <input class="form-control"
         ng-model="additionalDetails.awardManagers"
-        placeholder="Award Manager"
+        placeholder="Manager"
         crm-entityref="{
           create: true,
           entity: 'Contact',


### PR DESCRIPTION
## Overview
As part of this PR
1. The Award Manager Field has been renamed to Manager in the UI.
2. Added Github Action badges to the readme.md file, so that the status of the tests can be seen in the Repositories home page.
![2020-10-01 at 1 48 PM](https://user-images.githubusercontent.com/5058867/94785124-c5c32d80-03ec-11eb-9e16-08df802bf581.png)
3. Update Civicrm version to 5.28.3 in unit test github action.

## Before
![2020-10-01 at 1 51 PM](https://user-images.githubusercontent.com/5058867/94785390-2fdbd280-03ed-11eb-953e-739d82c74455.png)

## After
![2020-10-01 at 1 49 PM](https://user-images.githubusercontent.com/5058867/94785223-ec816400-03ec-11eb-86d9-9d695baf865d.png)

