### PR TITLE
RSE-1387: Display Is Template field

### DIFF
--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -49,7 +49,8 @@
       startDate: null,
       endDate: null,
       awardManagers: [],
-      selectedReviewFields: []
+      selectedReviewFields: [],
+      isTemplate: false
     };
 
     $scope.ifSaveButtonDisabled = ifSaveButtonDisabled;
@@ -309,7 +310,8 @@
         start_date: $scope.additionalDetails.startDate,
         end_date: $scope.additionalDetails.endDate,
         award_subtype: $scope.additionalDetails.awardSubtype,
-        review_fields: prepareReviewFields()
+        review_fields: prepareReviewFields(),
+        is_template: $scope.additionalDetails.isTemplate
       };
 
       if ($scope.awardDetailsID) {

--- a/ang/civiawards/award-creation/directives/basic-details-form.directive.html
+++ b/ang/civiawards/award-creation/directives/basic-details-form.directive.html
@@ -74,7 +74,7 @@
     </div>
   </div>
   <div class="form-group">
-    <label class="col-sm-3 control-label">{{ts('Is template?')}}</label>
+    <label class="col-sm-3 control-label">{{ts('Is Template?')}}</label>
     <div class="col-sm-5">
       <input type="checkbox" ng-model="additionalDetails.isTemplate">
     </div>

--- a/ang/civiawards/award-creation/directives/basic-details-form.directive.html
+++ b/ang/civiawards/award-creation/directives/basic-details-form.directive.html
@@ -74,6 +74,12 @@
     </div>
   </div>
   <div class="form-group">
+    <label class="col-sm-3 control-label">{{ts('Is template?')}}</label>
+    <div class="col-sm-5">
+      <input type="checkbox" ng-model="additionalDetails.isTemplate">
+    </div>
+  </div>
+  <div class="form-group">
     <label class="col-sm-3 control-label">{{ts('Enabled?')}}</label>
     <div class="col-sm-5">
       <input type="checkbox" ng-model="basicDetails.isEnabled">

--- a/ang/civiawards/award-creation/directives/basic-details-form.directive.js
+++ b/ang/civiawards/award-creation/directives/basic-details-form.directive.js
@@ -54,6 +54,7 @@
       $scope.additionalDetails.endDate = additionalDetails.end_date;
       $scope.additionalDetails.awardSubtype = additionalDetails.award_subtype;
       $scope.additionalDetails.awardManagers = additionalDetails.award_manager.join();
+      $scope.additionalDetails.isTemplate = isTruthy(additionalDetails.is_template);
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -85,7 +85,8 @@
               startDate: null,
               endDate: null,
               awardManagers: [],
-              selectedReviewFields: []
+              selectedReviewFields: [],
+              isTemplate: false
             });
           });
         });
@@ -244,7 +245,8 @@
               end_date: AwardAdditionalDetailsMockData.end_date,
               award_subtype: AwardAdditionalDetailsMockData.award_subtype,
               award_manager: ['2', '1'],
-              review_fields: [{ id: '19', required: '0', weight: 1 }]
+              review_fields: [{ id: '19', required: '0', weight: 1 }],
+              is_template: true
             });
           });
 
@@ -379,6 +381,7 @@
       $scope.additionalDetails.startDate = AwardAdditionalDetailsMockData.start_date;
       $scope.additionalDetails.endDate = AwardAdditionalDetailsMockData.end_date;
       $scope.additionalDetails.awardSubtype = AwardAdditionalDetailsMockData.award_subtype;
+      $scope.additionalDetails.isTemplate = true;
       $scope.additionalDetails.selectedReviewFields = [{
         id: ReviewFieldsMockData[0].id,
         required: false,

--- a/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
@@ -59,6 +59,7 @@
         expect($scope.additionalDetails.endDate).toEqual('2019-11-29');
         expect($scope.additionalDetails.awardSubtype).toEqual('1');
         expect($scope.additionalDetails.awardManagers).toEqual('2,1');
+        expect($scope.additionalDetails.isTemplate).toEqual(true);
       });
     });
 

--- a/ang/test/mocks/data/award-additional-details.data.js
+++ b/ang/test/mocks/data/award-additional-details.data.js
@@ -9,6 +9,7 @@
       start_date: '2019-10-29',
       end_date: '2019-11-29',
       award_manager: ['2', '1'],
+      is_template: true,
       review_fields: [{
         id: '19',
         weight: 1,


### PR DESCRIPTION
## Overview
This PR displays and sends the data for the "Is Template" field that was first added to the "award additional details" entity here:
https://github.com/compucorp/uk.co.compucorp.civiawards/pull/150

## Before
![Screen Shot 2020-11-19 at 4 42 44 PM](https://user-images.githubusercontent.com/1642119/99721955-5382d700-2a86-11eb-880c-65bc3933a724.png)
The "Is Template?" field is not present.

## After
![gif](https://user-images.githubusercontent.com/1642119/99721673-f1c26d00-2a85-11eb-9041-f6516e554c3e.gif)


## Technical Details

The `is_template` field is stored in the basic details directive. The award directive takes care of sending this stored value to the API.
