### PR TITLE
CPS-443: Sync Log Tables In Base Upgrader

### DIFF
--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -201,7 +201,12 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
 
       case 'enqueue':
         $result = $this->enqueuePendingRevisions($queue);
-        $this->syncLogTables();
+        $syncLogTableTask = new CRM_Queue_Task(
+          [get_class($this), 'syncLogTables'],
+          [],
+          'Sync Log Tables'
+        );
+        $queue->createItem($syncLogTableTask);
         return $result;
 
       default:
@@ -210,10 +215,15 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
 
   /**
    * Sync log tables.
+   *
+   * @param CRM_Queue_TaskContext $context
+   *   Queue task context.
    */
-  private function syncLogTables() {
+  public function syncLogTables(CRM_Queue_TaskContext $context) {
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
+
+    return TRUE;
   }
 
 }

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -183,4 +183,37 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
     return ltrim($file, '_');
   }
 
+  /**
+   * On upgrade.
+   *
+   * @param string $op
+   *   Operation name.
+   * @param CRM_Queue_Queue|null $queue
+   *   Queue object.
+   *
+   * @return bool[]|void
+   *   Operation result.
+   */
+  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+    switch ($op) {
+      case 'check':
+        return [$this->hasPendingRevisions()];
+
+      case 'enqueue':
+        $result = $this->enqueuePendingRevisions($queue);
+        $this->syncLogTables();
+        return $result;
+
+      default:
+    }
+  }
+
+  /**
+   * Sync log tables.
+   */
+  private function syncLogTables() {
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
+  }
+
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1007.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1007.php
@@ -16,7 +16,6 @@ class CRM_CiviAwards_Upgrader_Steps_Step1007 {
   public function apply() {
     $this->renameDbColumn();
     $this->renameOptionGroup();
-    $this->syncLogTables();
 
     return TRUE;
   }
@@ -51,14 +50,6 @@ class CRM_CiviAwards_Upgrader_Steps_Step1007 {
       CHANGE award_type award_subtype varchar(30) NOT NULL COMMENT 'One of the values of the award_subtype option group'";
 
     CRM_Core_DAO::executeQuery($renameColumnSql);
-  }
-
-  /**
-   * Sync log tables.
-   */
-  private function syncLogTables() {
-    $logging = new CRM_Logging_Schema();
-    $logging->fixSchemaDifferencesFor(CRM_CiviAwards_BAO_AwardDetail::getTableName());
   }
 
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1008.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1008.php
@@ -16,7 +16,6 @@ class CRM_CiviAwards_Upgrader_Steps_Step1008 {
    */
   public function apply() {
     $this->addIsTemplateColumn();
-    $this->syncLogTables();
 
     return TRUE;
   }
@@ -33,14 +32,6 @@ class CRM_CiviAwards_Upgrader_Steps_Step1008 {
         ALTER TABLE {$awardDetailTable}
         ADD COLUMN {$isTemplateColumn} tinyint DEFAULT 0 COMMENT 'Whether the award detail is for a template or not'");
     }
-  }
-
-  /**
-   * Sync log tables.
-   */
-  private function syncLogTables() {
-    $logging = new CRM_Logging_Schema();
-    $logging->fixSchemaDifferencesFor(AwardDetail::getTableName());
   }
 
 }


### PR DESCRIPTION
## Overview
This pr adds the code for syncing the log tables with the actual changes at the end of upgrading process so that all the log tables schema remains in sync with the actual tables schema.

## Technical Details
This pr changes `CRM/CiviAwards/Upgrader.php` to include the code for syncing the log tables with the actual tables at the end of upgrading process.