### PR TITLE
ACU-502: Award Finance General Edits 

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardPayment.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardPayment.tpl
@@ -5,10 +5,17 @@
             {if $elementName == 'separator'}
                 <hr>
             {else}
-              <div class="form-group row">
-                <label class="col-sm-2">{$form.$elementName.label}</label>
-                <div class="col-sm-10">{$form.$elementName.html}</div>
-              </div>
+                {if in_array($elementName, $fieldsAfterCurrencyTypes)}
+                    {$form.$elementName.html}</div></div>
+                {else}
+                  <div class="form-group row">
+                    <label class="col-sm-2">{$form.$elementName.label}</label>
+                    <div class="col-sm-10">{$form.$elementName.html}
+                    {if !in_array($elementName, $currencyTypeFields)}
+                    </div>
+                  </div>
+                    {/if}
+                {/if}
             {/if}
         {/foreach}
     </div>

--- a/xml/custom_fields/payment_information_install.xml
+++ b/xml/custom_fields/payment_information_install.xml
@@ -45,7 +45,7 @@
     </CustomField>
     <CustomField>
       <name>Payment_Amount_Currency_Type</name>
-      <label>Payment Amount Currency Type</label>
+      <label>Payment Amount</label>
       <data_type>String</data_type>
       <html_type>Select</html_type>
       <is_required>1</is_required>
@@ -116,7 +116,7 @@
     </CustomField>
     <CustomField>
       <name>Value_in_Functional_Currency_Type</name>
-      <label>Value in Functional Currency Type</label>
+      <label>Value in Functional Currency</label>
       <data_type>String</data_type>
       <html_type>Select</html_type>
       <is_required>0</is_required>
@@ -134,8 +134,8 @@
       <custom_group_name>Awards_Payment_Information</custom_group_name>
     </CustomField>
     <CustomField>
-      <name>Value_in_Functional_Currency</name>
-      <label>Value in Functional Currency</label>
+      <name>Value_in_Functional_Currency_Amount</name>
+      <label>Value in Functional Currency Amount</label>
       <data_type>Money</data_type>
       <html_type>Text</html_type>
       <is_searchable>1</is_searchable>


### PR DESCRIPTION
## Overview
This PR makes some adjustments to the Award payment form.
- The currency type field and the corresponding payment amount fields were aligned so that they are next to each other rather than being on separate lines in the form.
- The Value in Functional Currency Type custom field was renamed to Value in Functional Currency (Just the label) and the Value in Functional Currency field was renamed to Value in Functional Currency Amount (both label and name).
- The ability to configure/add to the currency type option values was also removed for currency type related fields.
- The time stamp for the due date field was also removed so the field is now date only.

<img width="639" alt="Create New Payment  CaseLatest 2021-02-15 18-27-30" src="https://user-images.githubusercontent.com/6951813/107978548-43af5c00-6fbd-11eb-918e-4479a41e672a.png">

## Before
These changes were not present.

## After
- These changes are added.
<img width="656" alt="Create New Payment  CaseLatest 2021-02-15 18-40-42" src="https://user-images.githubusercontent.com/6951813/107978657-78bbae80-6fbd-11eb-892b-95fa50c8a33b.png">

