### PR TITLE
RSE-1380: Add "Manage Workflows" Menu

### DIFF
--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -33,7 +33,7 @@ class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Servic
         'has_separator' => 1,
       ],
       [
-        'label' => ts("Manage" . $caseTypeCategoryName),
+        'label' => ts("Manage " . $caseTypeCategoryName),
         'name' => "manage_{$caseTypeCategoryName}_workflows",
         'url' => 'civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',
         'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",

--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -30,6 +30,14 @@ class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Servic
         'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
+        'has_separator' => 1,
+      ],
+      [
+        'label' => ts("Manage" . $caseTypeCategoryName),
+        'name' => "manage_{$caseTypeCategoryName}_workflows",
+        'url' => 'civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',
+        'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
+        'permission_operator' => 'OR',
       ],
     ];
 

--- a/CRM/CiviAwards/Setup/AddManageWorkflowMenu.php
+++ b/CRM/CiviAwards/Setup/AddManageWorkflowMenu.php
@@ -1,0 +1,17 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+
+/**
+ * Adds the Manage Workflow Menu item for existing Case types.
+ */
+class CRM_CiviAwards_Setup_AddManageWorkflowMenu {
+
+  /**
+   * And Create Manage Workflow Menu for applicant management categories.
+   */
+  public function apply() {
+    CaseCategoryMenu::createManageWorkflowMenuForExistingCaseCategories('applicant_management', TRUE);
+  }
+
+}

--- a/CRM/CiviAwards/Setup/AddManageWorkflowMenu.php
+++ b/CRM/CiviAwards/Setup/AddManageWorkflowMenu.php
@@ -11,7 +11,8 @@ class CRM_CiviAwards_Setup_AddManageWorkflowMenu {
    * And Create Manage Workflow Menu for applicant management categories.
    */
   public function apply() {
-    CaseCategoryMenu::createManageWorkflowMenuForExistingCaseCategories('applicant_management', TRUE);
+    $caseCategoryMenuObj = new CaseCategoryMenu();
+    $caseCategoryMenuObj->createManageWorkflowMenu('applicant_management', TRUE);
   }
 
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1006.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1006.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_CiviAwards_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+
+/**
+ * Creates Manage Workflow menu for existing 'applicant management' categories.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1006 {
+
+  /**
+   * Adds Custom Group support for Applicant management Case Types.
+   *
+   * @return bool
+   *   returns value.
+   */
+  public function apply() {
+    $step = new AddManageWorkflowMenu();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -714,8 +714,8 @@
       return {
         is_error: 0,
         version: 3,
-        count: RelationshipTypeData.values.length,
-        values: _.cloneDeep(RelationshipTypeData.values)
+        count: 8,
+        values: _.cloneDeep(_.slice(RelationshipTypeData.values, 0, 4))
       };
     }
 


### PR DESCRIPTION
## Overview
As part of this PR, the Manage Workflows menu has been created for `applicant_management` case type categories.

## Before
Menu Items were not present.

## After
Menu Items are created. 

## Technical Details
1. In `CRM/CiviAwards/Service/ApplicantManagementMenu.php`, added "Manage <caseTypeCategoryName>" menu item for newly created sites.

3. Added a new upgrader which uses `CRM_CiviAwards_Setup_AddManageWorkflowMenu ` class to create menu for existing sites.
