### PR TITLE
CPS-360: Fix save award bug when there are no custom fields defined

### DIFF
--- a/ang/civiawards/award-creation/directives/award-custom-field-sets.directive.js
+++ b/ang/civiawards/award-creation/directives/award-custom-field-sets.directive.js
@@ -43,20 +43,22 @@
 
       /**
        * Save the custom field set PHP form by triggering the hidden save button
-       * using jQuery
+       * using jQuery.
+       *
+       * If there is no custom fields form, it will continue as normal.
        *
        * @returns {Promise} promise
        */
       function save () {
+        var $submitButtonLink = $('.civiaward__custom-field-sets__container .award-custom-field');
+        var hasCustomFields = $submitButtonLink.length > 0;
         var defer = $q.defer();
 
-        if (!scope.awardId) {
+        if (!scope.awardId || !hasCustomFields) {
           defer.resolve();
         }
 
-        var submitButtonLink = '.civiaward__custom-field-sets__container .award-custom-field';
-
-        $(submitButtonLink).trigger('click');
+        $submitButtonLink.trigger('click');
 
         element.on('crmFormSuccess', function () {
           $(element).find('.civiaward__custom-field-sets__container').unblock();

--- a/ang/test/civiawards/award-creation/directives/award-custom-field-sets.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award-custom-field-sets.directive.spec.js
@@ -37,13 +37,18 @@
     });
 
     describe('when saving the award', () => {
-      var originalTriggerFn, originalUnblockFn;
-      var promise, customFieldSetsTabCallbackFn;
+      let originalTriggerFn, originalUnblockFn, promise,
+        customFieldSetsTabCallbackFn, customFieldSetsTabObj;
+      const fixture = `
+        <div class="civiaward__custom-field-sets__container test-fixture">
+          <div class="award-custom-field"></div>
+        </div>
+      `;
 
       beforeEach(() => {
         initDirective(5);
 
-        var customFieldSetsTabObj = _.find($scope.tabs, function (tabObj) {
+        customFieldSetsTabObj = _.find($scope.tabs, function (tabObj) {
           return tabObj.name === 'customFieldSets';
         });
 
@@ -51,11 +56,6 @@
         originalUnblockFn = $.fn.unblock;
         spyOn($.fn, 'trigger').and.callThrough();
         spyOn($.fn, 'unblock').and.callThrough();
-
-        promise = customFieldSetsTabObj.save();
-
-        customFieldSetsTabCallbackFn = jasmine.createSpy('promise');
-        promise.then(customFieldSetsTabCallbackFn);
       });
 
       afterEach(() => {
@@ -63,22 +63,50 @@
         $.fn.unblock = originalUnblockFn;
       });
 
-      it('saves the custom field set values', () => {
-        expect($.fn.trigger).toHaveBeenCalledWith('click');
+      describe('when there are custom fields defined', () => {
+        beforeEach(() => {
+          $('body').append(fixture);
+          promise = customFieldSetsTabObj.save();
+
+          customFieldSetsTabCallbackFn = jasmine.createSpy('promise');
+          promise.then(customFieldSetsTabCallbackFn);
+        });
+
+        afterEach(() => {
+          $('.test-fixture').remove();
+        });
+
+        it('saves the custom field set values', () => {
+          expect($.fn.trigger).toHaveBeenCalledWith('click');
+        });
+
+        describe('when the save is complete', () => {
+          beforeEach(() => {
+            civiawardCustomFieldSetsDirective.trigger('crmFormSuccess');
+            $scope.$digest();
+          });
+
+          it('saves the award itself', () => {
+            expect(customFieldSetsTabCallbackFn).toHaveBeenCalled();
+          });
+
+          it('hides the loading screen for custom field sets', () => {
+            expect($.fn.unblock).toHaveBeenCalled();
+          });
+        });
       });
 
-      describe('when the save is complete', () => {
+      describe('and there are no custom fields defined', () => {
         beforeEach(() => {
-          civiawardCustomFieldSetsDirective.trigger('crmFormSuccess');
+          promise = customFieldSetsTabObj.save();
+          customFieldSetsTabCallbackFn = jasmine.createSpy('promise');
+
+          promise.then(customFieldSetsTabCallbackFn);
           $scope.$digest();
         });
 
         it('saves the award itself', () => {
           expect(customFieldSetsTabCallbackFn).toHaveBeenCalled();
-        });
-
-        it('hides the loading screen for custom field sets', () => {
-          expect($.fn.unblock).toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
## Overview
This PR fixes an issue that happens when trying to save award types, but there are no custom fields defined.

## Before
![gif](https://user-images.githubusercontent.com/1642119/95909684-e71d0580-0d6c-11eb-89ce-507dca1939fe.gif)

## After

### When there are no custom fields
![gif](https://user-images.githubusercontent.com/1642119/95910157-9f4aae00-0d6d-11eb-8628-40715d139ed7.gif)

### When there are custom fields
![gif](https://user-images.githubusercontent.com/1642119/95911737-d91cb400-0d6f-11eb-92eb-916edaa42c48.gif)

## Technical Details

This is a regression issue introduced by https://github.com/compucorp/uk.co.compucorp.civiawards/pull/130 specifically this commit: https://github.com/compucorp/uk.co.compucorp.civiawards/commit/77b99e2

The problem is that when no custom fields are defined, the award form will wait for the non-existent form to trigger a success message, but this will never happen.

To fix this, we automatically resolve the save process of the award's custom field set directive if there are no custom fields defined.