### PR TITLE
ACU-495: Add payments pagination support

### DIFF
--- a/ang/civiawards-payments-tab/directives/payment-filters.directive.js
+++ b/ang/civiawards-payments-tab/directives/payment-filters.directive.js
@@ -7,8 +7,7 @@
       templateUrl: '~/civiawards-payments-tab/directives/payment-filters.directive.html',
       restrict: 'E',
       scope: {
-        filters: '=ngModel',
-        triggerNgChange: '&ngChange'
+        onFilter: '&'
       }
     };
   });

--- a/ang/civiawards-payments-tab/directives/payment-filters.directive.js
+++ b/ang/civiawards-payments-tab/directives/payment-filters.directive.js
@@ -7,7 +7,8 @@
       templateUrl: '~/civiawards-payments-tab/directives/payment-filters.directive.html',
       restrict: 'E',
       scope: {
-        onFilter: '&'
+        filters: '=ngModel',
+        triggerNgChange: '&ngChange'
       }
     };
   });

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.html
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.html
@@ -1,6 +1,7 @@
 <div class="panel panel-default table-responsive">
   <civiawards-payment-filters
-    on-filter="filterPayments($filters)"
+    ng-model="filters"
+    ng-change="filterPayments(filters)"
   ></civiawards-payment-filters>
   <table
     class="table"

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.html
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.html
@@ -1,6 +1,6 @@
 <div class="panel panel-default table-responsive">
   <civiawards-payment-filters
-    on-filter="filterPayments($filters)"
+    on-filter="submitFilters($filters)"
   ></civiawards-payment-filters>
   <table
     class="table"

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.html
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.html
@@ -37,6 +37,13 @@
       </tr>
     </tbody>
   </table>
+  <div class="panel-body" ng-if="paging.total > paging.pageSize">
+    <civicase-paging
+      class="pull-right"
+      paging-data="paging"
+      paging-action="goToPage($page)"
+    ></civicase-paging>
+  </div>
 </div>
 <div
   ng-if="payments.length === 0 && !isLoading"

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.html
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.html
@@ -1,7 +1,6 @@
 <div class="panel panel-default table-responsive">
   <civiawards-payment-filters
-    ng-model="filters"
-    ng-change="filterPayments(filters)"
+    on-filter="filterPayments($filters)"
   ></civiawards-payment-filters>
   <table
     class="table"

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.js
@@ -28,7 +28,6 @@
     var currentFilters = {};
     var customFields = [];
 
-    $scope.filters = {};
     $scope.isLoading = false;
 
     $scope.filterPayments = filterPayments;

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.js
@@ -28,6 +28,7 @@
     var currentFilters = {};
     var customFields = [];
 
+    $scope.filters = {};
     $scope.isLoading = false;
 
     $scope.filterPayments = filterPayments;

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.js
@@ -31,8 +31,8 @@
     $scope.isLoading = false;
     $scope.paging = { page: 1, pageSize: 25, total: 0, isDisabled: false };
 
-    $scope.filterPayments = filterPayments;
     $scope.goToPage = goToPage;
+    $scope.submitFilters = submitFilters;
 
     (function init () {
       filterPayments();
@@ -53,7 +53,6 @@
     function filterPayments (filters) {
       var realNameFilters = getFiltersRealNamesAndValues(filters);
       $scope.isLoading = true;
-      currentFilters = filters;
       $scope.paging.isDisabled = true;
 
       getPaymentActivitiesRequests(realNameFilters)
@@ -171,6 +170,21 @@
       $scope.paging.page = pageNumber;
 
       filterPayments(currentFilters);
+    }
+
+    /**
+     * Accepts payment filters and loads the payments that match
+     * the given filters. It will always show the first filtered page by
+     * default. The filters are stored temporarily in case the values are
+     * needed for refreshing the payments list.
+     *
+     * @param {object} filters parameters used to filter the payments.
+     */
+    function submitFilters (filters) {
+      currentFilters = filters;
+      $scope.paging.page = 1;
+
+      filterPayments(filters);
     }
   }
 })(CRM._, angular);

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -23,6 +23,14 @@
       });
     });
 
+    describe('on init', () => {
+      beforeEach(initController);
+
+      it('defines an empty filter object', () => {
+        expect($scope.filters).toEqual({});
+      });
+    });
+
     describe('payment activities', () => {
       beforeEach(() => {
         initController();

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -23,14 +23,6 @@
       });
     });
 
-    describe('on init', () => {
-      beforeEach(initController);
-
-      it('defines an empty filter object', () => {
-        expect($scope.filters).toEqual({});
-      });
-    });
-
     describe('payment activities', () => {
       beforeEach(() => {
         initController();

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -41,7 +41,7 @@
               activity_type_id: 'Awards Payment',
               return: ['id', 'target_contact_id', 'status_id.label',
                 'activity_date_time', 'custom', 'status_id.name'],
-              options: { limit: 0 }
+              options: { offset: 0, limit: 25 }
             }]);
         });
 
@@ -99,8 +99,8 @@
           initController();
           $scope.$digest();
 
-          apiResponses.Activity.values = generateNewMockPayments();
-          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.values);
+          apiResponses.Activity.get.values = generateNewMockPayments();
+          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
 
           $scope.filterPayments({ id: '123' });
           $scope.$digest();
@@ -161,8 +161,8 @@
 
       describe('when no payments have been filtered', () => {
         beforeEach(() => {
-          apiResponses.Activity.values = generateNewMockPayments();
-          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.values);
+          apiResponses.Activity.get.values = generateNewMockPayments();
+          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
 
           $rootScope.$broadcast('civiawards::paymentstable::refresh');
           $scope.$digest();
@@ -175,7 +175,7 @@
               case_id: mockApplication.id,
               activity_type_id: 'Awards Payment',
               return: jasmine.any(Array),
-              options: { limit: 0 }
+              options: { offset: 0, limit: 25 }
             }]);
         });
 
@@ -189,8 +189,8 @@
           $scope.filterPayments({ id: '123' });
           $scope.$digest();
 
-          apiResponses.Activity.values = generateNewMockPayments();
-          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.values);
+          apiResponses.Activity.get.values = generateNewMockPayments();
+          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
 
           civicaseCrmApi.calls.reset();
           $rootScope.$broadcast('civiawards::paymentstable::refresh');
@@ -206,6 +206,105 @@
 
         it('stores the refreshed payments', () => {
           expect($scope.payments).toEqual(expectedPayments);
+        });
+      });
+    });
+
+    describe('payments paging', () => {
+      describe('on init', () => {
+        beforeEach(() => {
+          initController();
+        });
+
+        it('defines an paging object with no records', () => {
+          expect($scope.paging).toEqual({
+            page: 1,
+            pageSize: 25,
+            total: 0,
+            isDisabled: true
+          });
+        });
+      });
+
+      describe('when loading the payments first page', () => {
+        beforeEach(() => {
+          apiResponses.Activity.getcount = 100;
+
+          initController();
+          $scope.$digest();
+        });
+
+        it('requests the total number of payments for the given filter', () => {
+          expect(_.toArray(civicaseCrmApi.calls.mostRecent().args[0]))
+            .toContain(['Activity', 'getcount', {
+              case_id: mockApplication.id,
+              activity_type_id: 'Awards Payment'
+            }]);
+        });
+
+        it('stores the total number of payments', () => {
+          expect($scope.paging.total).toBe(100);
+        });
+      });
+
+      describe('when going to a specific filtered page', () => {
+        beforeEach(() => {
+          initController();
+          $scope.$digest();
+
+          apiResponses.Activity.getcount = 100;
+          apiResponses.Activity.get.values = generateNewMockPayments();
+          expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
+
+          $scope.filterPayments({ id: '123' });
+          $scope.$digest();
+          civicaseCrmApi.calls.reset();
+          $scope.goToPage(3);
+        });
+
+        it('changes the page', () => {
+          expect($scope.paging.page).toBe(3);
+        });
+
+        it('disables the paging while the records are loading', () => {
+          expect($scope.paging.isDisabled).toBe(true);
+        });
+
+        it('fetches the records belonging to the given page', () => {
+          expect(_.toArray(civicaseCrmApi.calls.mostRecent().args[0]))
+            .toContain(['Activity', 'get', jasmine.objectContaining({
+              options: {
+                offset: 50,
+                limit: 25
+              }
+            })]);
+        });
+
+        it('requests the total count for the filtered payments', () => {
+          expect(_.toArray(civicaseCrmApi.calls.mostRecent().args[0]))
+            .toContain(['Activity', 'getcount', {
+              id: '123',
+              case_id: mockApplication.id,
+              activity_type_id: 'Awards Payment'
+            }]);
+        });
+
+        describe('after loading the payments page', () => {
+          beforeEach(() => {
+            $scope.$digest();
+          });
+
+          it('stores the total number of payments', () => {
+            expect($scope.paging.total).toBe(100);
+          });
+
+          it('stores the payments for the given page', () => {
+            expect($scope.payments).toEqual(expectedPayments);
+          });
+
+          it('enables paging', () => {
+            expect($scope.paging.isDisabled).toBe(false);
+          });
         });
       });
     });
@@ -262,8 +361,13 @@
         paymentTypes = _paymentTypes_;
 
         apiResponses = {
-          Activity: { count: mockPayments.length, values: mockPayments },
-          CustomField: { count: mockCustomFields.length, values: mockCustomFields }
+          Activity: {
+            get: { count: mockPayments.length, values: mockPayments },
+            getcount: mockPayments.length
+          },
+          CustomField: {
+            get: { count: mockCustomFields.length, values: mockCustomFields }
+          }
         };
 
         civicaseCrmApi.and.callFake((apiCalls) => {
@@ -274,7 +378,8 @@
           return $q.resolve(
             _.transform(apiCalls, (requestObject, requestParameters, requestKey) => {
               const entityName = requestParameters[0];
-              requestObject[requestKey] = apiResponses[entityName];
+              const actionName = requestParameters[1];
+              requestObject[requestKey] = apiResponses[entityName][actionName];
 
               return requestObject;
             })

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -102,7 +102,7 @@
           apiResponses.Activity.get.values = generateNewMockPayments();
           expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
 
-          $scope.filterPayments({ id: '123' });
+          $scope.submitFilters({ id: '123' });
           $scope.$digest();
         });
 
@@ -123,7 +123,7 @@
           initController();
           $scope.$digest();
 
-          $scope.filterPayments({ id: '' });
+          $scope.submitFilters({ id: '' });
           $scope.$digest();
         });
 
@@ -140,7 +140,7 @@
           initController();
           $scope.$digest();
 
-          $scope.filterPayments({ custom_Payee_Ref: '123' });
+          $scope.submitFilters({ custom_Payee_Ref: '123' });
           $scope.$digest();
         });
 
@@ -186,7 +186,7 @@
 
       describe('when the payments have been filtered', () => {
         beforeEach(() => {
-          $scope.filterPayments({ id: '123' });
+          $scope.submitFilters({ id: '123' });
           $scope.$digest();
 
           apiResponses.Activity.get.values = generateNewMockPayments();
@@ -256,7 +256,7 @@
           apiResponses.Activity.get.values = generateNewMockPayments();
           expectedPayments = getExpectedPaymentIds(apiResponses.Activity.get.values);
 
-          $scope.filterPayments({ id: '123' });
+          $scope.submitFilters({ id: '123' });
           $scope.$digest();
           civicaseCrmApi.calls.reset();
           $scope.goToPage(3);
@@ -305,6 +305,22 @@
           it('enables paging', () => {
             expect($scope.paging.isDisabled).toBe(false);
           });
+        });
+      });
+
+      describe('when filtering after going to a page', () => {
+        beforeEach(() => {
+          initController();
+          $scope.$digest();
+
+          $scope.goToPage(3);
+          $scope.$digest();
+          $scope.submitFilters({ id: '123' });
+          $scope.$digest();
+        });
+
+        it('goes to the first page', () => {
+          expect($scope.paging.page).toBe(1);
         });
       });
     });


### PR DESCRIPTION
## Overview

This PR adds pagination to the list of payments.

This PR depends on https://github.com/compucorp/uk.co.compucorp.civicase/pull/701

## Before
![pr](https://user-images.githubusercontent.com/1642119/108008825-9f86de80-6fd7-11eb-91d2-ff2387d2536a.gif)
All records are displayed in a single page.

## After

![pr](https://user-images.githubusercontent.com/1642119/108008744-7403f400-6fd7-11eb-8c81-0573dc35c3b9.gif)

## Technical Details

We implemented the `civicase-paging` directive on the `payments-table` directive. A `paging` object is defined containing all the information about the current page, the number of records per page, the number of records in total, and if the paging is disabled or not.

We disable paging when loading the payments.

Also, when filtering payments we always go to the first result page, otherwise we risk missing the results.