### PR TITLE
RSE-1457: Fix Issue With Award Instance Custom Field Set Not Being Updated

### DIFF
--- a/CRM/CiviAwards/Service/ApplicantManagementAwardDetailPostProcessor.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementAwardDetailPostProcessor.php
@@ -61,7 +61,7 @@ class CRM_CiviAwards_Service_ApplicantManagementAwardDetailPostProcessor {
     foreach ($customGroups as $cusGroup) {
       $extendColValue = !empty($cusGroup['extends_entity_column_value']) ? $cusGroup['extends_entity_column_value'] : [];
       $customGroupSubTypeList = !empty($this->customGroupSubTypes[$cusGroup['id']]) ? $this->customGroupSubTypes[$cusGroup['id']] : [];
-      if (array_intersect($customGroupSubTypeList, $caseTypeSubType) && !empty($extendColValue)) {
+      if (array_intersect($customGroupSubTypeList, $caseTypeSubType)) {
         $entityColumnValues = array_merge($extendColValue, [$caseTypeId]);
         $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
       }


### PR DESCRIPTION
## Overview
This PR fixes a bug that occurs when a new applicant management case type is being created and the custom field set related to the award sub type is not updated.

## Before
The issue described above exists.

## After
- When a custom field set is created for an award subtype, if there is no case type belonging to that subtype yet, the `extends_entity_column_value` is set to NULL. When a case type is added for that subtype, the `extends_entity_column_value` is supposed to be updated with the Case type ID. However there is a restriction that checks if the `extends_entity_column_value` is empty and does not allow this update. This restriction is not needed and this PR removes it.