### PR TITLE
RSE-1572: Fix Custom Fields Issue On Awards

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -32,6 +32,7 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
     $result = civicrm_api3('CaseType', 'get', [
       'return' => ['title', 'id'],
       'case_type_category' => ['IN' => $applicantManagementCategories],
+      'options' => ['limit' => 0],
     ]);
 
     return array_column($result['values'], 'title', 'id');
@@ -43,6 +44,7 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
   public static function getApplicantManagementCaseCategories() {
     $instance = civicrm_api3('CaseCategoryInstance', 'get', [
       'instance_id' => self::APPLICATION_MANAGEMENT_NAME,
+      'options' => ['limit' => 0],
     ]);
 
     if (empty($instance['values'])) {


### PR DESCRIPTION
## Overview
This pr fixes the issue with custom fields on an award configuration page. If there were more than 25 case types belonging to current case category instance then an error occurred on custom fields tab due to which users were not able to configure custom fields for an award.

## Before
There was an error message on the custom fields tab
![image-20201207-165106](https://user-images.githubusercontent.com/68388745/103352714-d311b600-4ac8-11eb-93ad-7b7582354edb.png)

## After
The above mentioned issue has been resolved
![Peek 2020-12-30 18-01](https://user-images.githubusercontent.com/68388745/103352803-0eac8000-4ac9-11eb-9b0e-49f8b005c828.gif)

## Technical Details
There was an api call to fetch all the case types that belong to current case category instance in `CRM/CiviAwards/Helper/CaseTypeCategory.php`, the result of this api call was used to determine that if the current award is valid or not. This api call was missing limit parameter which by default is 25 so only first 25 records were being fetched. This pr adds the limit parameters to the api call with a value of 0 which means to fetch all records without any limit and introduction of this paramater fixes the above described issue.