### PR TITLE
CPS-423: Sync Log Tables With Actual Tables While Running Upgraders

### DIFF
--- a/CRM/CiviAwards/Upgrader/Steps/Step1007.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1007.php
@@ -16,6 +16,7 @@ class CRM_CiviAwards_Upgrader_Steps_Step1007 {
   public function apply() {
     $this->renameDbColumn();
     $this->renameOptionGroup();
+    $this->syncLogTables();
 
     return TRUE;
   }
@@ -50,6 +51,14 @@ class CRM_CiviAwards_Upgrader_Steps_Step1007 {
       CHANGE award_type award_subtype varchar(30) NOT NULL COMMENT 'One of the values of the award_subtype option group'";
 
     CRM_Core_DAO::executeQuery($renameColumnSql);
+  }
+
+  /**
+   * Sync log tables.
+   */
+  private function syncLogTables() {
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferencesFor(CRM_CiviAwards_BAO_AwardDetail::getTableName());
   }
 
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1008.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1008.php
@@ -16,6 +16,7 @@ class CRM_CiviAwards_Upgrader_Steps_Step1008 {
    */
   public function apply() {
     $this->addIsTemplateColumn();
+    $this->syncLogTables();
 
     return TRUE;
   }
@@ -32,6 +33,14 @@ class CRM_CiviAwards_Upgrader_Steps_Step1008 {
         ALTER TABLE {$awardDetailTable}
         ADD COLUMN {$isTemplateColumn} tinyint DEFAULT 0 COMMENT 'Whether the award detail is for a template or not'");
     }
+  }
+
+  /**
+   * Sync log tables.
+   */
+  private function syncLogTables() {
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferencesFor(AwardDetail::getTableName());
   }
 
 }


### PR DESCRIPTION
## Overview
This pr fixes the error which occurred during deployment due to the fact that some upgraders were modifying the tables but not applying the change to the log table.

## Before
Running this upgraders resulted in an error that halted the whole deployment process.

## After
The code for syncing the log tables with new changes have been added to the upgraders.

## Technical Details
`Step1007.php` and `Step1007.php` has been updated with the code for syncing the log tables.