### PR TITLE
ACU-443: Add the Award Payment Bank Details Custom Field Set

### DIFF
--- a/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSet.php
+++ b/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSet.php
@@ -3,7 +3,7 @@
 use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
 
 /**
- * Enable Ban kDetails FieldSet Post Process Hook class.
+ * Enable Bank Details FieldSet Post Process Hook class.
  */
 class CRM_CiviAwards_Hook_PostProcess_EnableBankDetailsFieldSet extends CRM_CiviAwards_Hook_CaseCategoryFormBase {
 

--- a/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSet.php
+++ b/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSet.php
@@ -1,0 +1,62 @@
+<?php
+
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+
+/**
+ * Enable Ban kDetails FieldSet Post Process Hook class.
+ */
+class CRM_CiviAwards_Hook_PostProcess_EnableBankDetailsFieldSet extends CRM_CiviAwards_Hook_CaseCategoryFormBase {
+
+  /**
+   * Saves the case category instance type relationship.
+   *
+   * @param CRM_Core_Form $form
+   *   The Form instance.
+   * @param string $formName
+   *   The Form class name.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $formAction = $form->getVar('_action');
+
+    if ($formAction != CRM_Core_Action::DELETE) {
+      $submitValues = $form->getVar('_submitValues');
+      $financeManagementValue = $submitValues[FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME];
+
+      $bankDetailsFieldSet = $this->getBankDetailsFieldSet();
+      $isBankDetailsFieldSetEnabled = $bankDetailsFieldSet['is_active'] == 1;
+      if (!empty($financeManagementValue) && !$isBankDetailsFieldSetEnabled) {
+        $this->enableBankDetailsFieldSet($bankDetailsFieldSet['id']);
+      }
+    }
+  }
+
+  /**
+   * Gets bank details field set data.
+   *
+   * @return array
+   *   Bank details data.
+   */
+  private function getBankDetailsFieldSet() {
+    $result = civicrm_api3('CustomGroup', 'get', ['name' => 'Awards_Payment_Bank_Details']);
+
+    return array_shift($result['values']);
+  }
+
+  /**
+   * Sets the Bank details field set to active.
+   *
+   * @param int $customFieldSetId
+   *   Custom field set id.
+   */
+  private function enableBankDetailsFieldSet($customFieldSetId) {
+    civicrm_api3('CustomGroup', 'create', [
+      'id' => $customFieldSetId,
+      'is_active' => 1,
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Setup/AddCurrencyRelatedCustomFields.php
+++ b/CRM/CiviAwards/Setup/AddCurrencyRelatedCustomFields.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Setup Class for AddCurrencyRelatedCustomFields.
+ */
+class CRM_CiviAwards_Setup_AddCurrencyRelatedCustomFields {
+
+  /**
+   * Attaches the Currency related custom fields.
+   *
+   * These custom fields are not added in the XML file because
+   * we need to attach the currencies enabled option group and
+   * this can not be attached via the xml as it would attempt to
+   * recreate the option group and throw an error.
+   */
+  public function apply() {
+    $params = [
+      'Awards_Payment_Bank_Details' => [
+        'custom_group_id' => 'Awards_Payment_Bank_Details',
+        'name' => 'Currency_In_Which_Account_Is_Held',
+        'label' => 'Currency In Which Account Is Held',
+        'data_type' => 'String',
+        'html_type' => 'Select',
+        'is_required' => '0',
+        'is_searchable' => '0',
+        'is_search_range' => '0',
+        'weight' => '9',
+        'is_active' => '1',
+        'is_view' => '0',
+        'text_length' => '255',
+        'note_columns' => '60',
+        'note_rows' => '4',
+        'option_group_id' => 'currencies_enabled',
+        'in_selector' => '0',
+      ],
+    ];
+
+    foreach ($params as $customFieldName => $param) {
+      civicrm_api3('CustomField', 'create', $param);
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -9,6 +9,7 @@ use CRM_CiviAwards_Setup_CreateAwardSubtypeOptionGroup as CreateAwardSubtypeOpti
 use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
 use CRM_CiviAwards_Setup_DeleteApplicantReviewCustomField as DeleteApplicantReviewCustomField;
 use CRM_CiviAwards_Setup_AddApplicationManagementWordReplacement as AddApplicationManagementWordReplacement;
+use CRM_CiviAwards_Setup_AddCurrencyRelatedCustomFields as AddCurrencyRelatedCustomFields;
 use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardsCategory as RemoveCustomGroupSupportForAwardsCategory;
 use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForApplicantManagement as RemoveCustomGroupSupportForApplicantManagement;
 use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
@@ -45,6 +46,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     }
 
     $this->processXmlInstallationFiles();
+    (new AddCurrencyRelatedCustomFields())->apply();
   }
 
   /**

--- a/CRM/CiviAwards/Upgrader/Steps/Step1009.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1009.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_CiviAwards_Setup_AddCurrencyRelatedCustomFields as AddCurrencyRelatedCustomFields;
+
 /**
  * Installs the Award Payment Bank Details Field Set.
  */
@@ -8,12 +10,15 @@ class CRM_CiviAwards_Upgrader_Steps_Step1009 {
   /**
    * Installs the Award Payment Bank Details Field Set.
    *
+   * Also adds the currency related custom fields.
+   *
    * @return bool
    *   return value.
    */
   public function apply() {
     $upgrader = CRM_CiviAwards_Upgrader_Base::instance();
     $upgrader->executeCustomDataFile('xml/custom_fields/payment_bank_details_install.xml');
+    (new AddCurrencyRelatedCustomFields())->apply();
 
     return TRUE;
   }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1009.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1009.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Installs the Award Payment Bank Details Field Set.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1009 {
+
+  /**
+   * Installs the Award Payment Bank Details Field Set.
+   *
+   * @return bool
+   *   return value.
+   */
+  public function apply() {
+    $upgrader = CRM_CiviAwards_Upgrader_Base::instance();
+    $upgrader->executeCustomDataFile('xml/custom_fields/payment_bank_details_install.xml');
+
+    return TRUE;
+  }
+
+}

--- a/civiawards.php
+++ b/civiawards.php
@@ -81,6 +81,7 @@ function civiawards_civicrm_buildForm($formName, &$form) {
 function civiawards_civicrm_postProcess($formName, &$form) {
   $hooks = [
     new CRM_CiviAwards_Hook_PostProcess_SaveFinanceManagement(),
+    new CRM_CiviAwards_Hook_PostProcess_EnableBankDetailsFieldSet(),
   ];
 
   foreach ($hooks as $hook) {

--- a/tests/phpunit/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSetTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Hook/PostProcess/EnableBankDetailsFieldSetTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+use CRM_CiviAwards_Hook_PostProcess_EnableBankDetailsFieldSet as EnableBankDetailsFieldSetHook;
+
+/**
+ * Test class for the EnableBankDetailsFieldSet Hook.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Hook_PostProcess_EnableBankDetailsFieldSetTest extends BaseHeadlessTest {
+
+  /**
+   * Tests that bank details field set is enabled.
+   */
+  public function testBankDetailsFieldSetIsEnabledWhenFinanceManagementSettingIsTrue() {
+    $this->assertEquals(0, $this->getBankDetailsCustomGroupStatus());
+    $form = $this->getCaseCategoryFormObject(TRUE);
+    $hook = new EnableBankDetailsFieldSetHook();
+    $hook->run($form, CRM_Admin_Form_Options::class);
+
+    // The custom group is now enabled.
+    $this->assertEquals(1, $this->getBankDetailsCustomGroupStatus());
+  }
+
+  /**
+   * Tests that bank details field set remains disabled.
+   */
+  public function testBankDetailsFieldSetIsNotEnabledWhenFinanceManagementSettingIsFalse() {
+    $this->assertEquals(0, $this->getBankDetailsCustomGroupStatus());
+    $form = $this->getCaseCategoryFormObject(FALSE);
+    $hook = new EnableBankDetailsFieldSetHook();
+    $hook->run($form, CRM_Admin_Form_Options::class);
+    $this->assertEquals(0, $this->getBankDetailsCustomGroupStatus());
+  }
+
+  /**
+   * Tests that the bank details set is not disabled after it has been enabled.
+   */
+  public function testBankDetailsFieldSetIsNotDisabledWhenFinanceManagementSettingIsFalseIfItHasBeenPreviouslyEnabled() {
+    // Enable the bank details field set.
+    $form = $this->getCaseCategoryFormObject(TRUE);
+    (new EnableBankDetailsFieldSetHook())->run($form, CRM_Admin_Form_Options::class);
+    $this->assertEquals(1, $this->getBankDetailsCustomGroupStatus());
+
+    // Make sure it remains enabled even if finance management is false.
+    $form = $this->getCaseCategoryFormObject(FALSE);
+    (new EnableBankDetailsFieldSetHook())->run($form, CRM_Admin_Form_Options::class);
+    $this->assertEquals(1, $this->getBankDetailsCustomGroupStatus());
+  }
+
+  /**
+   * Gets case category form object.
+   *
+   * @param bool $financialManagementValue
+   *   Financial management value.
+   *
+   * @return \CRM_Admin_Form_Options
+   *   Form object.
+   */
+  private function getCaseCategoryFormObject($financialManagementValue = TRUE) {
+    $form = new CRM_Admin_Form_Options();
+    $form->setVar('_gName', 'case_type_categories');
+    $form->setVar('_action', CRM_Core_Action::ADD);
+    $submitValues = [
+      FinanceManagementSettingService::FINANCE_MANAGEMENT_NAME => $financialManagementValue,
+    ];
+    $form->setVar('_submitValues', $submitValues);
+
+    return $form;
+  }
+
+  /**
+   * Returns bank details custom group status.
+   *
+   * @return bool
+   *   Custom group status.
+   */
+  private function getBankDetailsCustomGroupStatus() {
+    $result = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => 'Awards_Payment_Bank_Details',
+    ]);
+
+    return $result['is_active'];
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Service/FinanceManagementSettingServiceTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/FinanceManagementSettingServiceTest.php
@@ -4,6 +4,8 @@ use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingS
 
 /**
  * Test class for the finance management settings service.
+ *
+ * @group headless
  */
 class CRM_CiviAwards_Service_FinanceManagementSettingServiceTest extends BaseHeadlessTest {
 

--- a/xml/custom_fields/payment_bank_details_install.xml
+++ b/xml/custom_fields/payment_bank_details_install.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+  <CustomGroups>
+    <CustomGroup>
+      <name>Awards_Payment_Bank_Details</name>
+      <title>Awards Payment Bank Details</title>
+      <extends>Contact</extends>
+      <style>Tab</style>
+      <collapse_display>0</collapse_display>
+      <help_pre></help_pre>
+      <help_post></help_post>
+      <weight>33</weight>
+      <is_active>0</is_active>
+      <table_name>civicrm_value_awards_paymen_45</table_name>
+      <is_multiple>0</is_multiple>
+      <collapse_adv_display>1</collapse_adv_display>
+      <created_date>2020-12-16 13:43:27</created_date>
+      <is_reserved>0</is_reserved>
+      <is_public>1</is_public>
+      <icon></icon>
+    </CustomGroup>
+  </CustomGroups>
+  <CustomFields>
+    <CustomField>
+      <name>Bank_Name</name>
+      <label>Bank Name</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>1</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>bank_name_69</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>IBAN</name>
+      <label>IBAN</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>2</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>iban_70</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Account_Holder_Name</name>
+      <label>Account Holder Name</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>3</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>account_holder_name_71</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Sort_code</name>
+      <label>Sort code</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>4</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>sort_code_72</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Account_number</name>
+      <label>Account number</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>5</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>account_number_73</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Notes</name>
+      <label>Notes</label>
+      <data_type>Memo</data_type>
+      <html_type>TextArea</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>6</weight>
+      <attributes>rows=4, cols=60</attributes>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>notes_74</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+  </CustomFields>
+</CustomData>

--- a/xml/custom_fields/payment_bank_details_install.xml
+++ b/xml/custom_fields/payment_bank_details_install.xml
@@ -10,7 +10,7 @@
       <collapse_display>0</collapse_display>
       <help_pre></help_pre>
       <help_post></help_post>
-      <weight>33</weight>
+      <weight>10</weight>
       <is_active>0</is_active>
       <table_name>civicrm_value_awards_paymen_45</table_name>
       <is_multiple>0</is_multiple>
@@ -23,42 +23,12 @@
   </CustomGroups>
   <CustomFields>
     <CustomField>
-      <name>Bank_Name</name>
-      <label>Bank Name</label>
+      <name>Account_Holder_Name</name>
+      <label>Bank Account Holder's Name</label>
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_search_range>0</is_search_range>
       <weight>1</weight>
-      <is_active>1</is_active>
-      <text_length>255</text_length>
-      <note_columns>60</note_columns>
-      <note_rows>4</note_rows>
-      <column_name>bank_name_69</column_name>
-      <in_selector>0</in_selector>
-      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
-    </CustomField>
-    <CustomField>
-      <name>IBAN</name>
-      <label>IBAN</label>
-      <data_type>String</data_type>
-      <html_type>Text</html_type>
-      <is_search_range>0</is_search_range>
-      <weight>2</weight>
-      <is_active>1</is_active>
-      <text_length>255</text_length>
-      <note_columns>60</note_columns>
-      <note_rows>4</note_rows>
-      <column_name>iban_70</column_name>
-      <in_selector>0</in_selector>
-      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
-    </CustomField>
-    <CustomField>
-      <name>Account_Holder_Name</name>
-      <label>Account Holder Name</label>
-      <data_type>String</data_type>
-      <html_type>Text</html_type>
-      <is_search_range>0</is_search_range>
-      <weight>3</weight>
       <is_active>1</is_active>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
@@ -68,23 +38,57 @@
       <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
     </CustomField>
     <CustomField>
-      <name>Sort_code</name>
-      <label>Sort code</label>
+      <name>Account_Holder_s_Address</name>
+      <label>Account Holder's Address</label>
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_search_range>0</is_search_range>
-      <weight>4</weight>
+      <weight>2</weight>
+      <help_pre>Please use the address which is linked to the account</help_pre>
       <is_active>1</is_active>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
-      <column_name>sort_code_72</column_name>
+      <column_name>account_holder_s_address_81</column_name>
       <in_selector>0</in_selector>
       <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
     </CustomField>
     <CustomField>
-      <name>Account_number</name>
-      <label>Account number</label>
+      <name>Bank_Name</name>
+      <label>Bank Name</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>0</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>3</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>bank_name_69</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Bank_Address</name>
+      <label>Bank Address</label>
+      <data_type>Memo</data_type>
+      <html_type>TextArea</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>4</weight>
+      <attributes>rows=4, cols=60</attributes>
+      <is_active>1</is_active>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>bank_address_82</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>SWIFT_code_BIC</name>
+      <label>SWIFT code/BIC</label>
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_search_range>0</is_search_range>
@@ -93,7 +97,55 @@
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
+      <column_name>swift_code_bic_83</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>IBAN_Branch</name>
+      <label>IBAN Branch</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>6</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>iban_branch_84</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Account_number</name>
+      <label>Account number</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>0</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>7</weight>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
       <column_name>account_number_73</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Routing_Code</name>
+      <label>Routing Code</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_search_range>0</is_search_range>
+      <weight>8</weight>
+      <is_active>1</is_active>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>routing_code_85</column_name>
       <in_selector>0</in_selector>
       <custom_group_name>Awards_Payment_Bank_Details</custom_group_name>
     </CustomField>
@@ -103,10 +155,9 @@
       <data_type>Memo</data_type>
       <html_type>TextArea</html_type>
       <is_search_range>0</is_search_range>
-      <weight>6</weight>
+      <weight>10</weight>
       <attributes>rows=4, cols=60</attributes>
       <is_active>1</is_active>
-      <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <column_name>notes_74</column_name>


### PR DESCRIPTION
## Overview
This PR adds the `Awards Payment Bank Details` custom field set for a contact. This custom field set is available for all contacts. 
The Custom field set is created disabled but will be enabled when the `Enable Finance Management` checkbox on the instance configuration screen is enabled and saved.
The first time an instance type has `Finance management` checkbox enabled this custom field set is also enabled. The custom field set is not disable if the `Enable Finance Management` is disabled/unchecked. It is  kept enabled.

## Before
This custom field set is not added. 

## After
The `Awards Payment Bank Details` custom field set is added on installation of extension and also an upgrader is added to add this field set for existing clients. The logic to also enable this custom field set is added.

Custom Fields For the `Awards Payment Bank Details` field set:

- Bank Account Holder's Name (Alphanumeric - singleline input - 255)
- Account Holder's Address; Pre Help in (question): Please use theaddress which is linked to the account
- Bank Name (Alphanumeric - singleline input - 255)
- Bank Address - Note - multiline (not wysiwyg) 4 rows / 60 width)
- SWIFT code/BIC (Alphanumeric - singleline input - 255)
- IBAN Branch (Alphanumeric - singleline input - 255)
- Account number (Alphanumeric - singleline input - 255)
- Routing Code (Alphanumeric - singleline input - 255)
- Currency In Which Account Is Held; link to to the "currencies enabled" option group
- Notes; Note - multiline (not wysiwyg) 4 rows / 60 width)


<img width="1273" alt="Prospectingcase-suite com  CaseLatest 2021-01-14 11-09-53" src="https://user-images.githubusercontent.com/6951813/104577110-61557280-5659-11eb-8977-03aeab2298d1.png">

The Custom field set is enabled when the Finance Management setting added [here](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/163) is checked. 

## Technical Details
- The `Awards Payment Bank Details` custom field set is created on a local site and the xml generated with `civix` for use in the installer and Upgrader.
