### PR TITLE
RSE-1554: Applicant Management edit workflow link

### DIFF
--- a/ang/civiawards-workflow/services/applicant-management-workflow.service.js
+++ b/ang/civiawards-workflow/services/applicant-management-workflow.service.js
@@ -19,8 +19,17 @@
     var awardSubtypes = AwardSubtype.getAll();
 
     this.createDuplicate = createDuplicate;
+    this.getEditWorkflowURL = getEditWorkflowURL;
     this.getWorkflowsList = getWorkflowsList;
     this.redirectToWorkflowCreationScreen = redirectToWorkflowCreationScreen;
+
+    /**
+     * @param {string/number} workflow workflow object
+     * @returns {string} url to edit workflow page
+     */
+    function getEditWorkflowURL (workflow) {
+      return 'civicrm/award/a/#/awards/' + workflow.case_type_category + '/' + workflow.id;
+    }
 
     /**
      * @param {object} selectedFilters selected filter values

--- a/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
+++ b/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
@@ -145,5 +145,19 @@
         expect($window.location.href).toBe('/civicrm/award/a/#/awards/new/2');
       });
     });
+
+    describe('when editing a workflow', () => {
+      var returnValue;
+
+      beforeEach(() => {
+        var workflow = CaseTypesMockData.getSequential()[0];
+
+        returnValue = ApplicantManagementWorkflow.getEditWorkflowURL(workflow);
+      });
+
+      it('redirects to the case type page for the clicked workflow', () => {
+        expect(returnValue).toBe('civicrm/award/a/#/awards/1/1');
+      });
+    });
   });
 })(CRM._);


### PR DESCRIPTION
## Overview
As part of this PR, "Edit Workflow" link redirects to create award page for Applicant Management workflows.

## Before
![before](https://user-images.githubusercontent.com/5058867/100597369-636ea680-3323-11eb-893f-6eac14e57f9b.gif)

## After
![after2](https://user-images.githubusercontent.com/5058867/100597241-35896200-3323-11eb-9f95-0c0ff13599b4.gif)

## Technical Details
1. Added `getEditWorkflowURL` function in `ApplicantManagementWorkflow` service, which returns url for edit award page.