### PR TITLE
RSE-1620: Fix Award Custom Fields Leakage Bug

### DIFF
--- a/CRM/CiviAwards/Service/ApplicantManagementCustomGroupPostProcessor.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementCustomGroupPostProcessor.php
@@ -54,11 +54,13 @@ class CRM_CiviAwards_Service_ApplicantManagementCustomGroupPostProcessor extends
       return;
     }
 
-    $subTypes = empty($customGroup->extends_entity_column_value) ? [] : explode(CRM_Core_DAO::VALUE_SEPARATOR, $customGroup->extends_entity_column_value);
+    $subTypes = empty($customGroup->extends_entity_column_value) || $customGroup->extends_entity_column_value === 'null'
+      ? []
+      : explode(CRM_Core_DAO::VALUE_SEPARATOR, $customGroup->extends_entity_column_value);
     $this->postProcessHelper->updateCustomGroupSubTypesList($customGroup->id, $subTypes);
 
     $caseTypeIds = $this->postProcessHelper->getCaseTypesForSubType($this->caseTypeCategories[$customGroup->extends], $subTypes);
-    $ids = 'null';
+    $ids = CRM_Core_DAO::VALUE_SEPARATOR . 0 . CRM_Core_DAO::VALUE_SEPARATOR;
     if (!empty($caseTypeIds)) {
       $ids = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $caseTypeIds) . CRM_Core_DAO::VALUE_SEPARATOR;
     }

--- a/tests/phpunit/CRM/CiviAwards/Service/ApplicantManagementCustomGroupPostProcessorTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/ApplicantManagementCustomGroupPostProcessorTest.php
@@ -86,7 +86,7 @@ class CRM_CiviAwards_Service_ApplicantManagementCustomGroupPostProcessorTest ext
       ],
       [
         2,
-        'null',
+        CRM_Core_DAO::VALUE_SEPARATOR . 0 . CRM_Core_DAO::VALUE_SEPARATOR,
         NULL,
       ],
       [


### PR DESCRIPTION
## Overview
This pr fixes the bug which was causing the awards custom field to leak into other case type category instances.

## Before
There were two causes for this bug one was when creating a custom field set for award sub types that do not have any case type associated to them yet the custom field set used to leak into other case category instances and secondly when selecting `any` from the sub type list while creating custom field set there was a glitch in the code due to which the custom field set was not attached to any award.

## After
Above mentioned both the problems are fixed.

## Technical Details
`saveCustomGroupForCaseCategory` function in file `CRM/CiviAwards/Service/ApplicantManagementCustomGroupPostProcessor.php` has been modified in such a way to use 0 as the default value for case types if there are no linked awards to the selected sub types which prevent the field set from leaking to other instances. Code glitch was also fixed in this same function to make `any` sub type option work properly. 