### PR TITLE
RSE-1566: Add Option Limit Parameter To Award Manager Get Api Call

### DIFF
--- a/ang/civiawards-base/services/process-my-awards-filter.service.js
+++ b/ang/civiawards-base/services/process-my-awards-filter.service.js
@@ -18,7 +18,8 @@
      */
     function processMyAwardsFilter (managerFilter) {
       var filters = {
-        sequential: 1
+        sequential: 1,
+        options: { limit: 0 }
       };
 
       if (managerFilter === 'my_awards') {

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -125,7 +125,11 @@
           });
 
           it('shows the awards where the logged in user is the manager and also applies the rest of filters', () => {
-            expect(civicaseCrmApi).toHaveBeenCalledWith('AwardManager', 'get', { sequential: 1, contact_id: 203 });
+            expect(civicaseCrmApi).toHaveBeenCalledWith('AwardManager', 'get', {
+              sequential: 1,
+              contact_id: 203,
+              options: { limit: 0 }
+            });
             expect(civicaseCrmApi).toHaveBeenCalledWith('AwardDetail', 'get', {
               sequential: 1,
               start_date: '10/12/2019',
@@ -163,7 +167,10 @@
         });
 
         it('shows the all the awards', () => {
-          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardManager', 'get', { sequential: 1 });
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardManager', 'get', {
+            sequential: 1,
+            options: { limit: 0 }
+          });
         });
       });
 


### PR DESCRIPTION
## Overview
This pr resolves the bug in award instance type filter. Previously there were some award types on an  instance that did not get displayed as a filter in the overview section on the dashboard.

## Before
Some of the award types got missed as can be seen in the picture below.
![Screenshot from 2020-12-09 18-27-15](https://user-images.githubusercontent.com/68388745/101636117-ada30680-3a4c-11eb-8673-5e34b4d0410e.png)


## After
All the available award types are shown to the user.
![Peek 2020-12-09 18-30](https://user-images.githubusercontent.com/68388745/101636178-c01d4000-3a4c-11eb-9b00-506568eaa17b.gif)


## Technical Details
Some of the records were missing due to the no limit parameter applied to the api call. If no limit is applied then default limit on an api call for civicrm apis is 25. So now a limit parameter with a value of 0 has been attached to the api call which means to fetch all the available records.