### PR TITLE
CPS-386: Release v1.0.0-beta.7

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     <url desc="Support">http://FIXME</url>
   </urls>
-  <releaseDate>2020-10-26</releaseDate>
-  <version>1.0.0-beta.6</version>
+  <releaseDate>2020-11-05</releaseDate>
+  <version>1.0.0-beta.7</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 05th November, 2020

**Improvements**

* Renamed `Award Type` field to `Award Sub Type`. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/146

**Bug Fixes**

* Fixed duplicate Awards functionality. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/145