### PR TITLE
RSE-1231: Fix Bug In Review Field Reordering

### DIFF
--- a/CRM/CiviAwards/Helper/ApplicantReview.php
+++ b/CRM/CiviAwards/Helper/ApplicantReview.php
@@ -28,18 +28,11 @@ class CRM_CiviAwards_Helper_ApplicantReview {
    * Return the Custom Group ID attached to the Applicant review activity type.
    */
   public static function getApplicantReviewCustomGroupId() {
-    $applicantReviewCustomGroup = [];
-    $result = civicrm_api3('CustomGroup', 'get', [
-      'sequential' => 1,
-      'extends' => 'Activity',
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
       'extends_entity_column_value' => self::getActivityTypeId(),
     ]);
 
-    if (!empty($result['values'])) {
-      $applicantReviewCustomGroup = array_shift($result['values']);
-    }
-
-    return $applicantReviewCustomGroup['id'];
+    return $customGroup['id'];
   }
 
 }

--- a/CRM/CiviAwards/Helper/ApplicantReview.php
+++ b/CRM/CiviAwards/Helper/ApplicantReview.php
@@ -3,7 +3,7 @@
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 
 /**
- * Class CRM_CiviAwards_Helper_ApplicantReview.
+ * Helper class CRM_CiviAwards_Helper_ApplicantReview.
  */
 class CRM_CiviAwards_Helper_ApplicantReview {
 
@@ -22,6 +22,24 @@ class CRM_CiviAwards_Helper_ApplicantReview {
     ]);
 
     return $result['values'][0]['value'];
+  }
+
+  /**
+   * Return the Custom Group ID attached to the Applicant review activity type.
+   */
+  public static function getApplicantReviewCustomGroupId() {
+    $applicantReviewCustomGroup = [];
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'extends' => 'Activity',
+      'extends_entity_column_value' => self::getActivityTypeId(),
+    ]);
+
+    if (!empty($result['values'])) {
+      $applicantReviewCustomGroup = array_shift($result['values']);
+    }
+
+    return $applicantReviewCustomGroup['id'];
   }
 
 }

--- a/CRM/CiviAwards/Service/AwardProfile.php
+++ b/CRM/CiviAwards/Service/AwardProfile.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_CiviAwards_Service_AwardProfile.
+ * Service class CRM_CiviAwards_Service_AwardProfile.
  */
 class CRM_CiviAwards_Service_AwardProfile {
 
@@ -34,26 +34,22 @@ class CRM_CiviAwards_Service_AwardProfile {
    *   Profile Id.
    *
    * @throws \CiviCRM_API3_Exception
+   *   API3 Exception.
    */
   public function createProfileFields(array $customFields, $profileId) {
+    $this->addContactIdField($profileId);
+
     foreach ($customFields as $customField) {
-      $uFField = civicrm_api3('UFField', 'create', [
+      civicrm_api3('UFField', 'create', [
         'uf_group_id' => $profileId,
         'field_name' => 'custom_' . $customField['id'],
         'field_type' => 'Activity',
         'label' => 'Activity Field' . $customField['id'],
         'is_required' => $customField['required'],
-      ]);
-
-      // UFField weight seems to be ignored on create irrespective of whatever is
-      // passed, Civi will assign the next available weight. So we update the
-      // weight after creating.
-      civicrm_api3('UFField', 'create', [
-        'id' => $uFField['id'],
         'weight' => $customField['weight'],
+        'option.autoweight' => FALSE,
       ]);
     }
-    $this->addContactIdField($profileId);
   }
 
   /**
@@ -136,7 +132,7 @@ class CRM_CiviAwards_Service_AwardProfile {
 
     $customFields = [];
     foreach ($result['values'] as $profileField) {
-      if (strpos($profileField['field_name'], 'custom_') === 0) { 
+      if (strpos($profileField['field_name'], 'custom_') === 0) {
         $customFields[] = [
           'id' => substr($profileField['field_name'], 7),
           'required' => $profileField['is_required'],

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardProfileTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardProfileTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use CRM_CiviAwards_Service_AwardProfile as AwardProfileService;
+use CRM_CiviAwards_Helper_CaseTypeCategory as CaseTypeCategory;
+use CRM_CiviAwards_Helper_ApplicantReview as ApplicantReviewHelper;
+
+/**
+ * Class for testing CRM_CiviAwards_Service_AwardProfile.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Service_AwardProfileTest extends BaseHeadlessTest {
+
+  /**
+   * Test the creation of profile fields.
+   */
+  public function testCreateProfileFieldsWithValidParams() {
+    $profileId = $this->createProfile();
+    $customFields = $this->createCustomFields(5);
+
+    (new AwardProfileService())->createProfileFields($customFields, $profileId);
+
+    $uFFields = civicrm_api3('UFField', 'get', [
+      'uf_group_id' => $profileId,
+    ]);
+
+    // Custom fields count + 1 for ID field.
+    $this->assertEquals($uFFields['count'], count($customFields) + 1);
+    foreach ($customFields as $customField) {
+      $createdUFField = NULL;
+      foreach ($uFFields['values'] as $uFField) {
+        if ($uFField['field_name'] == 'custom_' . $customField['id']) {
+          $createdUFField = $uFField;
+          break;
+        }
+      }
+
+      $this->assertNotNull($createdUFField);
+      $this->assertEquals($customField['required'], $createdUFField['is_required']);
+      $this->assertEquals($customField['weight'], $createdUFField['weight']);
+    }
+  }
+
+  /**
+   * Get the category type Id used for Awards cases.
+   */
+  private function getCaseTypeCategoryForAwards() {
+    $caseCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
+
+    return $caseCategories[CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME];
+  }
+
+  /**
+   * Create a given number of custom fields.
+   *
+   * @param int $fieldsNumber
+   *   Number of fields to be created.
+   *
+   * @return array
+   *   The Custom Fields information.
+   */
+  private function createCustomFields(int $fieldsNumber) {
+    $customFields = [];
+    for ($i = 0; $i < $fieldsNumber; $i++) {
+      $suffix = rand();
+      $customField = civicrm_api3('CustomField', 'create', [
+        'custom_group_id' => ApplicantReviewHelper::getApplicantReviewCustomGroupId(),
+        'name' => 'test_custom_' . $suffix,
+        'label' => 'test_custom_' . $suffix,
+        'data_type' => 'Boolean',
+        'default_value' => 1,
+        'html_type' => 'Radio',
+        'required' => rand(0, 1),
+        'weight' => rand(),
+      ]);
+      $customField = array_shift($customField['values']);
+
+      $customFields[] = [
+        'id' => $customField['id'],
+        'required' => $customField['is_required'],
+        'weight' => $customField['weight'],
+      ];
+    }
+
+    return $customFields;
+  }
+
+  /**
+   * Get the ID of the group used for Review Fields.
+   *
+   * @return int
+   *   Id of the profile created or retrieved.
+   */
+  private function createProfile() {
+    $caseTypeId = $this->getCaseTypeCategoryForAwards();
+
+    $result = civicrm_api3('UFGroup', 'get', [
+      'title' => 'Award Profile_' . $caseTypeId,
+      'name' => 'Award Profile_' . $caseTypeId,
+      'is_reserved' => 1,
+    ]);
+    if ($result['count'] > 0) {
+      return array_shift($result['values'])['id'];
+    }
+
+    return (new AwardProfileService())->createProfile($caseTypeId);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR solves the problem that appears while trying to update the Review Fields positions on a given award.
This was caused by a CiviCRM internal problem, that ignores the weight specified on the create/update API call.

## Before
The order that we assign to the review field is not persisted correctly:
![before](https://user-images.githubusercontent.com/74304572/103410961-50f4c080-4ba0-11eb-8165-e59dc007a7d4.gif)

## After
Te order persists after saving and refreshing:
![after](https://user-images.githubusercontent.com/74304572/103410997-6bc73500-4ba0-11eb-9662-4d545a152b04.gif)

## Technical Details
I deleted the previous workaround for saving the `weight` value. Anyway, it was not working anymore.
The key to solving the error was to add the option `option.autoweight`.
I did not found information about this option in online documentation or forums, I just inspected myself the CiviCRM code and found it.
Since is undocumented, I added a unit test, that will fail if the core developers remove this option.
