### PR TITLE
RSE-1034: Add filter to display disabled awards and applications

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -92,8 +92,14 @@
       processMyAwardsFilter(model.selectedFilters.awardFilter)
         .then(processAwardSubtypeFilters)
         .then(function (awardSubtypeIds) {
+          var isCaseTypeActive = model.selectedFilters.showDisabledAwards
+            ? '0'
+            : '1';
           var param = {
-            case_type_id: awardSubtypeIds.length > 0 ? { IN: awardSubtypeIds } : { 'IS NULL': 1 }
+            'case_type_id.is_active': isCaseTypeActive,
+            case_type_id: awardSubtypeIds.length > 0
+              ? { IN: awardSubtypeIds }
+              : { 'IS NULL': 1 }
           };
 
           if (model.selectedFilters.statuses.length > 0) {

--- a/ang/civiawards/dashboard/directives/more-filters-popup.html
+++ b/ang/civiawards/dashboard/directives/more-filters-popup.html
@@ -23,6 +23,14 @@
 
       <label>{{ts('Award End Date')}}</label>
       <civicase-ui-date-range date-range="model.selectedFilters.end_date"></civicase-ui-date-range>
+
+      <br />
+      <div
+        civicase-checkbox
+        ng-model="model.selectedFilters.showDisabledAwards"
+      >
+        {{ts('Show Disabled Awards')}}
+      </div>
     </div>
 
     <button

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -120,6 +120,7 @@
             dialogModel.selectedFilters.end_date = '15/12/2019';
             dialogModel.selectedFilters.award_subtypes = '1,2';
             dialogModel.selectedFilters.statuses = '2,3';
+            dialogModel.selectedFilters.showDisabledAwards = false;
             dialogModel.applyFilterAndCloseDialog();
             $rootScope.$digest();
           });
@@ -140,7 +141,44 @@
             expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::dashboard-filters::updated', {
               case_type_id: { IN: [1, 2] },
               status_id: { IN: ['2', '3'] },
-              'status_id.grouping': { IN: ['Closed', 'Opened'] }
+              'status_id.grouping': { IN: ['Closed', 'Opened'] },
+              'case_type_id.is_active': '1'
+            });
+          });
+        });
+
+        describe('disabled awards', () => {
+          describe('when showing disabled awards', () => {
+            beforeEach(() => {
+              dialogModel.selectedFilters.showDisabledAwards = true;
+              dialogModel.applyFilterAndCloseDialog();
+              $rootScope.$digest();
+            });
+
+            it('filters applications by disabled awards', () => {
+              expect($rootScope.$broadcast).toHaveBeenCalledWith(
+                'civicase::dashboard-filters::updated',
+                jasmine.objectContaining({
+                  'case_type_id.is_active': '0'
+                })
+              );
+            });
+          });
+
+          describe('when hiding disabled awards', () => {
+            beforeEach(() => {
+              dialogModel.selectedFilters.showDisabledAwards = false;
+              dialogModel.applyFilterAndCloseDialog();
+              $rootScope.$digest();
+            });
+
+            it('filters applications by enabled awards', () => {
+              expect($rootScope.$broadcast).toHaveBeenCalledWith(
+                'civicase::dashboard-filters::updated',
+                jasmine.objectContaining({
+                  'case_type_id.is_active': '1'
+                })
+              );
             });
           });
         });


### PR DESCRIPTION
## Overview
This PR adds a a "show disabled awards" filter. The filter will show awards, applications, and activities that would normally be hidden because they belong to a disabled award.

⚠️ Important: This PR implements the work done in https://github.com/compucorp/uk.co.compucorp.civiawards/pull/75 which had to be closed until a solution for disabled cases would be taken. 
This PR is also related to https://github.com/compucorp/uk.co.compucorp.civicase/pull/675

## Before
<img width="370" alt="Screen Shot 2021-01-07 at 9 53 27 PM" src="https://user-images.githubusercontent.com/1642119/103964897-e4933780-5132-11eb-95ea-d20e79754392.png">
the filter doesn't exist.

## After
![pr](https://user-images.githubusercontent.com/1642119/103965223-a34f5780-5133-11eb-84b4-f6c58aa0e0f8.gif)
both applications shown here belong to disabled awards

## Technical Details

We use the `civicase-checkbox` directive introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/675

Some of the changes introduced in https://github.com/compucorp/uk.co.compucorp.civiawards/pull/75  were not implemented in this PR because they were not necessary:

* Adding a relationship from the AwardManager entity to the CaseType entity. This was already done and querying awards by case type fields is possible.
* the `case_type_id.is_active` filter is only passed to the case filters object and not to the `AwardManager` endpoint because it would require refactoring `processMyAwardsFilter`. This is not necessary because this returns active and disabled awards belonging to a user and the case filter object will ensure that only disabled awards are returned.