### PR TITLE
CPS-411: Import awards using CSV importer extension

### DIFF
--- a/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
+++ b/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
@@ -22,7 +22,7 @@ class CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields implements API_Wrapper {
    * {@inheritdoc}
    */
   public function toApiOutput($apiRequest, $result) {
-    if ($this->canHandleTheRequest($apiRequest)) {
+    if ($this->canHandleTheRequest($apiRequest) && !empty($result['values'])) {
       $this->addAwardManagerDetails($apiRequest, $result['values']);
       $this->addProfileFields($apiRequest, $result['values']);
     }
@@ -41,9 +41,8 @@ class CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields implements API_Wrapper {
    */
   private function canHandleTheRequest(array $apiRequest) {
     return $apiRequest['entity'] === 'AwardDetail' && in_array($apiRequest['action'], [
-        'get',
-        'create',
-      ]);
+      'get', 'create',
+    ]);
   }
 
   /**

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -81,6 +81,10 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    *   Parameters.
    */
   private static function validateDates(array $params) {
+    if (empty($params['start_date'])) {
+      throw new Exception("Award Start Date should not be empty");
+    }
+
     if (!empty($params['start_date']) && !empty($params['end_date'])) {
       $startDate = new DateTime($params['start_date']);
       $endDate = new DateTime($params['end_date']);

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -66,13 +66,30 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    *   Parameters.
    */
   private static function validateParams(array &$params) {
-    if (empty($params['award_subtype'])) {
-      throw new Exception('Award Subtype should not be empty');
-    }
-
+    self::validateMandatory($params);
     self::validateDates($params);
     self::validateReviewFields($params);
     self::validateAwardManager($params);
+  }
+
+  /**
+   * Ensures that required fields are provided.
+   *
+   * @param array $params
+   *   Parameters.
+   */
+  private static function validateMandatory(array $params) {
+    $mandatoryFields = [
+      'start_date' => 'Award Start Date',
+      'award_subtype' => 'Award Subtype',
+      'award_manager' => 'Award Manager',
+    ];
+
+    foreach ($mandatoryFields as $field => $label) {
+      if (empty($params[$field])) {
+        throw new Exception("The {$label} field should not be empty");
+      }
+    }
   }
 
   /**
@@ -82,10 +99,6 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    *   Parameters.
    */
   private static function validateDates(array $params) {
-    if (empty($params['start_date'])) {
-      throw new Exception("Award Start Date should not be empty");
-    }
-
     if (!empty($params['start_date']) && !empty($params['end_date'])) {
       $startDate = new DateTime($params['start_date']);
       $endDate = new DateTime($params['end_date']);
@@ -129,10 +142,6 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    * @throws \Exception
    */
   private static function validateAwardManager(array $params) {
-    if (empty($params['award_manager'])) {
-      throw new Exception('Award Manager should not be empty');
-    }
-
     $contactManagers = (array) $params['award_manager'];
     foreach ($contactManagers as $contactId) {
       $contact = civicrm_api3('Contact', 'get', [

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -72,6 +72,7 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
 
     self::validateDates($params);
     self::validateReviewFields($params);
+    self::validateAwardManager($params);
   }
 
   /**
@@ -117,6 +118,30 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
     $reviewFields = CRM_Utils_Array::value('review_fields', $params);
     $reviewFieldsValidator = new CRM_CiviAwards_Helper_CreateReviewFieldsValidator();
     $reviewFieldsValidator->validate($reviewFields);
+  }
+
+  /**
+   * Validates award_manager options to ensure legal options are passed.
+   *
+   * @param array $params
+   *   Request Parameters.
+   *
+   * @throws \Exception
+   */
+  private static function validateAwardManager(array $params) {
+    if (empty($params['award_manager'])) {
+      throw new Exception('Award Manager should not be empty');
+    }
+
+    $contactManagers = (array) $params['award_manager'];
+    foreach ($contactManagers as $contactId) {
+      $contact = civicrm_api3('Contact', 'get', [
+        'id' => $contactId,
+      ]);
+      if ($contact['count'] == 0) {
+        throw new Exception("Invalid Contact Received: {$contactId}");
+      }
+    }
   }
 
 }

--- a/CRM/CiviAwards/BAO/AwardDetail.php
+++ b/CRM/CiviAwards/BAO/AwardDetail.php
@@ -66,6 +66,10 @@ class CRM_CiviAwards_BAO_AwardDetail extends CRM_CiviAwards_DAO_AwardDetail {
    *   Parameters.
    */
   private static function validateParams(array &$params) {
+    if (empty($params['award_subtype'])) {
+      throw new Exception('Award Subtype should not be empty');
+    }
+
     self::validateDates($params);
     self::validateReviewFields($params);
   }

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -29,8 +29,7 @@ class CRM_CiviAwards_Service_AwardImport {
 
     $params['case_type_id'] = $caseType['id'];
     $params['award_manager'] = !empty($params['award_manager']) ? explode(',', $params['award_manager']) : [];
-
-    $params['review_fields'] = !empty($params['review_fields']) ? json_decode($params['review_fields'], TRUE) : [];
+    $params['review_fields'] = [];
     try {
       civicrm_api3('AwardDetail', 'create', $params);
     }

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -16,7 +16,7 @@ class CRM_CiviAwards_Service_AwardImport {
   public function create(array $params) {
     $tx = new CRM_Core_Transaction();
 
-    $params['case_type_category'] = $this->getCaseCategoryValueForAwards();
+    $params['case_type_category'] = 'awards';
     $params['definition'] = $this->createDefinition($params);
     try {
       $caseType = civicrm_api3('CaseType', 'create', $params);

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -12,6 +12,8 @@ class CRM_CiviAwards_Service_AwardImport {
    *   Information for creating the award and related entities.
    */
   public function create(array $params) {
+    $this->validateParams($params);
+
     $tx = new CRM_Core_Transaction();
 
     $params['case_type_category'] = 'awards';
@@ -63,6 +65,18 @@ class CRM_CiviAwards_Service_AwardImport {
         ['name' => 'Application Manager'],
       ],
     ];
+  }
+
+  /**
+   * Validate information received.
+   *
+   * @param array $params
+   *   Information for creating the award and related entities.
+   */
+  private function validateParams(array $params) {
+    if (empty($params['title'])) {
+      throw new API_Exception('Invalid param received: Award Title should not be empty');
+    }
   }
 
 }

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -17,7 +17,7 @@ class CRM_CiviAwards_Service_AwardImport {
     $tx = new CRM_Core_Transaction();
 
     $params['case_type_category'] = 'awards';
-    $params['definition'] = $this->createDefinition($params);
+    $params['definition'] = $this->createDefaultDefinition($params);
     try {
       $caseType = civicrm_api3('CaseType', 'create', $params);
     }
@@ -54,46 +54,27 @@ class CRM_CiviAwards_Service_AwardImport {
   }
 
   /**
-   * Create the definition for the case type.
+   * Create a default definition for the award.
    *
-   * Makes an array with all the information required for the definition field
-   * on the case type.
-   *
-   * @param array $params
-   *   Information for creating the Award.
+   * Makes an array with all the minimal default information required for
+   * the definition field on the award.
    *
    * @return array
    *   Array with details for the definition field.
    */
-  private function createDefinition(array $params) {
-    if (!isset($params['activity_types'])) {
-      $params['activity_types'] = [
+  private function createDefaultDefinition() {
+    return [
+      'activityTypes' => [
         ['name' => 'Applicant Review'],
         ['name' => 'Email'],
         ['name' => 'Follow up'],
         ['name' => 'Meeting'],
         ['name' => 'Phone Call'],
-      ];
-    }
-    else {
-      $params['activity_types'] = json_decode($params['activity_types'], TRUE);
-    }
-
-    if (!isset($params['statuses'])) {
-      $params['statuses'] = [];
-    }
-    else {
-      $params['statuses'] = json_decode($params['statuses'], TRUE);
-    }
-
-    $params['caseRoles'] = [
-      ['name' => 'Application Manager'],
-    ];
-
-    return [
-      'activityTypes' => $params['activity_types'],
-      'caseRoles' => $params['caseRoles'],
-      'statuses' => $params['statuses'],
+      ],
+      'statuses' => [],
+      'caseRoles' => [
+        ['name' => 'Application Manager'],
+      ],
     ];
   }
 

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -39,33 +39,6 @@ class CRM_CiviAwards_Service_AwardImport {
       throw new API_Exception('Exception while saving the AwardDetail: ' . $exception->getMessage());
     }
 
-    if (!empty($params['review_panel_title'])) {
-      try {
-        civicrm_api3('AwardReviewPanel', 'create', [
-          'case_type_id' => $caseType['id'],
-          'title' => $params['review_panel_title'],
-          'is_active' => $params['review_panel_is_active'] ?? 1,
-          'visibility_settings' => [
-            'application_status' => [],
-            'anonymize_application' => '1',
-            'application_tags' => [],
-            'is_application_status_restricted' => '0',
-            'restricted_application_status' => [],
-          ],
-          'contact_settings' => [
-            'exclude_groups' => [],
-            'include_groups' => [],
-            'relationship' => [],
-          ],
-        ]);
-      }
-      catch (Exception $exception) {
-        $tx->rollback();
-
-        throw new API_Exception('Exception while saving the AwardReviewPanel: ' . $exception->getMessage());
-      }
-    }
-
     return TRUE;
   }
 

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Utility class for importing Awards using CSV importer extension.
  */
@@ -14,7 +15,7 @@ class CRM_CiviAwards_Service_AwardImport {
     $tx = new CRM_Core_Transaction();
 
     $params['case_type_category'] = 'awards';
-    $params['definition'] = $this->createDefaultDefinition($params);
+    $params['definition'] = $this->getDefaultDefinitionParams();
     try {
       $caseType = civicrm_api3('CaseType', 'create', $params);
     }
@@ -40,15 +41,15 @@ class CRM_CiviAwards_Service_AwardImport {
   }
 
   /**
-   * Create a default definition for the award.
+   * Returns the default definition params for the award.
    *
    * Makes an array with all the minimal default information required for
    * the definition field on the award.
    *
    * @return array
-   *   Array with details for the definition field.
+   *   Details for the definition field.
    */
-  private function createDefaultDefinition() {
+  private function getDefaultDefinitionParams() {
     return [
       'activityTypes' => [
         ['name' => 'Applicant Review'],

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -28,7 +28,8 @@ class CRM_CiviAwards_Service_AwardImport {
     }
 
     $params['case_type_id'] = $caseType['id'];
-    $params['award_manager'] = !empty($params['award_manager']) ? json_decode($params['award_manager'], TRUE) : [];
+    $params['award_manager'] = !empty($params['award_manager']) ? explode(',', $params['award_manager']) : [];
+
     $params['review_fields'] = !empty($params['review_fields']) ? json_decode($params['review_fields'], TRUE) : [];
     try {
       civicrm_api3('AwardDetail', 'create', $params);

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -26,9 +26,8 @@ class CRM_CiviAwards_Service_AwardImport {
 
       throw new API_Exception('Exception while saving the Case Type for Award: ' . $exception->getMessage());
     }
-    $caseTypeId = array_shift($caseType['values'])['id'];
 
-    $params['case_type_id'] = $caseTypeId;
+    $params['case_type_id'] = $caseType['id'];
     $params['award_manager'] = !empty($params['award_manager']) ? json_decode($params['award_manager'], TRUE) : [];
     $params['review_fields'] = !empty($params['review_fields']) ? json_decode($params['review_fields'], TRUE) : [];
     try {
@@ -43,7 +42,7 @@ class CRM_CiviAwards_Service_AwardImport {
     if (!empty($params['review_panel_title'])) {
       try {
         civicrm_api3('AwardReviewPanel', 'create', [
-          'case_type_id' => $caseTypeId,
+          'case_type_id' => $caseType['id'],
           'title' => $params['review_panel_title'],
           'is_active' => $params['review_panel_is_active'] ?? 1,
           'visibility_settings' => [

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -1,7 +1,4 @@
 <?php
-
-use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategory;
-
 /**
  * Utility class for importing Awards using CSV importer extension.
  */
@@ -40,17 +37,6 @@ class CRM_CiviAwards_Service_AwardImport {
     }
 
     return TRUE;
-  }
-
-  /**
-   * Get the case category value for Awards.
-   *
-   * @return int
-   *   The case category id for Awards.
-   */
-  public function getCaseCategoryValueForAwards() {
-    $caseCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
-    return $caseCategories[CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME];
   }
 
   /**

--- a/CRM/CiviAwards/Service/AwardImport.php
+++ b/CRM/CiviAwards/Service/AwardImport.php
@@ -1,0 +1,128 @@
+<?php
+
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategory;
+
+/**
+ * Utility class for importing Awards using CSV importer extension.
+ */
+class CRM_CiviAwards_Service_AwardImport {
+
+  /**
+   * Create an Award and the related entities.
+   *
+   * @param array $params
+   *   Information for creating the award and related entities.
+   */
+  public function create(array $params) {
+    $tx = new CRM_Core_Transaction();
+
+    $params['case_type_category'] = $this->getCaseCategoryValueForAwards();
+    $params['definition'] = $this->createDefinition($params);
+    try {
+      $caseType = civicrm_api3('CaseType', 'create', $params);
+    }
+    catch (Exception $exception) {
+      $tx->rollback();
+
+      throw new API_Exception('Exception while saving the Case Type for Award: ' . $exception->getMessage());
+    }
+    $caseTypeId = array_shift($caseType['values'])['id'];
+
+    $params['case_type_id'] = $caseTypeId;
+    $params['award_manager'] = !empty($params['award_manager']) ? json_decode($params['award_manager'], TRUE) : [];
+    $params['review_fields'] = !empty($params['review_fields']) ? json_decode($params['review_fields'], TRUE) : [];
+    try {
+      civicrm_api3('AwardDetail', 'create', $params);
+    }
+    catch (Exception $exception) {
+      $tx->rollback();
+
+      throw new API_Exception('Exception while saving the AwardDetail: ' . $exception->getMessage());
+    }
+
+    if (!empty($params['review_panel_title'])) {
+      try {
+        civicrm_api3('AwardReviewPanel', 'create', [
+          'case_type_id' => $caseTypeId,
+          'title' => $params['review_panel_title'],
+          'is_active' => $params['review_panel_is_active'] ?? 1,
+          'visibility_settings' => [
+            'application_status' => [],
+            'anonymize_application' => '1',
+            'application_tags' => [],
+            'is_application_status_restricted' => '0',
+            'restricted_application_status' => [],
+          ],
+          'contact_settings' => [
+            'exclude_groups' => [],
+            'include_groups' => [],
+            'relationship' => [],
+          ],
+        ]);
+      }
+      catch (Exception $exception) {
+        $tx->rollback();
+
+        throw new API_Exception('Exception while saving the AwardReviewPanel: ' . $exception->getMessage());
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Get the case category value for Awards.
+   *
+   * @return int
+   *   The case category id for Awards.
+   */
+  public function getCaseCategoryValueForAwards() {
+    $caseCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
+    return $caseCategories[CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME];
+  }
+
+  /**
+   * Create the definition for the case type.
+   *
+   * Makes an array with all the information required for the definition field
+   * on the case type.
+   *
+   * @param array $params
+   *   Information for creating the Award.
+   *
+   * @return array
+   *   Array with details for the definition field.
+   */
+  private function createDefinition(array $params) {
+    if (!isset($params['activity_types'])) {
+      $params['activity_types'] = [
+        ['name' => 'Applicant Review'],
+        ['name' => 'Email'],
+        ['name' => 'Follow up'],
+        ['name' => 'Meeting'],
+        ['name' => 'Phone Call'],
+      ];
+    }
+    else {
+      $params['activity_types'] = json_decode($params['activity_types'], TRUE);
+    }
+
+    if (!isset($params['statuses'])) {
+      $params['statuses'] = [];
+    }
+    else {
+      $params['statuses'] = json_decode($params['statuses'], TRUE);
+    }
+
+    $params['caseRoles'] = [
+      ['name' => 'Application Manager'],
+    ];
+
+    return [
+      'activityTypes' => $params['activity_types'],
+      'caseRoles' => $params['caseRoles'],
+      'statuses' => $params['statuses'],
+    ];
+  }
+
+}

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @file
+ * Award Import API file.
+ */
+
+use CRM_CiviAwards_Service_AwardImport as AwardImportService;
+
+/**
+ * AwardImport.create API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_award_import_create_spec(array &$spec) {
+
+  $spec['title'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => ts('Award Title'),
+    'description' => ts('Natural language name for the Award'),
+  ];
+
+  $spec['description'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => ts('Description'),
+    'description' => ts('Description of the Award'),
+  ];
+
+  $spec['is_active'] = [
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => ts('Enabled?'),
+    'description' => ts('Is this Award enabled?'),
+  ];
+
+  $spec['award_subtype'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => CRM_CiviAwards_ExtensionUtil::ts('Award Subtype'),
+    'description' => CRM_CiviAwards_ExtensionUtil::ts('One of the values of the award_subtype option group'),
+  ];
+
+  $spec['start_date'] = [
+    'type' => CRM_Utils_Type::T_DATE,
+    'title' => CRM_CiviAwards_ExtensionUtil::ts('Start Date'),
+    'description' => CRM_CiviAwards_ExtensionUtil::ts('Award Start Date'),
+  ];
+
+  $spec['end_date'] = [
+    'type' => CRM_Utils_Type::T_DATE,
+    'title' => CRM_CiviAwards_ExtensionUtil::ts('End Date'),
+    'description' => CRM_CiviAwards_ExtensionUtil::ts('Award End Date'),
+  ];
+
+  $spec['is_template'] = [
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => CRM_CiviAwards_ExtensionUtil::ts('Is Template?'),
+    'description' => CRM_CiviAwards_ExtensionUtil::ts('Whether the award detail is for a template or not'),
+  ];
+
+  $spec['award_manager'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Award manager',
+    'description' => 'An array of Contact IDs',
+  ];
+
+  $spec['review_fields'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Award review fields',
+    'description' => 'A two-dimensional array of Custom fields properties. Example [{"id": 2, "required": true, "weight": 14}]',
+  ];
+
+  $spec['activity_types'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Award activity types',
+    'description' => 'A two-dimensional array of activity types. Example [{"name": "Applicant Review"}, {"name": "Email"}]',
+  ];
+
+  $spec['statuses'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => 'Award statuses',
+    'description' => 'A two-dimensional array of Award statuses. Example ["won", "lost"]',
+  ];
+
+  $spec['review_panel_title'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => ts('Review panel title'),
+    'description' => ts('Title of the Award review panel'),
+  ];
+
+  $spec['review_panel_is_active'] = [
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => ts('Review panel enabled?'),
+    'description' => ts('Is the Review Panel enabled?'),
+  ];
+}
+
+/**
+ * AwardImport.create API.
+ *
+ * @param array $params
+ *   API parameters.
+ */
+function civicrm_api3_award_import_create(array $params) {
+  (new AwardImportService())->create($params);
+}

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -14,7 +14,6 @@ use CRM_CiviAwards_Service_AwardImport as AwardImportService;
  *   Description of fields supported by this API call.
  */
 function _civicrm_api3_award_import_create_spec(array &$spec) {
-
   $spec['title'] = [
     'type' => CRM_Utils_Type::T_STRING,
     'title' => ts('Award Title'),
@@ -29,8 +28,8 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
 
   $spec['is_active'] = [
     'type' => CRM_Utils_Type::T_BOOLEAN,
-    'title' => ts('Enabled?'),
-    'description' => ts('Is this Award enabled?'),
+    'title' => ts('Is Active'),
+    'description' => ts('Is this Award active?'),
   ];
 
   $spec['award_subtype'] = [
@@ -59,20 +58,8 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
 
   $spec['award_manager'] = [
     'type' => CRM_Utils_Type::T_STRING,
-    'title' => 'Award manager',
+    'title' => 'Award Manager',
     'description' => 'A comma-separated list of Contact IDs',
-  ];
-
-  $spec['activity_types'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => 'Award activity types',
-    'description' => 'A two-dimensional array of activity types. Example [{"name": "Applicant Review"}, {"name": "Email"}]',
-  ];
-
-  $spec['statuses'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => 'Award statuses',
-    'description' => 'A two-dimensional array of Award statuses. Example ["won", "lost"]',
   ];
 }
 

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -14,41 +14,9 @@ use CRM_CiviAwards_Service_AwardImport as AwardImportService;
  *   Description of fields supported by this API call.
  */
 function _civicrm_api3_award_import_create_spec(array &$spec) {
-  $spec['title'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => ts('Award Title'),
-    'description' => ts('Natural language name for the Award'),
-  ];
-
-  $spec['description'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => ts('Description'),
-    'description' => ts('Description of the Award'),
-  ];
-
-  $spec['is_active'] = [
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'title' => ts('Is Active'),
-    'description' => ts('Is this Award active?'),
-  ];
-
-  $spec['award_subtype'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => CRM_CiviAwards_ExtensionUtil::ts('Award Subtype'),
-    'description' => CRM_CiviAwards_ExtensionUtil::ts('One of the values of the award_subtype option group'),
-  ];
-
-  $spec['start_date'] = [
-    'type' => CRM_Utils_Type::T_DATE,
-    'title' => CRM_CiviAwards_ExtensionUtil::ts('Start Date'),
-    'description' => CRM_CiviAwards_ExtensionUtil::ts('Award Start Date'),
-  ];
-
-  $spec['end_date'] = [
-    'type' => CRM_Utils_Type::T_DATE,
-    'title' => CRM_CiviAwards_ExtensionUtil::ts('End Date'),
-    'description' => CRM_CiviAwards_ExtensionUtil::ts('Award End Date'),
-  ];
+  $caseTypeFields = civicrm_api3('CaseType', 'getfields', ['api_action' => 'get']);
+  $awardDetailFields = civicrm_api3('AwardDetail', 'getfields', ['api_action' => 'get']);
+  $spec = array_merge($caseTypeFields['values'], $awardDetailFields['values']);
 
   $spec['is_template'] = [
     'type' => CRM_Utils_Type::T_BOOLEAN,
@@ -60,6 +28,12 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
     'type' => CRM_Utils_Type::T_STRING,
     'title' => 'Award Manager',
     'description' => 'A comma-separated list of Contact IDs',
+  ];
+
+  $spec['award_subtype'] = [
+    'type' => CRM_Utils_Type::T_STRING,
+    'title' => CRM_CiviAwards_ExtensionUtil::ts('Award Subtype'),
+    'description' => CRM_CiviAwards_ExtensionUtil::ts('One of the values of the award_subtype option group'),
   ];
 }
 

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -60,7 +60,7 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
   $spec['award_manager'] = [
     'type' => CRM_Utils_Type::T_STRING,
     'title' => 'Award manager',
-    'description' => 'An array of Contact IDs',
+    'description' => 'A comma-separated list of Contact IDs',
   ];
 
   $spec['review_fields'] = [

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -74,18 +74,6 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
     'title' => 'Award statuses',
     'description' => 'A two-dimensional array of Award statuses. Example ["won", "lost"]',
   ];
-
-  $spec['review_panel_title'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => ts('Review panel title'),
-    'description' => ts('Title of the Award review panel'),
-  ];
-
-  $spec['review_panel_is_active'] = [
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'title' => ts('Review panel enabled?'),
-    'description' => ts('Is the Review Panel enabled?'),
-  ];
 }
 
 /**

--- a/api/v3/AwardImport.php
+++ b/api/v3/AwardImport.php
@@ -63,12 +63,6 @@ function _civicrm_api3_award_import_create_spec(array &$spec) {
     'description' => 'A comma-separated list of Contact IDs',
   ];
 
-  $spec['review_fields'] = [
-    'type' => CRM_Utils_Type::T_STRING,
-    'title' => 'Award review fields',
-    'description' => 'A two-dimensional array of Custom fields properties. Example [{"id": 2, "required": true, "weight": 14}]',
-  ];
-
   $spec['activity_types'] = [
     'type' => CRM_Utils_Type::T_STRING,
     'title' => 'Award activity types',

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -88,37 +88,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
   }
 
   /**
-   * Test the creation of ReviewPanel.
-   */
-  public function testImportAwardWithReviewPanelInformation() {
-    $paramsForReviewPanel = [
-      'review_panel_title' => 'Review Panel Title',
-      'review_panel_is_active' => 1,
-    ];
-    $params = array_merge(
-      $this->getBaseParamsForAward(),
-      $paramsForReviewPanel
-    );
-
-    (new AwardImportService())->create($params);
-
-    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
-      'title' => $params['title'],
-    ]);
-    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
-      'case_type_id' => $awardCaseType['name'],
-    ]);
-    $awardReviewPanel = civicrm_api3('AwardReviewPanel', 'getsingle', [
-      'title' => $paramsForReviewPanel['review_panel_title'],
-    ]);
-
-    $this->assertCaseTypeInformation($params, $awardCaseType);
-    $this->assertDetailsInformation($params, $awardDetail);
-    $this->assertEquals($paramsForReviewPanel['review_panel_title'], $awardReviewPanel['title']);
-    $this->assertEquals($paramsForReviewPanel['review_panel_is_active'], $awardReviewPanel['is_active']);
-  }
-
-  /**
    * Test the creation of case type with activity information.
    */
   public function testImportAwardWithActivityInformation() {

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -112,13 +112,36 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
   }
 
   /**
-   * Test that in case of error, all the operation is cancelled.
+   * Test that the operation fails when no award title is received.
    */
   public function testErrorImportingAwardWithEmptyTitle() {
     $params = $this->getBaseParamsForAward();
     $params['title'] = '';
     $this->expectException(API_Exception::class);
     $this->expectExceptionMessage('Invalid param received: Award Title should not be empty');
+    $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'get', [
+      'title' => $params['title'],
+    ]);
+    // No case type created.
+    $this->assertEquals(0, $awardCaseType['count']);
+    // No new award details found.
+    $this->assertEquals($initialAwardCount, civicrm_api3('AwardDetail', 'getcount'));
+  }
+
+  /**
+   * Test that the operation fails when no award subtype is received.
+   */
+  public function testErrorImportingAwardWithoutSubtype() {
+    $params = $this->getBaseParamsForAward();
+    $params['award_subtype'] = '';
+    $this->expectException(API_Exception::class);
+    $this->expectExceptionMessage(
+      'Exception while saving the AwardDetail: Award Subtype should not be empty'
+    );
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 
     (new AwardImportService())->create($params);

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_CiviAwards_Service_AwardImport as AwardImportService;
-use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
 
 /**
  * Class for test CRM_CiviAwards_Service_AwardImport.
@@ -86,32 +85,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $this->assertCount(2, $awardDetail['award_manager']);
     $this->assertContains($contactIdOne, $awardDetail['award_manager']);
     $this->assertContains($contactIdTwo, $awardDetail['award_manager']);
-  }
-
-  /**
-   * Test the creation of review fields.
-   */
-  public function testImportAwardWithReviewFieldsInformation() {
-    $customFields = [$this->createReviewField()];
-
-    $params = array_merge(
-      $this->getBaseParamsForAward(),
-      [
-        'review_fields' => json_encode($customFields),
-      ]
-    );
-
-    (new AwardImportService())->create($params);
-
-    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
-      'title' => $params['title'],
-    ]);
-    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
-      'case_type_id' => $awardCaseType['name'],
-    ]);
-    $this->assertCaseTypeInformation($params, $awardCaseType);
-    $this->assertDetailsInformation($params, $awardDetail);
-    $this->assertEquals($customFields, $awardDetail['review_fields']);
   }
 
   /**
@@ -237,7 +210,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
       'end_date' => date('Y-m-d', strtotime("+14 days")),
       'is_template' => '',
       'award_manager' => '',
-      'review_fields' => '',
     ];
   }
 
@@ -275,34 +247,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $this->assertEquals($expected['start_date'], $actual['start_date']);
     $this->assertEquals($expected['end_date'], $actual['end_date']);
     $this->assertEquals($expected['award_subtype'], $actual['award_subtype']);
-  }
-
-  /**
-   * Creates a review field.
-   *
-   * @return array
-   *   Review field details.
-   */
-  private function createReviewField() {
-    $suffix = rand();
-    $customField = civicrm_api3('CustomField', 'create', [
-      'custom_group_id' => ApplicantReviewHelper::getApplicantReviewCustomGroupId(),
-      'name' => 'test_review_field_' . $suffix,
-      'label' => 'Test Review Field ' . $suffix,
-      'data_type' => 'Boolean',
-      'default_value' => 1,
-      'html_type' => 'Radio',
-      'required' => 1,
-      'weight' => 2,
-    ]);
-
-    $customField = array_shift($customField['values']);
-
-    return [
-      'id' => $customField['id'],
-      'required' => $customField['is_required'],
-      'weight' => $customField['weight'],
-    ];
   }
 
 }

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -88,61 +88,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
   }
 
   /**
-   * Test the creation of case type with activity information.
-   */
-  public function testImportAwardWithActivityInformation() {
-    $activityTypes = [
-      ['name' => 'Email'],
-      ['name' => 'Follow up'],
-    ];
-
-    $params = array_merge(
-      $this->getBaseParamsForAward(),
-      [
-        'activity_types' => json_encode($activityTypes),
-      ]
-    );
-
-    (new AwardImportService())->create($params);
-
-    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
-      'title' => $params['title'],
-    ]);
-    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
-      'case_type_id' => $awardCaseType['name'],
-    ]);
-    $this->assertCaseTypeInformation($params, $awardCaseType);
-    $this->assertDetailsInformation($params, $awardDetail);
-    $this->assertEquals($activityTypes, $awardCaseType['definition']['activityTypes']);
-  }
-
-  /**
-   * Test the creation of case type with statuses information.
-   */
-  public function testImportAwardWithStatusesInformation() {
-    $statuses = ['won', 'lost', 'ongoing'];
-
-    $params = array_merge(
-      $this->getBaseParamsForAward(),
-      [
-        'statuses' => json_encode($statuses),
-      ]
-    );
-
-    (new AwardImportService())->create($params);
-
-    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
-      'title' => $params['title'],
-    ]);
-    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
-      'case_type_id' => $awardCaseType['name'],
-    ]);
-    $this->assertCaseTypeInformation($params, $awardCaseType);
-    $this->assertDetailsInformation($params, $awardDetail);
-    $this->assertEquals($statuses, $awardCaseType['definition']['statuses']);
-  }
-
-  /**
    * Test that in case of error, all the operation is cancelled.
    */
   public function testErrorImportingAwardWithDetailInformation() {
@@ -197,11 +142,6 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
 
     $caseTypeCategoryForAwards = (new AwardImportService())->getCaseCategoryValueForAwards();
     $this->assertEquals($caseTypeCategoryForAwards, $actual['case_type_category']);
-
-    // We only check the existence of the keys in definition field here,
-    // content is checked on specific tests.
-    $this->assertArrayHasKey('activityTypes', $actual['definition']);
-    $this->assertArrayHasKey('caseRoles', $actual['definition']);
   }
 
   /**

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -1,0 +1,275 @@
+<?php
+
+use CRM_CiviAwards_Service_AwardImport as AwardImportService;
+use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
+
+/**
+ * Class for test CRM_CiviAwards_Service_AwardImport.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
+
+  /**
+   * Test the creation of the Case Type and the AwardDetail.
+   */
+  public function testImportAwardWithBaseInformation() {
+    $params = $this->getBaseParamsForAward();
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+  }
+
+  /**
+   * Test the creation of the manager information.
+   */
+  public function testImportAwardWithManagerInformation() {
+    $contactId = CRM_CiviAwards_Test_Fabricator_Contact::fabricate()['id'];
+    $params = array_merge(
+      $this->getBaseParamsForAward(),
+      [
+        'award_manager' => json_encode([$contactId]),
+      ]
+    );
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+    $this->assertEquals($contactId, $awardDetail['award_manager'][0]);
+  }
+
+  /**
+   * Test the creation of review fields.
+   */
+  public function testImportAwardWithReviewFieldsInformation() {
+    $customFields = [$this->createReviewField()];
+
+    $params = array_merge(
+      $this->getBaseParamsForAward(),
+      [
+        'review_fields' => json_encode($customFields),
+      ]
+    );
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+    $this->assertEquals($customFields, $awardDetail['review_fields']);
+  }
+
+  /**
+   * Test the creation of ReviewPanel.
+   */
+  public function testImportAwardWithReviewPanelInformation() {
+    $paramsForReviewPanel = [
+      'review_panel_title' => 'Review Panel Title',
+      'review_panel_is_active' => 1,
+    ];
+    $params = array_merge(
+      $this->getBaseParamsForAward(),
+      $paramsForReviewPanel
+    );
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+    $awardReviewPanel = civicrm_api3('AwardReviewPanel', 'getsingle', [
+      'title' => $paramsForReviewPanel['review_panel_title'],
+    ]);
+
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+    $this->assertEquals($paramsForReviewPanel['review_panel_title'], $awardReviewPanel['title']);
+    $this->assertEquals($paramsForReviewPanel['review_panel_is_active'], $awardReviewPanel['is_active']);
+  }
+
+  /**
+   * Test the creation of case type with activity information.
+   */
+  public function testImportAwardWithActivityInformation() {
+    $activityTypes = [
+      ['name' => 'Email'],
+      ['name' => 'Follow up'],
+    ];
+
+    $params = array_merge(
+      $this->getBaseParamsForAward(),
+      [
+        'activity_types' => json_encode($activityTypes),
+      ]
+    );
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+    $this->assertEquals($activityTypes, $awardCaseType['definition']['activityTypes']);
+  }
+
+  /**
+   * Test the creation of case type with statuses information.
+   */
+  public function testImportAwardWithStatusesInformation() {
+    $statuses = ['won', 'lost', 'ongoing'];
+
+    $params = array_merge(
+      $this->getBaseParamsForAward(),
+      [
+        'statuses' => json_encode($statuses),
+      ]
+    );
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'getsingle', [
+      'title' => $params['title'],
+    ]);
+    $awardDetail = civicrm_api3('AwardDetail', 'getsingle', [
+      'case_type_id' => $awardCaseType['name'],
+    ]);
+    $this->assertCaseTypeInformation($params, $awardCaseType);
+    $this->assertDetailsInformation($params, $awardDetail);
+    $this->assertEquals($statuses, $awardCaseType['definition']['statuses']);
+  }
+
+  /**
+   * Test that in case of error, all the operation is cancelled.
+   */
+  public function testErrorImportingAwardWithDetailInformation() {
+    $params = $this->getBaseParamsForAward();
+    $params['start_date'] = 'invalid date';
+    $this->expectException(API_Exception::class);
+    $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'get', [
+      'title' => $params['title'],
+    ]);
+    // No case type created.
+    $this->assertEquals(0, $awardCaseType['count']);
+    // No new award details found.
+    $this->assertEquals($initialAwardCount, civicrm_api3('AwardDetail', 'getcount'));
+  }
+
+  /**
+   * Base information for creating the Case Type and Details.
+   *
+   * @return array
+   *   Base information.
+   */
+  private function getBaseParamsForAward() {
+    $suffix = rand();
+    return [
+      'title' => 'Test title asdf ' . $suffix,
+      'description' => 'test desc',
+      'is_active' => 1,
+      'award_subtype' => 2,
+      'start_date' => date('Y-m-d', strtotime('+1 day')),
+      'end_date' => date('Y-m-d', strtotime("+14 days")),
+      'is_template' => '',
+      'award_manager' => '',
+      'review_fields' => '',
+    ];
+  }
+
+  /**
+   * Helper for asserting Case Type information.
+   *
+   * @param array $expected
+   *   Expected information.
+   * @param array $actual
+   *   Information received.
+   */
+  private function assertCaseTypeInformation(array $expected, array $actual) {
+    $this->assertEquals($expected['title'], $actual['title']);
+    $this->assertEquals($expected['description'], $actual['description']);
+    $this->assertEquals($expected['is_active'], $actual['is_active']);
+
+    $caseTypeCategoryForAwards = (new AwardImportService())->getCaseCategoryValueForAwards();
+    $this->assertEquals($caseTypeCategoryForAwards, $actual['case_type_category']);
+
+    // We only check the existence of the keys in definition field here,
+    // content is checked on specific tests.
+    $this->assertArrayHasKey('activityTypes', $actual['definition']);
+    $this->assertArrayHasKey('caseRoles', $actual['definition']);
+  }
+
+  /**
+   * Helper for asserting Award Detail information.
+   *
+   * @param array $expected
+   *   Expected information.
+   * @param array $actual
+   *   Information received.
+   */
+  private function assertDetailsInformation(array $expected, array $actual) {
+    $this->assertEquals($expected['start_date'], $actual['start_date']);
+    $this->assertEquals($expected['end_date'], $actual['end_date']);
+    $this->assertEquals($expected['award_subtype'], $actual['award_subtype']);
+  }
+
+  /**
+   * Creates a review field.
+   *
+   * @return array
+   *   Review field details.
+   */
+  private function createReviewField() {
+    $suffix = rand();
+    $customField = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => ApplicantReviewHelper::getApplicantReviewCustomGroupId(),
+      'name' => 'test_review_field_' . $suffix,
+      'label' => 'Test Review Field ' . $suffix,
+      'data_type' => 'Boolean',
+      'default_value' => 1,
+      'html_type' => 'Radio',
+      'required' => 1,
+      'weight' => 2,
+    ]);
+
+    $customField = array_shift($customField['values']);
+
+    return [
+      'id' => $customField['id'],
+      'required' => $customField['is_required'],
+      'weight' => $customField['weight'],
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -156,6 +156,29 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
   }
 
   /**
+   * Test that the operation fails when no award start date is received.
+   */
+  public function testErrorImportingAwardWithoutStartDate() {
+    $params = $this->getBaseParamsForAward();
+    $params['start_date'] = '';
+    $this->expectException(API_Exception::class);
+    $this->expectExceptionMessage(
+      'Exception while saving the AwardDetail: Award Start Date should not be empty'
+    );
+    $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'get', [
+      'title' => $params['title'],
+    ]);
+    // No case type created.
+    $this->assertEquals(0, $awardCaseType['count']);
+    // No new award details found.
+    $this->assertEquals($initialAwardCount, civicrm_api3('AwardDetail', 'getcount'));
+  }
+
+  /**
    * Base information for creating the Case Type and Details.
    *
    * @return array

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_CiviAwards_Service_AwardImport as AwardImportService;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategory;
 
 /**
  * Class for test CRM_CiviAwards_Service_AwardImport.
@@ -140,7 +141,7 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $this->assertEquals($expected['description'], $actual['description']);
     $this->assertEquals($expected['is_active'], $actual['is_active']);
 
-    $caseTypeCategoryForAwards = (new AwardImportService())->getCaseCategoryValueForAwards();
+    $caseTypeCategoryForAwards = $this->getCaseCategoryValueForAwards();
     $this->assertEquals($caseTypeCategoryForAwards, $actual['case_type_category']);
   }
 
@@ -156,6 +157,17 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $this->assertEquals($expected['start_date'], $actual['start_date']);
     $this->assertEquals($expected['end_date'], $actual['end_date']);
     $this->assertEquals($expected['award_subtype'], $actual['award_subtype']);
+  }
+
+  /**
+   * Get the case category value for Awards.
+   *
+   * @return int
+   *   The case category id for Awards.
+   */
+  private function getCaseCategoryValueForAwards() {
+    $caseCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
+    return $caseCategories[CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME];
   }
 
 }

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -140,7 +140,7 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $params['award_subtype'] = '';
     $this->expectException(API_Exception::class);
     $this->expectExceptionMessage(
-      'Exception while saving the AwardDetail: Award Subtype should not be empty'
+      'Exception while saving the AwardDetail: The Award Subtype field should not be empty'
     );
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 
@@ -163,7 +163,7 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $params['start_date'] = '';
     $this->expectException(API_Exception::class);
     $this->expectExceptionMessage(
-      'Exception while saving the AwardDetail: Award Start Date should not be empty'
+      'Exception while saving the AwardDetail: The Award Start Date field should not be empty'
     );
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 
@@ -186,7 +186,7 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $params['award_manager'] = '';
     $this->expectException(API_Exception::class);
     $this->expectExceptionMessage(
-      'Exception while saving the AwardDetail: Award Manager should not be empty'
+      'Exception while saving the AwardDetail: The Award Manager field should not be empty'
     );
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -95,6 +95,9 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
     $params = $this->getBaseParamsForAward();
     $params['start_date'] = 'invalid date';
     $this->expectException(API_Exception::class);
+    $this->expectExceptionMessage(
+      "Exception while saving the AwardDetail: start_date is not a valid date: {$params['start_date']}"
+    );
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 
     (new AwardImportService())->create($params);

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardImportTest.php
@@ -91,13 +91,34 @@ class CRM_CiviAwards_Service_AwardImportTest extends BaseHeadlessTest {
   /**
    * Test that in case of error, all the operation is cancelled.
    */
-  public function testErrorImportingAwardWithDetailInformation() {
+  public function testErrorImportingAwardWithInvalidDate() {
     $params = $this->getBaseParamsForAward();
     $params['start_date'] = 'invalid date';
     $this->expectException(API_Exception::class);
     $this->expectExceptionMessage(
       "Exception while saving the AwardDetail: start_date is not a valid date: {$params['start_date']}"
     );
+    $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
+
+    (new AwardImportService())->create($params);
+
+    $awardCaseType = civicrm_api3('CaseType', 'get', [
+      'title' => $params['title'],
+    ]);
+    // No case type created.
+    $this->assertEquals(0, $awardCaseType['count']);
+    // No new award details found.
+    $this->assertEquals($initialAwardCount, civicrm_api3('AwardDetail', 'getcount'));
+  }
+
+  /**
+   * Test that in case of error, all the operation is cancelled.
+   */
+  public function testErrorImportingAwardWithEmptyTitle() {
+    $params = $this->getBaseParamsForAward();
+    $params['title'] = '';
+    $this->expectException(API_Exception::class);
+    $this->expectExceptionMessage('Invalid param received: Award Title should not be empty');
     $initialAwardCount = civicrm_api3('AwardDetail', 'getcount');
 
     (new AwardImportService())->create($params);


### PR DESCRIPTION
## Overview
This PR adds the functionality of mass-importing Awards, using the [CSV importer extension](https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport) and a new "helper" entity named "AwardImport".

**UPDATE**
It was added improvements on the error handling, for the situations in which some of these fields have an empty value: Award Title, Award Start Date, Award Subtype, Award Manager.
More explanation about these changes on the `Technical Details` part of this PR.

## Before
Before there was not possible to import the Awards using the mentioned extension, because it has some related entities that couldn't be imported at the same time. 
The related entities are `AwardDetails`, `AwardManager`, `AwardReviewPanel`, and some other.

## After
Now, going to the CSV Importer extension ( Administer > API csv import ), on the first screen of the process, the `AwardImport` entity can be selected.
![image](https://user-images.githubusercontent.com/74304572/104624247-ed04e880-56c5-11eb-85b4-02c7692f9c40.png)
And in the second step, the fields for Awards can be mapped accordingly:
![image](https://user-images.githubusercontent.com/74304572/104624382-13c31f00-56c6-11eb-9a7e-d5bc1bfaade9.png)

The new entity provides fields for loading all the basic and additional data for the awards.
Can be specified the information for: 
- case type (title, description)
- award details (start_date, end_date, is_active, is_template) 
- award manager (comma-separated list of contacts id)

## Comments
I am attaching an example CSV file.

[awards.txt](https://github.com/compucorp/uk.co.compucorp.civiawards/files/5815915/awards.txt)

## Technical Details

All the error handling was being delegated to the respective entities, for example, with award details:
```php
try {
      civicrm_api3('AwardDetail', 'create', $params);
    }
    catch (Exception $exception) {
      $tx->rollback();

      throw new API_Exception('Exception while saving the AwardDetail: ' . $exception->getMessage());
    }
```
But this was not considering (or at least informing correctly) the cases in which the value was empty. This is done on the frontend part in the current paths (outside the CSV importer)

For this reason, 4 new commits were added:

1. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/164/commits/3b0a689326dc2e1f0ae9bc577c44aaed4482b05b For the empty Award Title (related to Case Type Title)
For this information we don't have the entity on the package (`CaseType`) then I added the handling of the particular error on the Service itself.

2. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/164/commits/dfb78f3d3ea956d41659d06f60579328b5df7389 for the empty Award Subtype.
Inside the award details BAO.

3. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/164/commits/7b9440e8f2bd4daca75e55b9f44e069d2a94181d for the empty Award Start Date.
Also inside the AwardDetail BAO.

4. https://github.com/compucorp/uk.co.compucorp.civiawards/pull/164/commits/61cc6be43d8516af12cc8d570336c8f47aeb1e54 for the empty Award Manager.
In a new method of the AwardDetail BAO, `validateAwardManager`, playing a similar role than the already existing `validateReviewFields`.
Also, the code iterates over the list looking for the contact and giving information when it is not found.

I also manually tested the upload, and do the normal path of Award Creation.

**Related to informing the row with the error.**
There is no easy way to know the row that failed, but the extension is printing all the row with the error, along with the error received. Since the Award Title is unique, the row can be identification easily.
Example:
This row:
>"test award - TD5 - 1","description award imported 1",1,2,,,0,2

Will produce this error:

>"Error with entity ""create""! (Exception while saving the AwardDetail: Award Start Date should not be empty)","test award - TD5 - 1","description award imported 1",1,2,,,0,2

(notice that is the error + the full row)


