### PR TITLE
ACU-370: Fix markup of 'Review Submitted' button

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -109,8 +109,8 @@
           {else}
             <button disabled="true" class="btn btn-primary default validate pull-right">
               <i class="fas fa-check"></i>
-              Review Submitted
-            </button >
+              <span>Review Submitted</span>
+            </button>
           {/if}
         {else}
           <div class="crm-submit-buttons panel-footer clearfix">


### PR DESCRIPTION
## Overview
It was required to make first word only capitalized for the buttons, but css solution we implemented was not working on **View Review** page (like `/civicrm/ssp/awardreview?action=view&id=22&reset=1`). Reason - the button markup differs from other civicrm buttons. This PR fixes the issue.

## Before
![image](https://user-images.githubusercontent.com/39520000/98666589-4b2bed00-235e-11eb-82bc-b6110f6687b2.png)

## After
![image](https://user-images.githubusercontent.com/39520000/98666579-46ffcf80-235e-11eb-82a0-1ffa5cc8b772.png)

## Technical Details
We used following css code to use sentense case (capitalise first word only) for button labels:
```scss
.btn {
  text-transform: lowercase;

  span::first-letter,
  &::first-letter {
    text-transform: uppercase;
  }
}
```

It was not working here because the button does not have `<span>` as a wrapper for button text. It still could work if button would not have an icon, but there is an icon in this case (icon is considered to be the first letter).
So to fix the issue we added `<span>` wrapper for consistency with other buttons.