### PR TITLE
RSE-1455: Fix Duplicate Workflow functionality

### DIFF
--- a/ang/civiawards-workflow.ang.php
+++ b/ang/civiawards-workflow.ang.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Declares an Angular module which can be autoloaded in CiviCRM.
+ *
+ * See also:
+ * http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules.
+ */
+
+use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
+
+/**
+ * Get a list of JS files.
+ */
+function get_awards_workflow_js_files() {
+  return array_merge(
+    ['ang/civiawards-workflow.js'], GlobRecursive::get(dirname(__FILE__) . '/civiawards-workflow/*.js')
+  );
+}
+
+return [
+  'js' => get_awards_workflow_js_files(),
+  'requires' => [
+    'civicase-base',
+  ],
+];

--- a/ang/civiawards-workflow.js
+++ b/ang/civiawards-workflow.js
@@ -1,0 +1,3 @@
+(function (angular, $, _) {
+  angular.module('civiawards-workflow', CRM.angRequires('civiawards-workflow'));
+})(angular, CRM.$, CRM._);

--- a/ang/civiawards-workflow/duplicate-workflow-applicant-management.service.js
+++ b/ang/civiawards-workflow/duplicate-workflow-applicant-management.service.js
@@ -18,7 +18,7 @@
     function create (workflow) {
       return civicaseCrmApi([
         ['AwardDetail', 'get', { sequential: 1, case_type_id: workflow.id }],
-        ['CaseType', 'create', _.extend(workflow, { id: null })]
+        ['CaseType', 'create', _.extend({}, workflow, { id: null })]
       ]).then(function (data) {
         var awardsDetailsData = data[0].values[0];
 

--- a/ang/civiawards-workflow/duplicate-workflow-applicant-management.service.js
+++ b/ang/civiawards-workflow/duplicate-workflow-applicant-management.service.js
@@ -1,0 +1,34 @@
+(function (_, angular) {
+  var module = angular.module('civiawards-workflow');
+
+  module.service('DuplicateWorkflowApplicantmanagement', DuplicateWorkflow);
+
+  /**
+   * Duplicate applicant management workflows service
+   *
+   * @param {Function} civicaseCrmApi civicrm api service
+   */
+  function DuplicateWorkflow (civicaseCrmApi) {
+    this.create = create;
+
+    /**
+     * @param {object} workflow workflow object
+     * @returns {Promise} promise
+     */
+    function create (workflow) {
+      return civicaseCrmApi([
+        ['AwardDetail', 'get', { sequential: 1, case_type_id: workflow.id }],
+        ['CaseType', 'create', _.extend(workflow, { id: null })]
+      ]).then(function (data) {
+        var awardsDetailsData = data[0].values[0];
+
+        awardsDetailsData.id = null;
+        awardsDetailsData.case_type_id = data[1].values[0].id;
+
+        return civicaseCrmApi([
+          ['AwardDetail', 'create', awardsDetailsData]
+        ]);
+      });
+    }
+  }
+})(CRM._, angular);

--- a/ang/test/civiawards-workflow/duplicate-workflow-applicant-management.service.spec.js
+++ b/ang/test/civiawards-workflow/duplicate-workflow-applicant-management.service.spec.js
@@ -41,7 +41,7 @@
       it('duplicates the workflow', () => {
         expect(civicaseCrmApiMock).toHaveBeenCalledWith([
           ['AwardDetail', 'get', { sequential: 1, case_type_id: workflow.id }],
-          ['CaseType', 'create', _.extend(workflow, { id: null })]
+          ['CaseType', 'create', _.extend({}, workflow, { id: null })]
         ]);
 
         expect(civicaseCrmApiMock).toHaveBeenCalledWith([

--- a/ang/test/civiawards-workflow/duplicate-workflow-applicant-management.service.spec.js
+++ b/ang/test/civiawards-workflow/duplicate-workflow-applicant-management.service.spec.js
@@ -1,0 +1,56 @@
+/* eslint-env jasmine */
+
+((_) => {
+  describe('duplicate applicant management workflow', () => {
+    let $q, $rootScope, civicaseCrmApiMock, CaseTypesMockData,
+      DuplicateWorkflowApplicantmanagement, AwardAdditionalDetailsMockData;
+
+    beforeEach(module('civiawards-workflow', 'civicase.data', 'civiawards.data', ($provide) => {
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
+
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
+    }));
+
+    beforeEach(inject((_$q_, _$rootScope_, _DuplicateWorkflowApplicantmanagement_,
+      _CaseTypesMockData_, _AwardAdditionalDetailsMockData_) => {
+      $q = _$q_;
+      $rootScope = _$rootScope_;
+      DuplicateWorkflowApplicantmanagement = _DuplicateWorkflowApplicantmanagement_;
+      CaseTypesMockData = _CaseTypesMockData_;
+      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_;
+    }));
+
+    describe('when duplicating a workflow', () => {
+      var workflow, awardDetail;
+
+      beforeEach(() => {
+        awardDetail = AwardAdditionalDetailsMockData.get();
+        workflow = CaseTypesMockData.getSequential()[0];
+
+        civicaseCrmApiMock.and.returnValue($q.resolve([
+          { values: [awardDetail] },
+          { values: [workflow] }
+        ]));
+
+        DuplicateWorkflowApplicantmanagement.create(_.clone(workflow));
+
+        $rootScope.$digest();
+        $rootScope.$digest();
+      });
+
+      it('duplicates the workflow', () => {
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith([
+          ['AwardDetail', 'get', { sequential: 1, case_type_id: workflow.id }],
+          ['CaseType', 'create', _.extend(workflow, { id: null })]
+        ]);
+
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith([
+          ['AwardDetail', 'create', _.extend(AwardAdditionalDetailsMockData.get(), {
+            id: null,
+            case_type_id: '1'
+          })]
+        ]);
+      });
+    });
+  });
+})(CRM._);

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -23,7 +23,7 @@
       crmApi = _crmApi_;
       CaseStatus = _CaseStatus_;
       AwardMockData = _AwardMockData_;
-      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_;
+      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
       ReviewFieldsMockData = _ReviewFieldsMockData_;
       $scope = $rootScope.$new();
 

--- a/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
@@ -10,7 +10,7 @@
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       AwardMockData = _AwardMockData_;
-      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_;
+      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
       $scope = $rootScope.$new();
 
       $scope.$digest();

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -16,7 +16,7 @@
       dialogService = _dialogService_;
       crmApi = _crmApi_;
       ReviewFieldsMockData = _ReviewFieldsMockData_;
-      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_;
+      AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
       $scope = $rootScope.$new();
 
       dialogService.dialogs = {};

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -3,6 +3,7 @@
 (function (CRM) {
   CRM['civicase-base'] = {};
   CRM.civiawards = {};
+  // CRM['civiawards-workflow'] = {};
 
   /**
    * Dependency Injection for civiawards module, defined in ang/civiawards.ang.php

--- a/ang/test/karma.conf.js
+++ b/ang/test/karma.conf.js
@@ -39,12 +39,16 @@ module.exports = function (config) {
       extPath + '/ang/civiawards.js',
       { pattern: extPath + '/ang/civiawards/**/*.js' },
 
+      extPath + '/ang/civiawards-workflow.js',
+      { pattern: extPath + '/ang/civiawards-workflow/**/*.js' },
+
       // Spec files
       { pattern: civicasePath + '/ang/test/mocks/modules.mock.js' },
       { pattern: civicasePath + '/ang/test/mocks/**/*.js' },
       { pattern: extPath + '/ang/test/mocks/modules.mock.js' },
       { pattern: extPath + '/ang/test/mocks/**/*.js' },
-      { pattern: extPath + '/ang/test/civiawards/**/*.js' }
+      { pattern: extPath + '/ang/test/civiawards/**/*.js' },
+      { pattern: extPath + '/ang/test/civiawards-workflow/**/*.js' }
     ],
     exclude: [
     ],

--- a/ang/test/mocks/data/award-additional-details.data.js
+++ b/ang/test/mocks/data/award-additional-details.data.js
@@ -1,25 +1,38 @@
-(function () {
+((_) => {
   var module = angular.module('civiawards.data');
 
-  module.constant('AwardAdditionalDetailsMockData', {
-    id: '1',
-    case_type_id: '10',
-    award_type: '1',
-    start_date: '2019-10-29',
-    end_date: '2019-11-29',
-    award_manager: ['2', '1'],
-    review_fields: [{
-      id: '19',
-      weight: 1,
-      required: '1'
-    }, {
-      id: '20',
-      weight: 2,
-      required: '0'
-    }, {
-      id: '45',
-      weight: 3,
-      required: '0'
-    }]
+  module.service('AwardAdditionalDetailsMockData', function () {
+    var mockData = {
+      id: '1',
+      case_type_id: '10',
+      award_type: '1',
+      start_date: '2019-10-29',
+      end_date: '2019-11-29',
+      award_manager: ['2', '1'],
+      review_fields: [{
+        id: '19',
+        weight: 1,
+        required: '1'
+      }, {
+        id: '20',
+        weight: 2,
+        required: '0'
+      }, {
+        id: '45',
+        weight: 3,
+        required: '0'
+      }]
+    };
+
+    return {
+      /**
+       * Returns a list of mocked award details data
+       *
+       * @returns {Array} list of award details
+       */
+      get: function () {
+        return angular.copy(mockData);
+      }
+    };
   });
-}());
+})(CRM._);

--- a/civiawards.php
+++ b/civiawards.php
@@ -243,6 +243,13 @@ function civiawards_addCiviCaseDependentAngularModules(&$dependentModules) {
 }
 
 /**
+ * Implements addCiviCaseDependentAngularModules().
+ */
+function civiawards_addWorkflowDependentAngularModules(&$dependentModules) {
+  $dependentModules[] = "civiawards-workflow";
+}
+
+/**
  * Implements hook_civicrm_alterMenu().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMenu


### PR DESCRIPTION
## Overview
Fixed the Duplicate `applicant_management` workflow feature. 

## Technical Details
1. Created a new angularjs module `civiawards-workflow`, which is dependent on `workflow`.
2. Added `DuplicateWorkflowApplicantmanagement`, with the logic to duplicate applicant_management workflows.
