### PR TITLE
ACU-489: Award Payments Form Edit/View/Delete Business Logic

### DIFF
--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -477,11 +477,11 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
       $this->getValueForActivityStatus('exported_complete'),
     ];
 
-    return in_array($activityStatus, $notEditableStatuses) ? TRUE : FALSE;
+    return in_array($activityStatus, $notEditableStatuses);
   }
 
   /**
-   * Get pre-defined fields that are to be un-editable.
+   * Get pre-defined fields that are un-editable.
    *
    * @return array
    *   Form fields.

--- a/CRM/CiviAwards/Hook/BuildForm/SetCustomGroupSubTypeValues.php
+++ b/CRM/CiviAwards/Hook/BuildForm/SetCustomGroupSubTypeValues.php
@@ -74,7 +74,11 @@ class CRM_CiviAwards_Hook_BuildForm_SetCustomGroupSubTypeValues {
    */
   private function shouldRun($formName, CRM_Core_Form $form) {
     $defaults = $form->getVar('_defaults');
-    $extends = $defaults['extends'][0];
+
+    $extends = !empty($defaults['extends'][0]) ? $defaults['extends'][0] : [];
+    if (empty($extends)) {
+      return FALSE;
+    }
 
     return $formName == CRM_Custom_Form_Group::class &&
       $form->getVar('_action') != CRM_Core_Action::ADD &&

--- a/js/award-payment-form.js
+++ b/js/award-payment-form.js
@@ -1,0 +1,46 @@
+(function ($, nonEditableFields) {
+  $(document).on('crmLoad', function () {
+    (function init () {
+      makeFieldsNonEditable();
+      insertDeleteButtonAfterCancel();
+    })();
+
+    /**
+     * This function makes form fields that are supposed to be
+     * non editable based on some criteria to be non editable.
+     */
+    function makeFieldsNonEditable () {
+      nonEditableFields.forEach(function (field) {
+        var selector = '#' + field.name;
+        if (field.type === 'select2') {
+          $(selector).select2('readonly', true);
+        } else if (field.type === 'crmdatetime') {
+          $(selector).crmDatepicker('destroy').attr('readonly', true);
+        } else {
+          $(selector).attr('readonly', true);
+        }
+      });
+    }
+  });
+
+  /**
+   * Inserts the delete button to be right after cancel button.
+   */
+  function insertDeleteButtonAfterCancel () {
+    $('#award_payment_delete').insertAfter('.crm-button_qf_AwardPayment_cancel');
+  }
+
+  $('#award_payment_delete').click(function (e) {
+    e.preventDefault();
+    var activityId = $('input[name="activity_id"]').val();
+    CRM.confirm({ message: 'Please confirm you wish to delete this record?' }).on('crmConfirm:yes', function () {
+      CRM.api3('Activity', 'delete', { id: activityId }).done(function (result) {
+        if (result.is_error) {
+          CRM.alert(result.error_message, 'Error deleting Record', 'error');
+        }
+        CRM.alert('Record deleted successfully', 'Record Deleted', 'success');
+        window.location.href = '/civicrm/awardpayments';
+      });
+    });
+  });
+})(CRM.$, CRM.nonEditableFields, window);

--- a/templates/CRM/CiviAwards/Form/AwardPayment.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardPayment.tpl
@@ -13,11 +13,13 @@
         {/foreach}
     </div>
     <div class="crm-submit-buttons panel-footer clearfix">
-        {if $isViewAction}
+        {if $isViewAction && !$isActivityStatusExported}
           <a href="{crmURL p='civicrm/awardpayment' q=$editUrlParams}" class="edit button" title="{ts}Edit{/ts}"><span><i class="crm-i fa-pencil"></i> {ts}Edit{/ts}</span></a>
         {/if}
         {if $isViewAction || $isUpdateAction}
-          <a href="#" class="delete button" title="{ts}Delete{/ts}"><span><i class="crm-i fa-trash"></i> {ts}Delete{/ts}</span></a>
+            {if (call_user_func(array('CRM_Core_Permission','check'), 'delete activities') && !$activityStatusIsLocked) || call_user_func(array('CRM_Core_Permission','check'), 'administer CiviCRM')}
+              <a id='award_payment_delete' class="delete button" title="{ts}Delete{/ts}"><span><i class="crm-i fa-trash"></i> {ts}Delete{/ts}</span></a>
+            {/if}
         {/if}
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>

--- a/tests/phpunit/CRM/CiviAwards/Form/AwardPaymentTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Form/AwardPaymentTest.php
@@ -1,0 +1,281 @@
+<?php
+
+use CRM_CiviAwards_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_CiviAwards_Test_Fabricator_Case as CaseFabricator;
+
+/**
+ * Test class for Award Payment form.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Form_AwardPaymentTest extends BaseHeadlessTest {
+
+  use CRM_CiviAwards_Helper_SessionTrait;
+
+  /**
+   * Activity Statuses.
+   *
+   * @var array
+   */
+  private $activityStatuses;
+
+  /**
+   * Activity Contact.
+   *
+   * @var int
+   */
+  private $activityContact;
+
+  /**
+   * Case activity data.
+   *
+   * @var array
+   */
+  private $activityCase;
+
+  /**
+   * Set up data.
+   */
+  public function setUp() {
+    $this->activityContact = CRM_CiviAwards_Test_Fabricator_Contact::fabricate()['id'];
+    $this->setActivityStatuses();
+    $this->setActivityCase();
+  }
+
+  /**
+   * Test Error is thrown when updating exported activity.
+   */
+  public function testErrorIsThrownWhenUserIsTryingToUpdateAnExportedActivity() {
+    $activityId = $this->createActivity('exported_complete');
+    $form = $this->initializeAwardsForm(CRM_Core_Action::UPDATE);
+    $form->set('id', $activityId);
+    $form->set('case_id', $this->activityCase['id']);
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage(
+      "Action not supported!"
+    );
+    $form->preProcess();
+  }
+
+  /**
+   * Test activity is updated correctly.
+   */
+  public function testActivityFormValuesAreCorrectlyUpdated() {
+    $activityId = $this->createActivity('approved_complete');
+    $formValues = [
+      'status_id' => $this->getValueForActivityStatus('paid_complete'),
+      'target_contact_id' => 2,
+      'details' => 'This is test details',
+      'activity_date_time' => date('Y-m-d H:i:s'),
+    ];
+    $form = $this->initializeAwardsForm(CRM_Core_Action::UPDATE, $formValues);
+    $form->set('id', $activityId);
+    $form->buildForm();
+    $form->postProcess();
+    $result = $this->getActivity($activityId);
+    $this->assertEquals($formValues['details'], $result['details']);
+    $this->assertEquals($formValues['target_contact_id'], $result['target_contact_id'][0]);
+    $this->assertEquals($formValues['status_id'], $result['status_id']);
+  }
+
+  /**
+   * Test activity is created correctly.
+   */
+  public function testActivityIsCorrectlyCreated() {
+    $this->registerCurrentLoggedInContactInSession($this->activityContact);
+    $formValues = [
+      'status_id' => $this->getValueForActivityStatus('paid_complete'),
+      'target_contact_id' => $this->activityContact,
+      'details' => 'Test details',
+      'activity_date_time' => date('Y-m-d H:i:s'),
+    ];
+    $form = $this->initializeAwardsForm(CRM_Core_Action::ADD, $formValues);
+    $form->set('case_id', $this->activityCase['id']);
+    $form->buildForm();
+    $form->postProcess();
+    $result = $this->getActivity($this->getCaseActivity($this->activityCase['id']));
+    $this->assertEquals($formValues['details'], $result['details']);
+    $this->assertEquals($formValues['target_contact_id'], $result['target_contact_id'][0]);
+    $this->assertEquals($formValues['status_id'], $result['status_id']);
+    $this->assertEquals($this->activityCase['id'], $result['case_id'][0]);
+  }
+
+  /**
+   * Test activity status is exported correctly set in template.
+   *
+   * @dataProvider getDataForIsTestingIsExported
+   */
+  public function testIsExportedStatusIsCorrectlySet($activityStaus, $isExportedValue) {
+    $activityId = $this->createActivity($activityStaus);
+    $form = $this->initializeAwardsForm(CRM_Core_Action::VIEW);
+    $form->set('id', $activityId);
+    $form->buildForm();
+    $isActivityStatusExported = $form->getTemplate()->get_template_vars('isActivityStatusExported');
+    $this->assertEquals($isExportedValue, $isActivityStatusExported);
+  }
+
+  /**
+   * Test activity status is locked correctly set in template.
+   *
+   * @dataProvider getDataForActivityStatusIsLocked
+   */
+  public function testActivityStatusIsLockedCorrectlySet($activityStaus, $isExportedValue) {
+    $activityId = $this->createActivity($activityStaus);
+    $form = $this->initializeAwardsForm(CRM_Core_Action::VIEW);
+    $form->set('id', $activityId);
+    $form->buildForm();
+    $activityStatusIsLocked = $form->getTemplate()->get_template_vars('activityStatusIsLocked');
+    $this->assertEquals($isExportedValue, $activityStatusIsLocked);
+  }
+
+  /**
+   * Get activity linked to the case.
+   *
+   * @param int $caseId
+   *   Case Id.
+   *
+   * @return int
+   *   Activity id.
+   */
+  private function getCaseActivity($caseId) {
+    $activity = civicrm_api3('Activity', 'getsingle', [
+      'sequential' => 1,
+      'case_id' => $caseId,
+    ]);
+
+    return $activity['id'];
+  }
+
+  /**
+   * Data set for testIsExportedStatusIsCorrectlySet.
+   *
+   * @return array
+   *   Data set.
+   */
+  public function getDataForIsTestingIsExported() {
+    return [
+      ['approved_complete', FALSE],
+      ['approved_complete', FALSE],
+      ['exported_complete', TRUE],
+    ];
+  }
+
+  /**
+   * Data set for testActivityStatusIsLockedCorrectlySet.
+   *
+   * @return array
+   *   Data set.
+   */
+  public function getDataForActivityStatusIsLocked() {
+    return [
+      ['paid_complete', TRUE],
+      ['failed_incomplete', TRUE],
+      ['exported_complete', TRUE],
+      ['approved_complete', FALSE],
+      ['applied_for_incomplete', FALSE],
+    ];
+  }
+
+  /**
+   * Get activity.
+   *
+   * @param int $activityId
+   *   Activity Id.
+   *
+   * @return array
+   *   Activity data.
+   */
+  private function getActivity($activityId) {
+    return civicrm_api3('Activity', 'getsingle', [
+      'id' => $activityId,
+      'return' => [
+        'case_id',
+        'activity_date_time',
+        'target_contact_id',
+        'details',
+        'status_id',
+      ],
+    ]);
+  }
+
+  /**
+   * Get value for activity status.
+   *
+   * @param string $statusName
+   *   Status Name.
+   *
+   * @return mixed
+   *   Activity status value.
+   */
+  private function getValueForActivityStatus($statusName) {
+    $activityStatuses = $this->activityStatuses;
+    foreach ($activityStatuses as $activityStatus) {
+      if ($activityStatus['name'] == $statusName) {
+        return $activityStatus['value'];
+      }
+    }
+  }
+
+  /**
+   * Create Activity.
+   *
+   * @param string $activityStatusName
+   *   Activity status name.
+   *
+   * @return int
+   *   Activity Id.
+   */
+  public function createActivity($activityStatusName) {
+    $result = civicrm_api3('Activity', 'create', [
+      'status_id' => $this->getValueForActivityStatus($activityStatusName),
+      'source_contact_id' => $this->activityContact,
+      'case_id' => $this->activityCase['id'],
+      'activity_type_id' => 'Awards Payment',
+    ]);
+
+    return $result['id'];
+  }
+
+  /**
+   * Fabricates a case and sets it for use.
+   */
+  private function setActivityCase() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $this->activityCase = CaseFabricator::fabricate(
+      ['status_id' => 1, 'case_type_id' => $caseType['id']]
+    );
+  }
+
+  /**
+   * Sets the activity statuses.
+   */
+  private function setActivityStatuses() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'activity_status',
+      'grouping' => 'Awards Payments',
+    ]);
+
+    $this->activityStatuses = $result['values'];
+  }
+
+  /**
+   * Gets initialized form object.
+   *
+   * @param string $action
+   *   Form action.
+   * @param array $formValues
+   *   Form values.
+   *
+   * @return \CRM_CiviAwards_Form_AwardPayment
+   *   Form object.
+   */
+  private function initializeAwardsForm($action, array $formValues = []) {
+    $form = new CRM_CiviAwards_Form_AwardPayment();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_CiviAwards_Form_AwardPayment', 'Award Payment');
+    $form->_action = $action;
+    $form->_submitValues = $formValues;
+
+    return $form;
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Helper/SessionTrait.php
+++ b/tests/phpunit/CRM/CiviAwards/Helper/SessionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Session Helper trait.
+ */
+trait CRM_CiviAwards_Helper_SessionTrait {
+
+  /**
+   * Register contact in session.
+   *
+   * @param int $contactID
+   *   Contact Id.
+   */
+  private function registerCurrentLoggedInContactInSession($contactID) {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+  }
+
+  /**
+   * Unregister contact from session.
+   */
+  private function unregisterCurrentLoggedInContactFromSession() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', NULL);
+  }
+
+  /**
+   * Set permissions in session.
+   *
+   * @param array $permissions
+   *   Permissions.
+   */
+  private function setPermissions(array $permissions = []) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+  }
+
+}

--- a/xml/Menu/civiawards.xml
+++ b/xml/Menu/civiawards.xml
@@ -28,6 +28,6 @@
     <path>civicrm/awardpayment</path>
     <page_callback>CRM_CiviAwards_Form_AwardPayment</page_callback>
     <title>AwardPayment</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>create/edit awards</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR adds some business logic to the Awards Payments form. It adds logic that determines when a field is editable and who can edit it and also defines permissions for when an awards payment form can be deleted and who can delete. 

## Before
The business logic for editing/viewing/deleting an awards payment form was not present.

## After
**Edit Awards Payment FOrmBusiness Logic**
- If the status of the payment is in: "Exported, Paid, Failed" then the following fields are not editable by the user and are in a disabled state: Payee, Type, Payment amount, Payment currency, Due date, Payee ref. Note that the disabled fields are not validated on the backend, The purpose of the disabled fields just to denote the fact that they shouldn't be changed and they can easily be changed by simply changing the award payment status and re-submitting the form.

<img width="546" alt="Edit Payment  CaseLatest 2021-02-08 10-36-22" src="https://user-images.githubusercontent.com/6951813/107201948-ec781d00-69f9-11eb-96ec-0af9eb7a289c.png">



**View Award Payments Form Business Logic**
- The edit button on the form is not shown if the Award payment status is Exported

<img width="593" alt="View Payment  CaseLatest 2021-02-08 10-39-52" src="https://user-images.githubusercontent.com/6951813/107202077-103b6300-69fa-11eb-972c-cf8e202f447d.png">

**Delete Award Payments Form Business Logic**
- The delete button is only shown if the Award Payments status is not in Exported, Paid or Failed and user has "delete activities" permission OR if the user has the "Administer CiviCRM permission"


## Comments
Unit tests for the Award Payments form was added. The Form calls some hooks already added in the extension and the tests was throwing some errors due to some non existent variables in the hooks. This was fixed in both this extension and the civicase extension since civicase needs to be installed for awards extension to run.