### PR TITLE
RSE-44: Set instance value whether category instance exists or not.

### DIFF
--- a/CRM/CiviAwards/Setup/CreateApplicantManagementOption.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantManagementOption.php
@@ -47,14 +47,9 @@ class CRM_CiviAwards_Setup_CreateApplicantManagementOption {
     $caseCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
     $awardCaseCategoryValue = $caseCategories[CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME];
     $caseCategoryInstance = new CaseCategoryInstance();
-    $caseCategoryInstance->instance_id = $instanceValue;
     $caseCategoryInstance->category_id = $awardCaseCategoryValue;
     $caseCategoryInstance->find(TRUE);
-
-    if (!empty($caseCategoryInstance->id)) {
-      return;
-    }
-
+    $caseCategoryInstance->instance_id = $instanceValue;
     $caseCategoryInstance->save();
   }
 


### PR DESCRIPTION
## Overview
As part of this PR, the instance

## Overview
This PR modifies the `CreateApplicantManagementOption` setup to update the instance type of the `awards` case type category whether the category has previously been assigned an instance or not.


## Technical Details
This is necessary because in compuclient deployed sites, it has a static database used and the award case category option value exists when civicase tries to assign an instance type for the awards category. An error occurs because the upgrader version for comopuclient for awards is at `1001` and upgrader `1002` tries to update the `awards` category instance. This causes a duplicate error when inserting in db. 


```php

(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => exceptionHandler
        )

    [code] => -5
    [message] => DB Error: already exists
    [mode] => 16
    [debug_info] => INSERT INTO `civicrm_case_category_instance` (`category_id` , `instance_id` ) VALUES ( 2 ,  2 )  [nativecode=1062 ** Duplicate entry '2' for key 'unique_category']
    [type] => DB_Error
    [user_info] => INSERT INTO `civicrm_case_category_instance` (`category_id` , `instance_id` ) VALUES ( 2 ,  2 )  [nativecode=1062 ** Duplicate entry '2' for key 'unique_category']
    [to_string] => [db_error: message="DB Error: already exists" code=-5 mode=callback callback=CRM_Core_Error::exceptionHandler prefix="" info="INSERT INTO `civicrm_case_category_instance` (`category_id` , `instance_id` ) VALUES ( 2 ,  2 )  [nativecode=1062 ** Duplicate entry '2' for key 'unique_category']"]
)
```