### PR TITLE
RSE-1295: Fix Create/Edit Award Redirection

### DIFF
--- a/ang/civiawards-workflow/services/applicant-management-workflow.service.js
+++ b/ang/civiawards-workflow/services/applicant-management-workflow.service.js
@@ -28,7 +28,7 @@
      * @returns {string} url to edit workflow page
      */
     function getEditWorkflowURL (workflow) {
-      return 'civicrm/award/a/#/awards/' + workflow.case_type_category + '/' + workflow.id;
+      return 'civicrm/award/a/#/awards/' + workflow.case_type_category + '/' + workflow.id + '/' + 'workflow';
     }
 
     /**
@@ -179,7 +179,7 @@
      * @param {object} caseTypeCategory case type category object
      */
     function redirectToWorkflowCreationScreen (caseTypeCategory) {
-      $window.location.href = '/civicrm/award/a/#/awards/new/' + caseTypeCategory.value;
+      $window.location.href = '/civicrm/award/a/#/awards/new/' + caseTypeCategory.value + '/workflow';
     }
   }
 })(CRM._, angular);

--- a/ang/civiawards/app.routes.js
+++ b/ang/civiawards/app.routes.js
@@ -2,14 +2,14 @@
   var module = angular.module('civiawards');
 
   module.config(function ($routeProvider) {
-    $routeProvider.when('/awards/new/:caseTypeCategoryId', {
+    $routeProvider.when('/awards/new/:caseTypeCategoryId/:redirectTo', {
       template: function (params) {
-        return '<civiaward case-type-category-id="' + params.caseTypeCategoryId + '"></civiaward>';
+        return '<civiaward case-type-category-id="' + params.caseTypeCategoryId + '" redirect-to="' + params.redirectTo + '"></civiaward>';
       }
     });
-    $routeProvider.when('/awards/:caseTypeCategoryId/:awardId/:focusedTabName?', {
+    $routeProvider.when('/awards/:caseTypeCategoryId/:awardId/:redirectTo/:focusedTabName?', {
       template: function (params) {
-        return '<civiaward award-id="' + params.awardId + '" case-type-category-id="' + params.caseTypeCategoryId + '" focused-tab-name="' + params.focusedTabName + '"></civiaward>';
+        return '<civiaward award-id="' + params.awardId + '" case-type-category-id="' + params.caseTypeCategoryId + '" focused-tab-name="' + params.focusedTabName + '" redirect-to="' + params.redirectTo + '"></civiaward>';
       }
     });
   });

--- a/ang/civiawards/award-creation/directives/award.directive.html
+++ b/ang/civiawards/award-creation/directives/award.directive.html
@@ -71,11 +71,11 @@
           <button
             ng-disabled="ifSaveButtonDisabled()"
             type="button"
-            ng-click="saveAndNavigateToDashboard()" class="btn btn-primary">
+            ng-click="saveAndNavigateToPreviousPage()" class="btn btn-primary">
             Save and Done
           </button>
           <button
-            ng-click="navigateToDashboard()" class="btn btn-secondary-outline">
+            ng-click="navigateToPreviousPage()" class="btn btn-secondary-outline">
             Cancel
           </button>
         </div>

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -6,6 +6,7 @@
       scope: {
         awardId: '=',
         caseTypeCategoryId: '=',
+        redirectTo: '@',
         focusedTabName: '@'
       },
       controller: 'CiviAwardCreateEditAwardController',
@@ -57,8 +58,8 @@
     $scope.selectTab = selectTab;
     $scope.saveAwardInBG = saveAwardInBG;
     $scope.saveNewAward = saveNewAward;
-    $scope.saveAndNavigateToDashboard = saveAndNavigateToDashboard;
-    $scope.navigateToDashboard = navigateToDashboard;
+    $scope.saveAndNavigateToPreviousPage = saveAndNavigateToPreviousPage;
+    $scope.navigateToPreviousPage = navigateToPreviousPage;
 
     (function init () {
       if ($scope.awardId) {
@@ -184,11 +185,11 @@
     }
 
     /**
-     * Saves an existing Award and navigates to dashboard
+     * Saves an existing Award and navigates to the previous page
      */
-    function saveAndNavigateToDashboard () {
+    function saveAndNavigateToPreviousPage () {
       saveAward()
-        .then(navigateToDashboard)
+        .then(navigateToPreviousPage)
         .then(showSucessNotification);
     }
 
@@ -252,12 +253,17 @@
     }
 
     /**
-     * Navigate to the Dashboard Page
+     * Navigate to the Previous Page
      */
-    function navigateToDashboard () {
+    function navigateToPreviousPage () {
       var caseTypeCategoryName = CaseTypeCategory.findById($scope.caseTypeCategoryId).name;
+      var url = '/civicrm/workflow/a?case_type_category=' + caseTypeCategoryName + '#/list';
 
-      $window.location.href = '/civicrm/case/a/?case_type_category=' + caseTypeCategoryName + '#/case?case_type_category=' + caseTypeCategoryName;
+      if ($scope.redirectTo === 'dashboard') {
+        url = '/civicrm/case/a/?case_type_category=' + caseTypeCategoryName + '#/case?case_type_category=' + caseTypeCategoryName;
+      }
+
+      $window.location.href = url;
     }
 
     /**
@@ -266,7 +272,7 @@
      * @param {string/number} awardID id of the award
      */
     function navigateToAwardEditPage (awardID) {
-      $location.path('/awards/' + $scope.caseTypeCategoryId + '/' + awardID + '/stages');
+      $location.path('/awards/' + $scope.caseTypeCategoryId + '/' + awardID + '/' + $scope.redirectTo + '/stages');
     }
 
     /**

--- a/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
@@ -32,7 +32,7 @@
      */
     function redirectToAwardsCreationScreen () {
       var currentCaseTypeCategoryValue = CaseTypeCategory.findByName($routeParams.case_type_category).value;
-      var newAwardUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + currentCaseTypeCategoryValue);
+      var newAwardUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + currentCaseTypeCategoryValue + '/dashboard');
 
       $window.location.href = newAwardUrl;
     }

--- a/ang/civiawards/dashboard/directives/edit-award-button.controller.js
+++ b/ang/civiawards/dashboard/directives/edit-award-button.controller.js
@@ -1,4 +1,4 @@
-(function (angular, getCrmUrl) {
+(function (angular) {
   var module = angular.module('civiawards');
 
   module.controller('EditAwardButtonController', EditAwardButtonController);
@@ -18,6 +18,6 @@
 
     $scope.canEditAwards = canCreateOrEditAwards;
     $scope.editAwardUrl = 'civicrm/award/a/#/awards/' +
-     currentCaseTypeCategoryValue + '/' + $scope.caseType.id;
+     currentCaseTypeCategoryValue + '/' + $scope.caseType.id + '/' + 'dashboard';
   }
-})(angular, CRM.url);
+})(angular);

--- a/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
+++ b/ang/test/civiawards-workflow/services/applicant-management-workflow.service.spec.js
@@ -142,7 +142,7 @@
       });
 
       it('redirects to the case management new workflow page', () => {
-        expect($window.location.href).toBe('/civicrm/award/a/#/awards/new/2');
+        expect($window.location.href).toBe('/civicrm/award/a/#/awards/new/2/workflow');
       });
     });
 
@@ -156,7 +156,7 @@
       });
 
       it('redirects to the case type page for the clicked workflow', () => {
-        expect(returnValue).toBe('civicrm/award/a/#/awards/1/1');
+        expect(returnValue).toBe('civicrm/award/a/#/awards/1/1/workflow');
       });
     });
   });

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -399,45 +399,92 @@
     });
 
     describe('when saving a new award', () => {
-      beforeEach(() => {
-        createController({ ifNewAward: true });
-        setAwardDetails();
+      describe('from dashboard', () => {
+        beforeEach(() => {
+          createController({ ifNewAward: true, redirectTo: 'dashboard' });
+          setAwardDetails();
 
-        $scope.saveNewAward();
-        $scope.$digest();
+          $scope.saveNewAward();
+          $scope.$digest();
+        });
+
+        it('redirects to edit the award', () => {
+          expect($location.path).toHaveBeenCalledWith('/awards/3/10/dashboard/stages');
+        });
+
+        it('shows a notification after save is successfull', () => {
+          expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+        });
       });
 
-      it('redirects to edit the award', () => {
-        expect($location.path).toHaveBeenCalledWith('/awards/3/10/stages');
-      });
+      describe('from manage workflow page', () => {
+        beforeEach(() => {
+          createController({ ifNewAward: true, redirectTo: 'workflow' });
+          setAwardDetails();
 
-      it('shows a notification after save is successfull', () => {
-        expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+          $scope.saveNewAward();
+          $scope.$digest();
+        });
+
+        it('redirects to edit the award', () => {
+          expect($location.path).toHaveBeenCalledWith('/awards/3/10/workflow/stages');
+        });
+
+        it('shows a notification after save is successfull', () => {
+          expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+        });
       });
     });
 
     describe('when SAVE AND DONE is clicked', () => {
-      beforeEach(() => {
-        createController({ ifNewAward: true });
-        setAwardDetails();
+      describe('from dashboard', () => {
+        beforeEach(() => {
+          createController({ ifNewAward: true, redirectTo: 'dashboard' });
+          setAwardDetails();
 
-        $scope.saveAndNavigateToDashboard();
-        $scope.$digest();
+          $scope.saveAndNavigateToPreviousPage();
+          $scope.$digest();
+        });
+
+        it('shows saving notification while save is in progress', () => {
+          expect(crmStatus).toHaveBeenCalledWith({
+            start: $scope.ts('Saving Award...'),
+            success: $scope.ts('Saved')
+          }, jasmine.any(Object));
+        });
+
+        it('redirects to award dashboard page', () => {
+          expect($window.location.href).toBe('/civicrm/case/a/?case_type_category=awards#/case?case_type_category=awards');
+        });
+
+        it('shows a notification after save is successfull', () => {
+          expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+        });
       });
 
-      it('shows saving notification while save is in progress', () => {
-        expect(crmStatus).toHaveBeenCalledWith({
-          start: $scope.ts('Saving Award...'),
-          success: $scope.ts('Saved')
-        }, jasmine.any(Object));
-      });
+      describe('from manage workflow page', () => {
+        beforeEach(() => {
+          createController({ ifNewAward: true, redirectTo: 'workflow' });
+          setAwardDetails();
 
-      it('redirects to award dashboard page', () => {
-        expect($window.location.href).toBe('/civicrm/case/a/?case_type_category=awards#/case?case_type_category=awards');
-      });
+          $scope.saveAndNavigateToPreviousPage();
+          $scope.$digest();
+        });
 
-      it('shows a notification after save is successfull', () => {
-        expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+        it('shows saving notification while save is in progress', () => {
+          expect(crmStatus).toHaveBeenCalledWith({
+            start: $scope.ts('Saving Award...'),
+            success: $scope.ts('Saved')
+          }, jasmine.any(Object));
+        });
+
+        it('redirects to manage awards page', () => {
+          expect($window.location.href).toBe('/civicrm/workflow/a?case_type_category=awards#/list');
+        });
+
+        it('shows a notification after save is successfull', () => {
+          expect(CRM.alert).toHaveBeenCalledWith('Award Successfully Saved.', 'Saved', 'success');
+        });
       });
     });
 
@@ -473,6 +520,7 @@
       }
 
       $scope.caseTypeCategoryId = '3';
+      $scope.redirectTo = params.redirectTo;
 
       $controller('CiviAwardCreateEditAwardController', {
         $scope: $scope

--- a/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-(function (_, angular, getCrmUrl) {
+(function (_) {
   var AWARDS_CATEGORY_NAME = 'awards';
 
   describe('Case Type Items configuration', () => {
@@ -48,4 +48,4 @@
       });
     });
   });
-})(CRM._, angular, CRM.url);
+})(CRM._);

--- a/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
@@ -71,7 +71,7 @@
 
     describe('when clicking the action button', () => {
       const awardCaseTypeCategoryId = 3;
-      const expectedUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + awardCaseTypeCategoryId);
+      const expectedUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + awardCaseTypeCategoryId + '/dashboard');
 
       beforeEach(() => {
         spyOn($location, 'url');


### PR DESCRIPTION
## Overview
Previously, when pressing the "Save and Done" or "Cancel" button from Award Create/Edit screen, browser always redirected to Dashboard. Now, the redirection happens to Dashboard if Create/Edit Award was clicked from Dashboard. Otherwise the browser redirects to the Manage Awards screen.

## Technical Details
In `ang/civiawards/app.routes.js`, added a new route parameter called `redirectTo`. 
When coming from Dashboard page, value of this Parameter is `Dashboard`, and when coming from Manage Awards page, the values is `workflow`. Based on this property, the redirection url is changed.