### PR TITLE
RSE-1404: Fix Contact Group limit

### DIFF
--- a/ang/civiawards/shared/directives/contacts-group-dropdown.directive.js
+++ b/ang/civiawards/shared/directives/contacts-group-dropdown.directive.js
@@ -73,21 +73,21 @@
 
         _.chain(groupsData)
           .filter(function (group) {
-            return !isTruthy(group.extra.is_hidden) && isTruthy(group.extra.is_active);
+            return !isTruthy(group.is_hidden) && isTruthy(group.is_active);
           })
           .each(function (group) {
             returnData.include.push({
               id: 'include_' + group.id,
               value: group.id,
               mode: 'include',
-              text: group.label
+              text: group.title
             });
 
             returnData.exclude.push({
               id: 'exclude_' + group.id,
               value: group.id,
               mode: 'exclude',
-              text: group.label
+              text: group.title
             });
           }).value();
 
@@ -100,9 +100,8 @@
        * @returns {Promise} promise
        */
       function fetchGroupsData () {
-        return crmApi('Group', 'getlist', {
-          options: { limit: 0 },
-          extra: ['is_hidden', 'is_active']
+        return crmApi('Group', 'get', {
+          options: { limit: 0 }
         }).then(function (groupsData) {
           return groupsData.values;
         });


### PR DESCRIPTION
## Overview
This PR fixes an issue where the contact groups selection for review panels would only show a limited number of groups.

## Before
![gif](https://user-images.githubusercontent.com/1642119/99534951-98234b00-297e-11eb-9610-d856984c34a9.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/99535053-c012ae80-297e-11eb-92d1-2abf4431be53.gif)


## Technical Details

We decided to fetch all group records instead of using the `getlist` endpoint that works well with autocomplete inputs because of the following reasons:

* The select2 input was triggering multiple requests to the getlist: one to transform the initial values into proper options with labels, every time a new key was stroked with a 300ms delay, and one after selecting an option (for unknown reasons).
* The implementation was too complicated because of the input's behaviour where an included option can be removed if the same excluded option is selected, and vice-versa. This behaviour was not working well with the ajax implementation and making it work was taking longer than expected.

Because of the reasons above we decided to go with the simpler solution of replacing the `getlist` endpoint with `get` and fetch all records beforehand.
