### PR TITLE
RSE-1459: Filter Unused Award Subtypes

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -55,13 +55,27 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
   }
 
   /**
-   * Returns the option values for Award Subtypes.
+   * Returns the option values for Award Subtypes that has been used.
    *
    * @return array
    *   Award Subtypes.
    */
   public static function getSubTypes() {
-    return AwardDetail::buildOptions('award_subtype');
+    $usedSubTypes = civicrm_api3('AwardDetail', 'get', [
+      'return' => ['award_subtype'],
+      'options' => ['limit' => 0],
+    ]);
+    if (empty($usedSubTypes['values'])) {
+      return [];
+    }
+    $usedSubTypes = array_unique(array_column($usedSubTypes['values'], 'award_subtype'));
+
+    $allSubTypes = AwardDetail::buildOptions('award_subtype');
+    $allSubTypes = array_filter($allSubTypes, function ($key) use ($usedSubTypes) {
+      return in_array($key, $usedSubTypes);
+    }, ARRAY_FILTER_USE_KEY);
+
+    return $allSubTypes;
   }
 
 }


### PR DESCRIPTION
## Overview
This pr filters out the unused award sub types while creating or updating a custom field set for award. As these sub types were not used yet so they resulted in empty case type for that custom field set due to which the custom field set was leaking into other case categories as well.

## Before
The above mentioned problem existed and as shown below all the available sub types were show in the custom field set form.
![Screenshot from 2021-01-13 12-53-32](https://user-images.githubusercontent.com/68388745/104423933-85a14880-55a0-11eb-81c0-9d7d0b2acba7.png)

## After
The mentioned problem is resolved and only those sub types are show which has atleast one award attached to it.
![Screenshot from 2021-01-13 12-52-38](https://user-images.githubusercontent.com/68388745/104423961-8c2fc000-55a0-11eb-9633-ac70ba442977.png)

## Technical Details
`getSubTypes` function in file `CRM/CiviAwards/Helper/CaseTypeCategory.php` was responsible for providing the award sub types, so it has been modified to provide only those award sub types which has been used atleast once.