### PR TITLE
ACU-441: Implement Enable Finance Management Setting For Applicant Management Categories

### DIFF
--- a/CRM/CiviAwards/Hook/BuildForm/AddFinanceManagementField.php
+++ b/CRM/CiviAwards/Hook/BuildForm/AddFinanceManagementField.php
@@ -1,0 +1,81 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+
+/**
+ * Manages adding the finance management field to case category form.
+ */
+class CRM_CiviAwards_Hook_BuildForm_AddFinanceManagementField extends CRM_CiviAwards_Hook_CaseCategoryFormBase {
+
+  /**
+   * Adds the Enable Finance Management Form field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $this->addFinanceManagementFormField($form);
+    $this->addFinanceManagementTemplate();
+    $instanceTypeOptions = array_flip(CRM_Civicase_BAO_CaseCategoryInstance::buildOptions('instance_id', 'validate'));
+    $applicantManagementOptionValue = $instanceTypeOptions[CaseTypeCategoryHelper::APPLICATION_MANAGEMENT_NAME];
+    $form->assign('applicantManagement', $applicantManagementOptionValue);
+  }
+
+  /**
+   * Adds the finance management form field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  private function addFinanceManagementFormField(CRM_Core_Form $form) {
+    $financeManagement = $form->add(
+      'advcheckbox',
+      FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME,
+      ts('Enable Finance Management')
+    );
+
+    if ($form->getVar('_id')) {
+      $caseCategoryValues = $form->getVar('_values');
+      $defaultFinanceManagementValue = $this->getDefaultValue($caseCategoryValues['value']);
+      $financeManagement->setValue($defaultFinanceManagementValue);
+    }
+  }
+
+  /**
+   * Adds the template for the finance management field.
+   */
+  private function addFinanceManagementTemplate() {
+    $templatePath = CRM_CiviAwards_ExtensionUtil::path() . '/templates';
+    CRM_Core_Region::instance('page-body')->add(
+      [
+        'template' => "{$templatePath}/CRM/CiviAwards/Form/FinanceManagement.tpl",
+      ]
+    );
+  }
+
+  /**
+   * Returns the default value for the finance management field.
+   *
+   * @param int $categoryValue
+   *   Category value.
+   *
+   * @return mixed|null
+   *   Default value.
+   */
+  private function getDefaultValue($categoryValue) {
+    $financeManagementValues = Civi::settings()->get(FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME);
+    if (empty($financeManagementValues[$categoryValue])) {
+      return NULL;
+    }
+
+    return $financeManagementValues[$categoryValue];
+  }
+
+}

--- a/CRM/CiviAwards/Hook/CaseCategoryFormBase.php
+++ b/CRM/CiviAwards/Hook/CaseCategoryFormBase.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Base class for the CaseCategoryForm hook classes.
+ *
+ * This is implemented by hook classes responding to changes
+ * on the case category form page. It defines common functions
+ * that can be shared by the hook classes.
+ */
+class CRM_CiviAwards_Hook_CaseCategoryFormBase {
+
+  /**
+   * Determines the condition for the hook to run.
+   *
+   * The hook will run when the option value for the case type category
+   * option group is being created or edited.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   True if the hook class should run.
+   */
+  protected function shouldRun(CRM_Core_Form $form, $formName) {
+    $optionGroupName = $form->getVar('_gName');
+    return $formName == CRM_Admin_Form_Options::class && $optionGroupName == 'case_type_categories';
+  }
+
+}

--- a/CRM/CiviAwards/Hook/PostProcess/SaveFinanceManagement.php
+++ b/CRM/CiviAwards/Hook/PostProcess/SaveFinanceManagement.php
@@ -1,0 +1,59 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_Civicase_Hook_PostProcess_SaveCaseCategoryInstance as CaseCategoryInstanceHook;
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+
+/**
+ * Finance Management Post Process Hook class.
+ */
+class CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagement extends CRM_CiviAwards_Hook_CaseCategoryFormBase {
+
+  /**
+   * Saves the case category instance type relationship.
+   *
+   * @param CRM_Core_Form $form
+   *   The Form instance.
+   * @param string $formName
+   *   The Form class name.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+    $formAction = $form->getVar('_action');
+    $financialManagementService = new FinanceManagementSettingService();
+
+    if ($formAction == CRM_Core_Action::DELETE) {
+      $formValues = $form->getVar('_values');
+      $financialManagementService->deleteForCaseCategory($formValues['value']);
+    }
+    else {
+      $submitValues = $form->getVar('_submitValues');
+      $caseCategoryValue = $submitValues['value'];
+      $instanceTypeValue = $submitValues[CaseCategoryInstanceHook::INSTANCE_TYPE_FIELD_NAME];
+      if (!$this->isApplicantManagement($instanceTypeValue)) {
+        return;
+      }
+
+      $financeManagementValue = $submitValues[FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME];
+      $financialManagementService->saveForCaseCategory($caseCategoryValue, $financeManagementValue);
+    }
+  }
+
+  /**
+   * Checks if the instance type is of applicant management.
+   *
+   * @param int $instanceType
+   *   Category Instance Type.
+   *
+   * @return bool
+   *   Applicant management instance or not.
+   */
+  private function isApplicantManagement($instanceType) {
+    $instanceOptions = CRM_Civicase_BAO_CaseCategoryInstance::buildOptions('instance_id', 'validate');
+
+    return $instanceOptions[$instanceType] == CaseTypeCategoryHelper::APPLICATION_MANAGEMENT_NAME;
+  }
+
+}

--- a/CRM/CiviAwards/Service/FinanceManagementSetting.php
+++ b/CRM/CiviAwards/Service/FinanceManagementSetting.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Class for interacting with the FinanceManagement Setting.
+ */
+class CRM_CiviAwards_Service_FinanceManagementSetting {
+
+  /**
+   * Finance management name.
+   */
+  const FINANCE_MANAGEMENT_NAME = 'case_category_finance_management';
+
+  /**
+   * Saves the financial management value for the case category.
+   *
+   * @param int $caseCategoryId
+   *   Case category Id.
+   * @param bool $financeManagementValue
+   *   Finance Management Value.
+   */
+  public function saveForCaseCategory($caseCategoryId, $financeManagementValue) {
+    $financeManagementValues = $this->get();
+    $financeManagementValues[$caseCategoryId] = $financeManagementValue;
+    Civi::settings()->set(self::FINANCE_MANAGEMENT_NAME, $financeManagementValues);
+  }
+
+  /**
+   * Deletes the finance management value for the case category.
+   *
+   * @param int $caseCategoryId
+   *   Case category Id.
+   */
+  public function deleteForCaseCategory($caseCategoryId) {
+    $financeManagementValues = $this->get();
+    if (empty($financeManagementValues) || !isset($financeManagementValues[$caseCategoryId])) {
+      return;
+    }
+
+    unset($financeManagementValues[$caseCategoryId]);
+    Civi::settings()->set(self::FINANCE_MANAGEMENT_NAME, $financeManagementValues);
+  }
+
+  /**
+   * Gets the financial management settings.
+   *
+   * @param int|null $caseCategoryId
+   *   Case category Id.
+   *
+   * @return array|null
+   *   Financial management settings value.
+   */
+  public function get($caseCategoryId = NULL) {
+    $financeManagementValues = Civi::settings()->get(self::FINANCE_MANAGEMENT_NAME);
+
+    if (!$caseCategoryId) {
+      return !empty($financeManagementValues) ? $financeManagementValues : [];
+    }
+
+    return !empty($financeManagementValues[$caseCategoryId]) ? $financeManagementValues[$caseCategoryId] : NULL;
+  }
+
+}

--- a/civiawards.php
+++ b/civiawards.php
@@ -67,6 +67,20 @@ function civiawards_civicrm_enable() {
 function civiawards_civicrm_buildForm($formName, &$form) {
   $hooks = [
     new CRM_CiviAwards_Hook_BuildForm_SetCustomGroupSubTypeValues(),
+    new CRM_CiviAwards_Hook_BuildForm_AddFinanceManagementField(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($form, $formName);
+  }
+}
+
+/**
+ * Implements hook_civicrm_buildForm().
+ */
+function civiawards_civicrm_postProcess($formName, &$form) {
+  $hooks = [
+    new CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagement(),
   ];
 
   foreach ($hooks as $hook) {

--- a/templates/CRM/CiviAwards/Form/FinanceManagement.tpl
+++ b/templates/CRM/CiviAwards/Form/FinanceManagement.tpl
@@ -1,0 +1,30 @@
+<script type="text/javascript">
+    {literal}
+    CRM.$(function($) {
+      CRM.$('#case_category_finance_management').insertAfter(CRM.$('#case_category_instance_type'));
+      toggleFinanceManagementFieldVisibility();
+      CRM.$('#case_category_instance_type').change(function () {
+        toggleFinanceManagementFieldVisibility();
+      });
+    });
+
+    function toggleFinanceManagementFieldVisibility() {
+      var applicantManagementValue = {/literal} {$applicantManagement} {literal};
+      var instanceType = CRM.$('#case_category_instance_type option:selected').val();
+
+      if (instanceType == applicantManagementValue) {
+        CRM.$('#case_category_finance_management').show();
+      }
+      else {
+        CRM.$('#case_category_finance_management').hide();
+      }
+    }
+    {/literal}
+</script>
+
+<table>
+  <tr id="case_category_finance_management">
+    <td class="label"> {$form.case_category_finance_management.label} </td>
+    <td> {$form.case_category_finance_management.html} </td>
+  </tr>
+</table>

--- a/tests/phpunit/CRM/CiviAwards/Hook/PostProcess/SaveFinanceManagementTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Hook/PostProcess/SaveFinanceManagementTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use CRM_Civicase_Hook_PostProcess_SaveCaseCategoryInstance as CaseCategoryInstanceHook;
+use CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagement as SaveFinanceManagementHook;
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Test class for the SaveFinanceManagementTest Hook.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagementTest extends BaseHeadlessTest {
+
+  /**
+   * Tests setting is not saved if not applicant management.
+   */
+  public function testSettingNotSavedWhenNotApplicantManagementInstance() {
+    $instanceOptions = array_flip(CRM_Civicase_BAO_CaseCategoryInstance::buildOptions('instance_id', 'validate'));
+    $caseCategoryId = 5;
+    $instanceType = $instanceOptions['case_management'];
+    $form = $this->getCaseCategoryFormObject($caseCategoryId, $instanceType);
+    $hook = new SaveFinanceManagementHook();
+    $hook->run($form, CRM_Admin_Form_Options::class);
+    $financeManagementService = new FinanceManagementSettingService();
+    $this->assertEmpty($financeManagementService->get());
+  }
+
+  /**
+   * Tests setting is saved.
+   */
+  public function testSettingIsSavedWhenApplicantManagementInstance() {
+    $instanceOptions = array_flip(CRM_Civicase_BAO_CaseCategoryInstance::buildOptions('instance_id', 'validate'));
+    $caseCategoryId = 5;
+    $instanceType = $instanceOptions[CaseTypeCategoryHelper::APPLICATION_MANAGEMENT_NAME];
+    $form = $this->getCaseCategoryFormObject($caseCategoryId, $instanceType, TRUE);
+    $hook = new SaveFinanceManagementHook();
+    $hook->run($form, CRM_Admin_Form_Options::class);
+    $financeManagementService = new FinanceManagementSettingService();
+    $result = $financeManagementService->get();
+    $this->assertCount(1, $result);
+    $this->assertTrue($result[$caseCategoryId]);
+  }
+
+  /**
+   * Gets case category form object.
+   *
+   * @param int $caseCategoryId
+   *   Case category Id.
+   * @param int $instanceType
+   *   Instance Type.
+   * @param bool $financialManagementValue
+   *   Financial management value.
+   *
+   * @return \CRM_Admin_Form_Options
+   *   Form object.
+   */
+  private function getCaseCategoryFormObject($caseCategoryId, $instanceType, $financialManagementValue = TRUE) {
+    $form = new CRM_Admin_Form_Options();
+    $form->setVar('_gName', 'case_type_categories');
+    $form->setVar('_action', CRM_Core_Action::ADD);
+    $submitValues = [
+      'value' => $caseCategoryId,
+      CaseCategoryInstanceHook::INSTANCE_TYPE_FIELD_NAME => $instanceType,
+      FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME => $financialManagementValue,
+    ];
+    $form->setVar('_submitValues', $submitValues);
+
+    return $form;
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Service/FinanceManagementSettingServiceTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/FinanceManagementSettingServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+
+/**
+ * Test class for the finance management settings service.
+ */
+class CRM_CiviAwards_Service_FinanceManagementSettingServiceTest extends BaseHeadlessTest {
+
+  /**
+   * Tests save for case category.
+   */
+  public function testSaveForCaseCategory() {
+    $caseCategoryId1 = 5;
+    $caseCategoryId2 = 8;
+    $financeManagement = new FinanceManagementSettingService();
+    $financeManagement->saveForCaseCategory($caseCategoryId1, TRUE);
+    $financeManagement->saveForCaseCategory($caseCategoryId2, FALSE);
+    $results = $this->getFinanceManagementValues();
+    $this->assertTrue($results[$caseCategoryId1]);
+    $this->assertFalse($results[$caseCategoryId2]);
+    $this->assertCount(2, $results);
+  }
+
+  /**
+   * Test delete for case category.
+   */
+  public function testDeleteForCaseCategory() {
+    $caseCategoryId = 5;
+    $financeManagement = new FinanceManagementSettingService();
+    $financeManagement->saveForCaseCategory($caseCategoryId, TRUE);
+    $results = $financeManagementValues = Civi::settings()->get(FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME);
+    $this->assertTrue($results[$caseCategoryId]);
+    $financeManagement->deleteForCaseCategory($caseCategoryId);
+    $results = $this->getFinanceManagementValues();
+    $this->assertCount(0, $results);
+  }
+
+  /**
+   * Test get without passing a parameter.
+   */
+  public function testGetWithoutCaseCategoryParameter() {
+    $caseCategoryId1 = 5;
+    $caseCategoryId2 = 8;
+    $financeManagement = new FinanceManagementSettingService();
+    $financeManagement->saveForCaseCategory($caseCategoryId1, FALSE);
+    $financeManagement->saveForCaseCategory($caseCategoryId2, TRUE);
+    $results = $financeManagement->get();
+    $this->assertCount(2, $results);
+    $this->assertFalse($results[$caseCategoryId1]);
+    $this->assertTrue($results[$caseCategoryId2]);
+  }
+
+  /**
+   * Test get when parameter is passed.
+   */
+  public function testGetWithCaseCategoryParameter() {
+    $caseCategoryId1 = 5;
+    $caseCategoryId2 = 8;
+    $financeManagement = new FinanceManagementSettingService();
+    $financeManagement->saveForCaseCategory($caseCategoryId1, FALSE);
+    $financeManagement->saveForCaseCategory($caseCategoryId2, TRUE);
+    $result = $financeManagement->get($caseCategoryId2);
+    $this->assertTrue($result);
+  }
+
+  /**
+   * Get financial management values.
+   *
+   * @return array
+   *   Financial management values.
+   */
+  private function getFinanceManagementValues() {
+    return Civi::settings()->get(FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds a new checkbox `Enable Finance Management` to the case type category form creation screen. This checkbox however only shows up for Applicant management case type categories. This setting will be used later to determine applicant management case categories that finance payment tabs will be added for.

## Before
This functionality was not yet implemented.

## After
- This functionality is implemented and the checkbox field is added to the case type categories form. 
- A new service `CRM_CiviAwards_Service_FinanceManagementSetting` is created to handle interfacing with the storing, deleting and retrieval of this setting.
- The `Enable Finance Management` checkbox form field was added using the buildFormHook (CRM_CiviAwards_Hook_BuildForm_AddFinanceManagementField) and it's processing was handled using the `postProcessHook` (CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagement) with a new template added to inject the field.

![FinanceSetting](https://user-images.githubusercontent.com/6951813/102233142-3b20a380-3ef0-11eb-85cf-3c4c175e1b80.gif)

