### PR TITLE
CPS:347: Update version and release date

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     <url desc="Support">http://FIXME</url>
   </urls>
-  <releaseDate>2020-09-28</releaseDate>
-  <version>1.0.0-beta.4</version>
+  <releaseDate>2020-10-09</releaseDate>
+  <version>1.0.0-beta.5</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 09th October, 2020


**Bug Fixes**
* Empty statuses are not allowed in review panel if "Change the status of an application" field is checked. [RSE-1246](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/132).