### PR TITLE
ACU-518: Fix payment status types

### DIFF
--- a/CRM/CiviAwards/Setup/CreateAwardPaymentActivityTypes.php
+++ b/CRM/CiviAwards/Setup/CreateAwardPaymentActivityTypes.php
@@ -80,26 +80,32 @@ class CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes {
       [
         'name' => 'applied_for_incomplete',
         'label' => 'Applied for (incomplete)',
+        'filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
       ],
       [
         'name' => 'approved_complete',
         'label' => 'Approved (complete)',
+        'filter' => CRM_Activity_BAO_Activity::COMPLETED,
       ],
       [
         'name' => 'exported_complete',
         'label' => 'Exported (complete)',
+        'filter' => CRM_Activity_BAO_Activity::COMPLETED,
       ],
       [
         'name' => 'paid_complete',
         'label' => 'Paid (complete)',
+        'filter' => CRM_Activity_BAO_Activity::COMPLETED,
       ],
       [
         'name' => 'cancelled_cancelled',
         'label' => 'Cancelled (cancelled)',
+        'filter' => CRM_Activity_BAO_Activity::CANCELLED,
       ],
       [
         'name' => 'failed_incomplete',
         'label' => 'Failed (incomplete)',
+        'filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
       ],
     ];
   }
@@ -115,6 +121,7 @@ class CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes {
           'option_group_id' => 'activity_status',
           'name' => $activityStatus['name'],
           'label' => $activityStatus['label'],
+          'filter' => $activityStatus['filter'],
           'grouping' => self::AWARD_PAYMENTS_ACTIVITY_CATEGORY,
           'is_reserved' => TRUE,
         ]


### PR DESCRIPTION
## Overview
This PR fixes the status type for payments. Previously all payments statuses would be "incomplete" when they needed to have different types such as completed, or cancelled.

## Before
![pr](https://user-images.githubusercontent.com/1642119/108422505-05a87700-720d-11eb-94eb-f0442f6cc49b.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/108422852-7b144780-720d-11eb-97a3-24599bb6a854.gif)

## Technical Details

We added a new `filter` field to the list of activity status types on the `CreateAwardPaymentActivityTypes` setup class. The `filter` field is what is used to determine the type of status and the values accepted are hardcoded integers that can be referenced from constants stored in `CRM_Activity_BAO_Activity`