### PR TITLE
RSE-1434: Review panel statuses

### DIFF
--- a/ang/civiawards/award-creation/directives/award.directive.html
+++ b/ang/civiawards/award-creation/directives/award.directive.html
@@ -48,7 +48,10 @@
           </div>
           <div class="tab-pane active" ng-show="activeTab === 'reviewPanels'">
             <div class="table-tab">
-              <civiaward-review-panels award-id="awardId"></civiaward-review-panels>
+              <civiaward-review-panels
+                award-id="awardId"
+                status-options="applicationStatusOptions"
+              ></civiaward-review-panels>
             </div>
           </div>
           <div class="tab-pane active" ng-show="activeTab === 'reviewFields'">

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -63,11 +63,10 @@
       if ($scope.awardId) {
         $scope.activeTab = getDefaultTabName();
         fetchAwardInformation()
-          .then(function (result) {
-            var applicationStatuses = getApplicationStatusesFromAwardType(result.caseType);
-            $scope.applicationStatusOptions = getApplicantStatusSelect2Options(applicationStatuses);
+          .then(function (award) {
+            updateApplicationStatusOptions(award.caseType);
 
-            $scope.$emit('civiawards::edit-award::details-fetched', result);
+            $scope.$emit('civiawards::edit-award::details-fetched', award);
           });
       }
     }());
@@ -211,7 +210,9 @@
         .then(saveCaseTypeBasicDetails)
         .then(saveAdditionAwardDetails)
         .then(function (award) {
-          return award.case_type_id;
+          updateApplicationStatusOptions(award.caseType);
+
+          return award.additionalDetails.case_type_id;
         })
         .catch(function (error) {
           var errorMesssage = error.error_code === 'already exists'
@@ -359,8 +360,22 @@
 
       return crmApi('AwardDetail', 'create', params)
         .then(function (awardData) {
-          return awardData.values[0];
+          return {
+            caseType: award,
+            additionalDetails: awardData.values[0]
+          };
         });
+    }
+
+    /**
+     * Update the application status options based on the values stored in the
+     * given case type.
+     *
+     * @param {object} caseType A Case Type object including its definition.
+     */
+    function updateApplicationStatusOptions (caseType) {
+      var applicationStatuses = getApplicationStatusesFromAwardType(caseType);
+      $scope.applicationStatusOptions = getApplicantStatusSelect2Options(applicationStatuses);
     }
   });
 })(angular, CRM.$, CRM._);

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -16,8 +16,7 @@
 
   module.controller('CiviAwardCreateEditAwardController', function (
     $location, $q, $scope, $window, CaseTypeCategory, CaseStatus, crmApi, crmStatus,
-    getSelect2Value) {
-    var ts = CRM.ts('civicase');
+    getSelect2Value, ts) {
     var DEFAULT_ACTIVITY_TYPES = [
       { name: 'Applicant Review' },
       { name: 'Email' },
@@ -27,7 +26,6 @@
     ];
 
     $scope.applicationStatusOptions = [];
-    $scope.ts = ts;
     $scope.pageTitle = 'New Award';
     $scope.isNameDisabled = true;
     $scope.submitInProgress = false;

--- a/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
@@ -101,7 +101,7 @@
               crm-ui-select="{
                 allowClear: true,
                 multiple: true,
-                data: model.applicantStatusSelect2Options
+                data: model.statusOptions
               }"
             />
           </div>

--- a/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
@@ -146,7 +146,7 @@
               crm-ui-select="{
                 allowClear: true,
                 multiple: true,
-                data: model.applicantStatusSelect2Options
+                data: model.statusOptions
               }"
             />
           </div>

--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -7,7 +7,8 @@
       templateUrl: '~/civiawards/award-creation/directives/review-panels/review-panels.directive.html',
       restrict: 'E',
       scope: {
-        awardId: '='
+        awardId: '<',
+        statusOptions: '<'
       }
     };
   });
@@ -43,7 +44,6 @@
     $scope.selectTab = selectTab;
 
     (function init () {
-      $scope.applicantStatusSelect2Options = getApplicantStatusSelect2Options();
       resetReviewPanelPopup();
       handleInitialDataLoad();
     }());
@@ -60,17 +60,6 @@
         options: { limit: 0 }
       }).then(function (data) {
         return data.values;
-      });
-    }
-
-    /**
-     * Returns Applicant Status's to be used in the UI
-     *
-     * @returns {Array} applicant status's array in a format suitable for select 2
-     */
-    function getApplicantStatusSelect2Options () {
-      return _.map(caseStatusesIndexed, function (caseStatus) {
-        return { id: caseStatus.value, text: caseStatus.label, name: caseStatus.name };
       });
     }
 
@@ -494,7 +483,8 @@
           height: 'auto',
           width: '650px',
           title: ts('Create Review Panel'),
-          buttons: prepareButtonsForReviewPanelPopup()
+          buttons: prepareButtonsForReviewPanelPopup(),
+          statusOptions: $scope.statusOptions
         }
       );
     }

--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -22,7 +22,6 @@
     var tagsIndexed = {};
     var caseStatusesIndexed = CaseStatus.getAll();
 
-    $scope.ts = ts;
     $scope.submitInProgress = false;
     $scope.isLoading = false;
     $scope.submitButtonClickedOnce = false;

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -30,7 +30,9 @@
       spyOn($scope, '$emit');
       spyOn(CRM, 'alert').and.callThrough();
 
-      crmApi.and.returnValue($q.resolve({}));
+      crmApi.and.returnValue($q.resolve({
+        caseType: _.first(AwardMockData)
+      }));
       $scope.$digest();
       $scope.basic_details_form = { awardName: { $pristine: true } };
     }));
@@ -107,6 +109,61 @@
             caseType: AwardMockData[0],
             additionalDetails: AwardAdditionalDetailsMockData
           });
+        });
+      });
+    });
+
+    describe('status options', () => {
+      describe('when the controller initialises', () => {
+        beforeEach(() => {
+          createController({});
+        });
+
+        it('defines the list of status options as empty', () => {
+          expect($scope.applicationStatusOptions).toEqual([]);
+        });
+      });
+
+      describe('when the award has some status names stored', () => {
+        beforeEach(() => {
+          const award = _.chain(AwardMockData).first().cloneDeep().value();
+          award.definition.statuses = ['Open', 'Closed'];
+
+          crmApi.and.returnValue($q.resolve({
+            caseType: award
+          }));
+
+          createController({});
+          $scope.$digest();
+        });
+
+        it('stores the status data as select2 options', () => {
+          expect($scope.applicationStatusOptions).toEqual([
+            { id: '1', text: 'Ongoing', name: 'Open' },
+            { id: '2', text: 'Resolved', name: 'Closed' }
+          ]);
+        });
+      });
+
+      describe('when the award has no status names stored', () => {
+        beforeEach(() => {
+          const award = _.chain(AwardMockData).first().cloneDeep().value();
+          delete award.definition.statuses;
+
+          crmApi.and.returnValue($q.resolve({
+            caseType: award
+          }));
+
+          createController({});
+          $scope.$digest();
+        });
+
+        it('stores all the statuses data as select2 options', () => {
+          expect($scope.applicationStatusOptions).toEqual([
+            { id: '1', text: 'Ongoing', name: 'Open' },
+            { id: '2', text: 'Resolved', name: 'Closed' },
+            { id: '3', text: 'Urgent', name: 'Urgent' }
+          ]);
         });
       });
     });

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -30,9 +30,7 @@
       spyOn($scope, '$emit');
       spyOn(CRM, 'alert').and.callThrough();
 
-      crmApi.and.returnValue($q.resolve({
-        caseType: _.first(AwardMockData)
-      }));
+      crmApi.and.callFake(mockCrmApiService);
       $scope.$digest();
       $scope.basic_details_form = { awardName: { $pristine: true } };
     }));
@@ -296,13 +294,33 @@
           it('saves the additional award details', () => {
             expect(crmApi).toHaveBeenCalledWith('AwardDetail', 'create', {
               sequential: true,
-              case_type_id: '1',
+              case_type_id: _.first(AwardMockData).id,
               start_date: AwardAdditionalDetailsMockData.start_date,
               end_date: AwardAdditionalDetailsMockData.end_date,
               award_subtype: AwardAdditionalDetailsMockData.award_subtype,
               award_manager: ['2', '1'],
               review_fields: [{ id: '19', required: '0', weight: 1 }]
             });
+          });
+
+          it('updates the list of application status options', () => {
+            expect($scope.applicationStatusOptions).toEqual([
+              {
+                id: '1',
+                text: 'Ongoing',
+                name: 'Open'
+              },
+              {
+                id: '2',
+                text: 'Resolved',
+                name: 'Closed'
+              },
+              {
+                id: '3',
+                text: 'Urgent',
+                name: 'Urgent'
+              }
+            ]);
           });
 
           it('shows a notification after save is successfull', () => {
@@ -326,10 +344,6 @@
           });
 
           setAwardDetails();
-
-          crmApi.and.returnValue($q.resolve({
-            values: [AwardAdditionalDetailsMockData]
-          }));
           $scope.saveAwardInBG();
           $scope.$digest();
         });
@@ -442,9 +456,7 @@
         weight: 1
       }];
 
-      crmApi.and.returnValue($q.resolve({
-        values: [AwardAdditionalDetailsMockData]
-      }));
+      crmApi.and.callFake(mockCrmApiService);
     }
 
     /**
@@ -462,6 +474,34 @@
       $controller('CiviAwardCreateEditAwardController', {
         $scope: $scope
       });
+    }
+
+    /**
+     * Mocks API calls and responses through the CRM API Service.
+     *
+     * @param {string|object} entity The Entity name or an object with multiple requests.
+     * @param {string} action The Action name
+     * @param {object} params Extra parameters to send to the endpoint.
+     *
+     * @returns {Promise} The mocked API response.
+     */
+    function mockCrmApiService (entity, action, params) {
+      const mockAwardType = _.extend({}, _.first(AwardMockData), {
+        definition: {}
+      });
+      const entityResponses = {
+        AwardDetail: { values: [AwardAdditionalDetailsMockData] },
+        CaseType: { values: [mockAwardType] }
+      };
+
+      if (_.isObject(entity)) {
+        return $q.resolve({
+          caseType: mockAwardType,
+          additionalDetails: AwardAdditionalDetailsMockData
+        });
+      }
+
+      return $q.resolve(entityResponses[entity]);
     }
   });
 }(CRM._));

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -3,7 +3,7 @@
   describe('civiawardReviewPanels', () => {
     let $rootScope, $controller, $scope, crmApi, $q, crmStatus, ts, ContactsData,
       dialogService, RelationshipTypeData, GroupData, ReviewPanelsMockData,
-      entityActionHandlers, TagsMockData;
+      entityActionHandlers, TagsMockData, statusOptions;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'crmUtil', 'civicase.data', 'civiawards.data', function ($provide) {
       $provide.value('crmApi', getCrmApiMock());
@@ -30,6 +30,11 @@
       $scope = $rootScope.$new();
 
       dialogService.dialogs = {};
+      statusOptions = [
+        { id: '1', text: 'Ongoing', name: 'Open' },
+        { id: '2', text: 'Resolved', name: 'Closed' },
+        { id: '3', text: 'Urgent', name: 'Urgent' }
+      ];
 
       $scope.$digest();
     }));
@@ -83,14 +88,6 @@
           }
         });
       });
-
-      it('shows list of application statuses inside the applications tab of review panel popup', () => {
-        expect($scope.applicantStatusSelect2Options).toEqual([
-          { id: '1', text: 'Ongoing', name: 'Open' },
-          { id: '2', text: 'Resolved', name: 'Closed' },
-          { id: '3', text: 'Urgent', name: 'Urgent' }
-        ]);
-      });
     });
 
     describe('when "Add Review Panel" button is clicked', () => {
@@ -113,6 +110,16 @@
           '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
           $scope,
           jasmine.any(Object)
+        );
+      });
+
+      it('provides the list of status options to the panel popup', () => {
+        expect(dialogService.open).toHaveBeenCalledWith('ReviewPanels',
+          '~/civiawards/award-creation/directives/review-panels/review-panel-popup.html',
+          $scope,
+          jasmine.objectContaining({
+            statusOptions: statusOptions
+          })
         );
       });
 
@@ -702,6 +709,8 @@
      * Create Controller
      */
     function createController () {
+      $scope.statusOptions = statusOptions;
+
       $controller('CiviawardReviewPanelsController', {
         $scope: $scope
       });


### PR DESCRIPTION
## Overview
This PR fixes an issue where all statuses are displayed when creating or editing review panels. This statuses should only be the ones selected in the "Award Stages" tab.

## Before
![gif](https://user-images.githubusercontent.com/1642119/99594838-1c4ef000-29ca-11eb-82df-1db3f5042c9e.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/99594516-a77bb600-29c9-11eb-9484-b1a3a5b84b86.gif)

## Technical Details

The list of statuses is now provided by the award directive instead of the review panel directive. The decision for this is that the award directive has the information about the list of statuses belonging to the award type and the review panel did not. Instead of sending the whole award type data, we send the specific list of statuses we want to display.

The award directive creates the list of status options by checking the status names stored in the award type. If no names are stored, all statuses are returned. This mirrors core behaviour.

Some `ts` service references were removed since they are already provided by civicase.

## Bug Fixes

The statuses were not being updated after the award type was saved. This was fixed in c884f82.

### Before
![gif](https://user-images.githubusercontent.com/1642119/99921380-6274be00-2d00-11eb-910d-99f6f7bc38d8.gif)


### After

![gif](https://user-images.githubusercontent.com/1642119/99921109-a1a20f80-2cfe-11eb-93b0-804704563fe0.gif)

### Technical details

We created a new `updateApplicationStatusOptions` function that gets called when the directive is mounted to the DOM and when the award type is saved in the `saveAward` function. `updateApplicationStatusOptions` generates the list of application status options according to the case type stored in the award directive.


