### PR TITLE
RSE-1553: Add Create new button

### DIFF
--- a/ang/civiawards-workflow/services/applicant-management-workflow.service.js
+++ b/ang/civiawards-workflow/services/applicant-management-workflow.service.js
@@ -12,14 +12,15 @@
    * @param {object} ContactsCache contacts cache service
    * @param {Function} processMyAwardsFilter service to process my awards filters
    * @param {object} Select2Utils select 2 utility service
-   * @param {Function} isTruthy service to check if value is truthy
+   * @param {object} $window window object of the browser
    */
   function ApplicantManagementWorkflow ($q, civicaseCrmApi, AwardSubtype,
-    ContactsCache, processMyAwardsFilter, Select2Utils, isTruthy) {
+    ContactsCache, processMyAwardsFilter, Select2Utils, $window) {
     var awardSubtypes = AwardSubtype.getAll();
 
     this.createDuplicate = createDuplicate;
     this.getWorkflowsList = getWorkflowsList;
+    this.redirectToWorkflowCreationScreen = redirectToWorkflowCreationScreen;
 
     /**
      * @param {object} selectedFilters selected filter values
@@ -161,6 +162,15 @@
       }
 
       return filters;
+    }
+
+    /**
+     * Redirect to the workflow creation screen
+     *
+     * @param {object} caseTypeCategory case type category object
+     */
+    function redirectToWorkflowCreationScreen (caseTypeCategory) {
+      $window.location.href = '/civicrm/award/a/#/awards/new/' + caseTypeCategory.value;
     }
   }
 })(CRM._, angular);

--- a/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
+++ b/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
@@ -2,7 +2,7 @@
 
 ((_) => {
   describe('applicant management workflow', () => {
-    let $q, $rootScope, civicaseCrmApiMock, CaseTypesMockData,
+    let $q, $rootScope, $window, civicaseCrmApiMock, CaseTypesMockData,
       AwardAdditionalDetailsMockData, ApplicantManagementWorkflow,
       ContactsCache, ContactsData, processMyAwardsFilterMock;
 
@@ -12,12 +12,14 @@
 
       $provide.value('civicaseCrmApi', civicaseCrmApiMock);
       $provide.value('processMyAwardsFilter', processMyAwardsFilterMock);
+      $provide.value('$window', { location: {} });
     }));
 
     beforeEach(inject((_$q_, _$rootScope_, _ApplicantManagementWorkflow_,
-      _CaseTypesMockData_, _AwardAdditionalDetailsMockData_,
+      _$window_, _CaseTypesMockData_, _AwardAdditionalDetailsMockData_,
       _ContactsCache_, _ContactsData_, _processMyAwardsFilter_) => {
       $q = _$q_;
+      $window = _$window_;
       $rootScope = _$rootScope_;
       ContactsData = _ContactsData_;
       ApplicantManagementWorkflow = _ApplicantManagementWorkflow_;
@@ -131,6 +133,16 @@
             case_type_id: '1'
           })]
         ]);
+      });
+    });
+
+    describe('when redirecting to the create workflow page', () => {
+      beforeEach(() => {
+        ApplicantManagementWorkflow.redirectToWorkflowCreationScreen({ value: '2' });
+      });
+
+      it('redirects to the case management new workflow page', () => {
+        expect($window.location.href).toBe('/civicrm/award/a/#/awards/new/2');
       });
     });
   });


### PR DESCRIPTION
## Overview
The "New Workflow" button, redirects to the new Award page, instead of new Case Type Page.

## Before
"New Workflow" button redirected to New Case Type page always.

## After
![after2](https://user-images.githubusercontent.com/5058867/100581451-c2c1bc00-330d-11eb-9733-1b03c5446dce.gif)

## Technical Details
Added `redirectToWorkflowCreationScreen` function is `ApplicantManagementWorkflow` service, which redirects to the new Award page.
