### PR TITLE
ACU-522: Add Euro currency

### DIFF
--- a/CRM/CiviAwards/Upgrader/Steps/Step1010.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1010.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Adds the Euro currency option.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1010 {
+
+  /**
+   * Apply function that runs on setup.
+   *
+   * @return bool
+   *   true when successfull.
+   */
+  public function apply() {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'currencies_enabled',
+      'name' => 'EUR (€)',
+      'label' => 'EUR',
+      'value' => 'EUR',
+      'is_default' => 0,
+      'is_active' => TRUE,
+      'is_reserved' => FALSE,
+    ]);
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds the Euro to the list of currencies.

## Before
<img width="851" alt="Screen Shot 2021-02-18 at 11 35 38 PM" src="https://user-images.githubusercontent.com/1642119/108454594-05c36980-7243-11eb-8581-ef8fe89db7fb.png">

## After
<img width="911" alt="Screen Shot 2021-02-18 at 11 38 22 PM" src="https://user-images.githubusercontent.com/1642119/108454599-078d2d00-7243-11eb-80ca-e09e25369788.png">

## Technical Details

We added a new upgrader that uses `CRM_Core_BAO_OptionValue::ensureOptionValueExists` to add the Euro currency once no matter how many times the function is called.