### PR TITLE
RSE-1597: Block reviews for disabled applications

### DIFF
--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
@@ -4,6 +4,7 @@
       class="btn btn-primary crm-popup civiawards__reviews-tab__action-button"
       ng-click="handleAddReviewActivity()"
       type="button"
+      ng-disabled="caseItem['case_type_id.is_active'] === '0'"
     >
       <i class="material-icons civicase__icon">add_circle</i>
       {{ts('Add Review')}}
@@ -59,6 +60,7 @@
                 aria-expanded="false"
                 uib-dropdown-toggle
                 aria-label="{{ ts('Actions') }}"
+                ng-disabled="caseItem['case_type_id.is_active'] === '0'"
               >
                 <i class="material-icons">more_vert</i>
               </button>

--- a/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
@@ -19,10 +19,15 @@
     }));
 
     describe('after the awards module has been configured', () => {
+      const AWARD_BUTTON_PATH = '~/civiawards/dashboard/directives/edit-award-button.html';
+
       it('it adds the edit award button template to the awards case type', () => {
         expect(DashboardCaseTypeItems).toEqual({
           [AwardMockData[0].name]: [{
-            templateUrl: '~/civiawards/dashboard/directives/edit-award-button.html'
+            templateUrl: AWARD_BUTTON_PATH
+          }],
+          [AwardMockData[1].name]: [{
+            templateUrl: AWARD_BUTTON_PATH
           }]
         });
       });

--- a/ang/test/mocks/configs/awards-case-types.config.js
+++ b/ang/test/mocks/configs/awards-case-types.config.js
@@ -1,9 +1,7 @@
-(function () {
+((_) => {
   var module = angular.module('civiawards.data');
 
   module.config((AwardMockData, CaseTypesMockDataProvider) => {
-    CaseTypesMockDataProvider.add({
-      [AwardMockData.id]: AwardMockData[0]
-    });
+    _.each(AwardMockData, CaseTypesMockDataProvider.add);
   });
-}());
+})(CRM._);

--- a/ang/test/mocks/data/award.data.js
+++ b/ang/test/mocks/data/award.data.js
@@ -19,7 +19,7 @@
     is_forkable: '1',
     is_forked: ''
   }, {
-    id: '10',
+    id: '11',
     name: 'new_award_2',
     title: 'New Award 2',
     description: 'Description 2',


### PR DESCRIPTION
## Overview
This PR blocks reviews from being added or updated for disabled applications.

This PR depends on https://github.com/compucorp/uk.co.compucorp.civicase/pull/679

## Before & After
Please look the last part of the civicase PR.


## Technical Details

* The "Add Review" and review action buttons are disabled when the case is disabled.
* Unit tests have been fixed as they were failing before. Civicase updated the way mocked case types are added here https://github.com/compucorp/uk.co.compucorp.civicase/pull/671/files#diff-6549489c078a5b7f418956858cebef0412da1eafa451159dd8e15c4e875db017R415-R421 because the way we were adding data was not consistent. We were passing arrays when we needed to be passing objects. To avoid having inconsistent behaviour only a single case type data object is accepted so we use `_.each` to pass all award case types.