### PR TITLE
ACU-505: Remove Configuration Cog for Payment Currency

### DIFF
--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -109,7 +109,7 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
     $this->assign('activityStatusIsLocked', $this->activityStatusIsLocked());
     $this->assign('isActivityStatusExported', $this->isActivityStatusExported);
     $this->assign('fieldsAfterCurrencyTypes', $this->getFieldsAfterCurrencyTypes());
-    $this->assign('currencyTypeFields', $this->getCurrencyTypeFields());
+    $this->assign('currencyTypeFields', $this->getCurrencyTypeFieldsBeforeAmountFields());
 
     if ($isViewAction) {
       $this->freeze();
@@ -431,6 +431,20 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
    *   Form fields.
    */
   private function getCurrencyTypeFields() {
+    return [
+      $this->getCustomFieldFormElementName('Payment_Amount_Currency_Type'),
+      $this->getCustomFieldFormElementName('Value_in_Functional_Currency_Type'),
+      $this->getCustomFieldFormElementName('Payment_Currency'),
+    ];
+  }
+
+  /**
+   * Returns currency related fields that are before amount fields.
+   *
+   * @return array
+   *   Form fields.
+   */
+  private function getCurrencyTypeFieldsBeforeAmountFields() {
     return [
       $this->getCustomFieldFormElementName('Payment_Amount_Currency_Type'),
       $this->getCustomFieldFormElementName('Value_in_Functional_Currency_Type'),


### PR DESCRIPTION
## Overview
This PR removes the ability to configure option type values for currency for the payment currency field.

## Before
<img width="853" alt="Manage Applications  CaseLatest 2021-02-17 17-42-11" src="https://user-images.githubusercontent.com/6951813/108237562-53a77700-7148-11eb-88c1-1fd2f21d49ed.png">


## After
<img width="886" alt="Manage Applications  CaseLatest 2021-02-17 17-36-33" src="https://user-images.githubusercontent.com/6951813/108237757-80f42500-7148-11eb-9666-810f3ad08c25.png">
