### PR TITLE
RSE-1627: Fix award filter notifications

### DIFF
--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -21,6 +21,14 @@
   function MoreFiltersDashboardActionButtonController ($rootScope, $scope, $q,
     Select2Utils, civicaseCrmApi, dialogService, ts, CaseStatus, AwardSubtype,
     isApplicationManagementScreen, processMyAwardsFilter) {
+    var DEFAULT_FILTERS = {
+      awardFilter: 'my_awards',
+      statuses: '',
+      award_subtypes: '',
+      start_date: null,
+      end_date: null,
+      showDisabledAwards: false
+    };
     var model = {
       statuses: _.map(CaseStatus.getAll(), mapSelectOptions),
       award_subtypes: _.map(AwardSubtype.getAll(), mapSelectOptions),
@@ -28,13 +36,7 @@
         { text: ts('My Awards'), id: 'my_awards' },
         { text: ts('All Awards'), id: 'all_awards' }
       ],
-      selectedFilters: {
-        awardFilter: 'my_awards',
-        statuses: '',
-        award_subtypes: '',
-        start_date: null,
-        end_date: null
-      },
+      selectedFilters: _.clone(DEFAULT_FILTERS),
       applyFilterAndCloseDialog: applyFilterAndCloseDialog
     };
 
@@ -49,18 +51,13 @@
     }());
 
     /**
-     * Checks if Notification should be visible
+     * Checks if Notification should be visible. This is true when the user
+     * has selected a new filter value different from the default state.
      *
      * @returns {boolean} if Notification should be visible
      */
     function isNotificationVisible () {
-      return !_.isEqual(model.selectedFilters, {
-        awardFilter: 'my_awards',
-        statuses: '',
-        award_subtypes: '',
-        start_date: null,
-        end_date: null
-      });
+      return !_.isEqual(model.selectedFilters, DEFAULT_FILTERS);
     }
 
     /**

--- a/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.js
@@ -27,7 +27,7 @@
       award_subtypes: '',
       start_date: null,
       end_date: null,
-      showDisabledAwards: false
+      onlyShowDisabledAwards: false
     };
     var model = {
       statuses: _.map(CaseStatus.getAll(), mapSelectOptions),
@@ -89,7 +89,7 @@
       processMyAwardsFilter(model.selectedFilters.awardFilter)
         .then(processAwardSubtypeFilters)
         .then(function (awardSubtypeIds) {
-          var isCaseTypeActive = model.selectedFilters.showDisabledAwards
+          var isCaseTypeActive = model.selectedFilters.onlyShowDisabledAwards
             ? '0'
             : '1';
           var param = {

--- a/ang/civiawards/dashboard/directives/more-filters-popup.html
+++ b/ang/civiawards/dashboard/directives/more-filters-popup.html
@@ -27,9 +27,9 @@
       <br />
       <div
         civicase-checkbox
-        ng-model="model.selectedFilters.showDisabledAwards"
+        ng-model="model.selectedFilters.onlyShowDisabledAwards"
       >
-        {{ts('Show Disabled Awards')}}
+        {{ts('Only Show Disabled Awards')}}
       </div>
     </div>
 

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -120,7 +120,7 @@
             dialogModel.selectedFilters.end_date = '15/12/2019';
             dialogModel.selectedFilters.award_subtypes = '1,2';
             dialogModel.selectedFilters.statuses = '2,3';
-            dialogModel.selectedFilters.showDisabledAwards = false;
+            dialogModel.selectedFilters.onlyShowDisabledAwards = false;
             dialogModel.applyFilterAndCloseDialog();
             $rootScope.$digest();
           });
@@ -150,7 +150,7 @@
         describe('disabled awards', () => {
           describe('when showing disabled awards', () => {
             beforeEach(() => {
-              dialogModel.selectedFilters.showDisabledAwards = true;
+              dialogModel.selectedFilters.onlyShowDisabledAwards = true;
               dialogModel.applyFilterAndCloseDialog();
               $rootScope.$digest();
             });
@@ -167,7 +167,7 @@
 
           describe('when hiding disabled awards', () => {
             beforeEach(() => {
-              dialogModel.selectedFilters.showDisabledAwards = false;
+              dialogModel.selectedFilters.onlyShowDisabledAwards = false;
               dialogModel.applyFilterAndCloseDialog();
               $rootScope.$digest();
             });
@@ -219,7 +219,7 @@
           dialogModel.selectedFilters.award_subtypes = '';
           dialogModel.selectedFilters.start_date = null;
           dialogModel.selectedFilters.end_date = null;
-          dialogModel.selectedFilters.showDisabledAwards = false;
+          dialogModel.selectedFilters.onlyShowDisabledAwards = false;
           dialogModel.applyFilterAndCloseDialog();
         });
 
@@ -235,7 +235,7 @@
           dialogModel.selectedFilters.award_subtypes = '';
           dialogModel.selectedFilters.start_date = null;
           dialogModel.selectedFilters.end_date = null;
-          dialogModel.selectedFilters.showDisabledAwards = false;
+          dialogModel.selectedFilters.onlyShowDisabledAwards = false;
           dialogModel.applyFilterAndCloseDialog();
         });
 

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -219,6 +219,7 @@
           dialogModel.selectedFilters.award_subtypes = '';
           dialogModel.selectedFilters.start_date = null;
           dialogModel.selectedFilters.end_date = null;
+          dialogModel.selectedFilters.showDisabledAwards = false;
           dialogModel.applyFilterAndCloseDialog();
         });
 
@@ -234,6 +235,7 @@
           dialogModel.selectedFilters.award_subtypes = '';
           dialogModel.selectedFilters.start_date = null;
           dialogModel.selectedFilters.end_date = null;
+          dialogModel.selectedFilters.showDisabledAwards = false;
           dialogModel.applyFilterAndCloseDialog();
         });
 


### PR DESCRIPTION
## Overview
This PR fixes the notifications for the award filters on the dashboard. The notification red mark would stay on as soon as the filter's value changed and would not be removed, as per its normal behaviour, after reverting back the form to its original state.

It also updates the label for the disabled awards filter. The reason for the change is to make it explicit that only disabled awards and applications will be displayed instead of giving the impression of showing both enabled and disabled awards and applications.

This PR is related to https://github.com/compucorp/uk.co.compucorp.civicase/pull/687

## Before
![pr](https://user-images.githubusercontent.com/1642119/105797536-8bb30400-5f66-11eb-9c14-00da3908ed77.gif)


## After
![pr](https://user-images.githubusercontent.com/1642119/105796789-fe6faf80-5f65-11eb-886d-84d7272d1d95.gif)


## Technical Details

* We updated the `isNotificationVisible` function in `more-filters-dashboard-action-button.controller.js ` so it includes the disabled award filter in the check.
* The filter was renamed to `onlyShowDisabledAwards`.
* The label for the filter was updated.
