### PR TITLE
COMCL-101: Regenerate civix file and Base upgrader class

### DIFF
--- a/CRM/CiviAwards/Upgrader/Base.php
+++ b/CRM/CiviAwards/Upgrader/Base.php
@@ -9,9 +9,9 @@ use CRM_CiviAwards_ExtensionUtil as E;
 class CRM_CiviAwards_Upgrader_Base {
 
   /**
-   * @var varies, subclass of this
+   * @var CRM_CiviAwards_Upgrader_Base
    */
-  static $instance;
+  public static $instance;
 
   /**
    * @var CRM_Queue_TaskContext
@@ -19,22 +19,25 @@ class CRM_CiviAwards_Upgrader_Base {
   protected $ctx;
 
   /**
-   * @var string, eg 'com.example.myextension'
+   * @var string
+   *   eg 'com.example.myextension'
    */
   protected $extensionName;
 
   /**
-   * @var string, full path to the extension's source tree
+   * @var string
+   *   full path to the extension's source tree
    */
   protected $extensionDir;
 
   /**
-   * @var array(revisionNumber) sorted numerically
+   * @var array
+   *   sorted numerically
    */
   private $revisions;
 
   /**
-   * @var boolean
+   * @var bool
    *   Flag to clean up extension revision data in civicrm_setting
    */
   private $revisionStorageIsDeprecated = FALSE;
@@ -42,12 +45,11 @@ class CRM_CiviAwards_Upgrader_Base {
   /**
    * Obtain a reference to the active upgrade handler.
    */
-  static public function instance() {
+  public static function instance() {
     if (!self::$instance) {
-      // FIXME auto-generate
       self::$instance = new CRM_CiviAwards_Upgrader(
         'uk.co.compucorp.civiawards',
-        realpath(__DIR__ . '/../../../')
+        E::path()
       );
     }
     return self::$instance;
@@ -59,11 +61,11 @@ class CRM_CiviAwards_Upgrader_Base {
    * Note: Each upgrader instance should only be associated with one
    * task-context; otherwise, this will be non-reentrant.
    *
-   * @code
+   * ```
    * CRM_CiviAwards_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
-   * @endcode
+   * ```
    */
-  static public function _queueAdapter() {
+  public static function _queueAdapter() {
     $instance = self::instance();
     $args = func_get_args();
     $instance->ctx = array_shift($args);
@@ -72,6 +74,12 @@ class CRM_CiviAwards_Upgrader_Base {
     return call_user_func_array([$instance, $method], $args);
   }
 
+  /**
+   * CRM_CiviAwards_Upgrader_Base constructor.
+   *
+   * @param $extensionName
+   * @param $extensionDir
+   */
   public function __construct($extensionName, $extensionDir) {
     $this->extensionName = $extensionName;
     $this->extensionDir = $extensionDir;
@@ -82,7 +90,8 @@ class CRM_CiviAwards_Upgrader_Base {
   /**
    * Run a CustomData file.
    *
-   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
   public function executeCustomDataFile($relativePath) {
@@ -93,11 +102,12 @@ class CRM_CiviAwards_Upgrader_Base {
   /**
    * Run a CustomData file
    *
-   * @param string $xml_file the CustomData XML file path (absolute path)
+   * @param string $xml_file
+   *   the CustomData XML file path (absolute path)
    *
    * @return bool
    */
-  protected static function executeCustomDataFileByAbsPath($xml_file) {
+  protected function executeCustomDataFileByAbsPath($xml_file) {
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
     return TRUE;
@@ -106,7 +116,8 @@ class CRM_CiviAwards_Upgrader_Base {
   /**
    * Run a SQL file.
    *
-   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the SQL file path (relative to this extension's dir)
    *
    * @return bool
    */
@@ -119,10 +130,14 @@ class CRM_CiviAwards_Upgrader_Base {
   }
 
   /**
+   * Run the sql commands in the specified file.
+   *
    * @param string $tplFile
    *   The SQL file path (relative to this extension's dir).
    *   Ex: "sql/mydata.mysql.tpl".
+   *
    * @return bool
+   * @throws \CRM_Core_Exception
    */
   public function executeSqlTemplate($tplFile) {
     // Assign multilingual variable to Smarty.
@@ -141,8 +156,10 @@ class CRM_CiviAwards_Upgrader_Base {
    * Run one SQL query.
    *
    * This is just a wrapper for CRM_Core_DAO::executeSql, but it
-   * provides syntatic sugar for queueing several tasks that
+   * provides syntactic sugar for queueing several tasks that
    * run different queries
+   *
+   * @return bool
    */
   public function executeSql($query, $params = []) {
     // FIXME verify that we raise an exception on error
@@ -151,7 +168,7 @@ class CRM_CiviAwards_Upgrader_Base {
   }
 
   /**
-   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   * Syntactic sugar for enqueuing a task which calls a function in this class.
    *
    * The task is weighted so that it is processed
    * as part of the currently-pending revision.
@@ -193,6 +210,8 @@ class CRM_CiviAwards_Upgrader_Base {
 
   /**
    * Add any pending revisions to the queue.
+   *
+   * @param CRM_Queue_Queue $queue
    */
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $this->queue = $queue;
@@ -200,7 +219,7 @@ class CRM_CiviAwards_Upgrader_Base {
     $currentRevision = $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revision) {
       if ($revision > $currentRevision) {
-        $title = ts('Upgrade %1 to revision %2', [
+        $title = E::ts('Upgrade %1 to revision %2', [
           1 => $this->extensionName,
           2 => $revision,
         ]);
@@ -227,7 +246,8 @@ class CRM_CiviAwards_Upgrader_Base {
   /**
    * Get a list of revisions.
    *
-   * @return array(revisionNumbers) sorted numerically
+   * @return array
+   *   revisionNumbers sorted numerically
    */
   public function getRevisions() {
     if (!is_array($this->revisions)) {
@@ -256,7 +276,7 @@ class CRM_CiviAwards_Upgrader_Base {
 
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
-    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+    if ($revision = \Civi::settings()->get($key)) {
       $this->revisionStorageIsDeprecated = TRUE;
     }
     return $revision;

--- a/civiawards.civix.php
+++ b/civiawards.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_CiviAwards_ExtensionUtil {
-  const SHORT_NAME = "civiawards";
-  const LONG_NAME = "uk.co.compucorp.civiawards";
-  const CLASS_PREFIX = "CRM_CiviAwards";
+  const SHORT_NAME = 'civiawards';
+  const LONG_NAME = 'uk.co.compucorp.civiawards';
+  const CLASS_PREFIX = 'CRM_CiviAwards';
 
   /**
    * Translate a string using the extension's domain.
@@ -43,8 +43,7 @@ class CRM_CiviAwards_ExtensionUtil {
    */
   public static function url($file = NULL) {
     if ($file === NULL) {
-      return rtrim(CRM_Core_Resources::singleton()
-        ->getUrl(self::LONG_NAME), '/');
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
     return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
   }
@@ -83,7 +82,7 @@ use CRM_CiviAwards_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _civiawards_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -113,7 +112,7 @@ function _civiawards_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _civiawards_civix_civicrm_xmlMenu(&$files) {
   foreach (_civiawards_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -124,7 +123,7 @@ function _civiawards_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _civiawards_civix_civicrm_install() {
   _civiawards_civix_civicrm_config();
@@ -136,7 +135,7 @@ function _civiawards_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _civiawards_civix_civicrm_postInstall() {
   _civiawards_civix_civicrm_config();
@@ -150,7 +149,7 @@ function _civiawards_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _civiawards_civix_civicrm_uninstall() {
   _civiawards_civix_civicrm_config();
@@ -162,7 +161,7 @@ function _civiawards_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _civiawards_civix_civicrm_enable() {
   _civiawards_civix_civicrm_config();
@@ -176,7 +175,7 @@ function _civiawards_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _civiawards_civix_civicrm_disable() {
@@ -194,10 +193,11 @@ function _civiawards_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _civiawards_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _civiawards_civix_upgrader()) {
@@ -218,14 +218,15 @@ function _civiawards_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _civiawards_civix_find_files($dir, $pattern) {
   if (is_callable(['CRM_Utils_File', 'findFiles'])) {
@@ -244,7 +245,7 @@ function _civiawards_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -255,12 +256,13 @@ function _civiawards_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _civiawards_civix_civicrm_managed(&$entities) {
   $mgdFiles = _civiawards_civix_find_files(__DIR__, '*.mgd.php');
@@ -286,7 +288,7 @@ function _civiawards_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _civiawards_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -297,14 +299,13 @@ function _civiawards_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -315,7 +316,7 @@ function _civiawards_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _civiawards_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -334,6 +335,25 @@ function _civiawards_civix_civicrm_angularModules(&$angularModules) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _civiawards_civix_civicrm_themes(&$themes) {
+  $files = _civiawards_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -343,7 +363,8 @@ function _civiawards_civix_civicrm_angularModules(&$angularModules) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _civiawards_civix_glob($pattern) {
   $result = glob($pattern);
@@ -358,16 +379,18 @@ function _civiawards_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _civiawards_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
-        'label' => CRM_Utils_Array::value('name', $item),
-        'active' => 1,
-      ), $item),
-    );
+    $menu[] = [
+      'attributes' => array_merge([
+        'label'      => CRM_Utils_Array::value('name', $item),
+        'active'     => 1,
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -380,7 +403,7 @@ function _civiawards_civix_insert_navigation_menu(&$menu, $path, $item) {
         if (!isset($entry['child'])) {
           $entry['child'] = [];
         }
-        $found = _civiawards_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _civiawards_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -391,7 +414,7 @@ function _civiawards_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _civiawards_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _civiawards_civix_fixNavigationMenu($nodes);
   }
 }
@@ -402,7 +425,7 @@ function _civiawards_civix_navigationMenu(&$nodes) {
  */
 function _civiawards_civix_fixNavigationMenu(&$nodes) {
   $maxNavID = 1;
-  array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
@@ -433,17 +456,11 @@ function _civiawards_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _civiawards_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
@@ -453,28 +470,24 @@ function _civiawards_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _civiawards_civix_civicrm_entityTypes(&$entityTypes) {
   $entityTypes = array_merge($entityTypes, [
-    'CRM_CiviAwards_DAO_AwardDetail' =>
-      [
-        'name' => 'AwardDetail',
-        'class' => 'CRM_CiviAwards_DAO_AwardDetail',
-        'table' => 'civicrm_award_detail',
-      ],
-    'CRM_CiviAwards_DAO_AwardManager' =>
-      [
-        'name' => 'AwardManager',
-        'class' => 'CRM_CiviAwards_DAO_AwardManager',
-        'table' => 'civicrm_award_manager',
-      ],
-    'CRM_CiviAwards_DAO_AwardReviewPanel' =>
-      [
-        'name' => 'AwardReviewPanel',
-        'class' => 'CRM_CiviAwards_DAO_AwardReviewPanel',
-        'table' => 'civicrm_award_review_panel',
-      ],
+    'CRM_CiviAwards_DAO_AwardDetail' => [
+      'name' => 'AwardDetail',
+      'class' => 'CRM_CiviAwards_DAO_AwardDetail',
+      'table' => 'civicrm_award_detail',
+    ],
+    'CRM_CiviAwards_DAO_AwardManager' => [
+      'name' => 'AwardManager',
+      'class' => 'CRM_CiviAwards_DAO_AwardManager',
+      'table' => 'civicrm_award_manager',
+    ],
+    'CRM_CiviAwards_DAO_AwardReviewPanel' => [
+      'name' => 'AwardReviewPanel',
+      'class' => 'CRM_CiviAwards_DAO_AwardReviewPanel',
+      'table' => 'civicrm_award_review_panel',
+    ],
   ]);
 }

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -15,5 +15,7 @@
         <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
         <!-- These files are mainly auto generated and has some rules we want to exclude -->
         <exclude-pattern>CRM/CiviAwards/DAO/*</exclude-pattern>
+        <exclude-pattern>civiawards.civix.php</exclude-pattern>
+        <exclude-pattern>CRM/CiviAwards/Upgrader/Base.php</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
## Overview

This PR fixes is to updates civix file and an upgrader base class.  The base class and civix file are generated automatically by running `civix generate:upgrader
`
The reason for regenerating the civix file and base upgrader class because CiviCRM changed the way they handle warning for using a deprecated function.  See this [PR ](https://github.com/civicrm/civicrm-core/pull/19256).

The changed will always throw use deprecated warning if the deprecated function is used in anywhere, for example, Drupal module, CiviCRM extension. This would not have an issue we install the extension / module via user interface. However, when we use Drush site-install command to install the Drupal site that ship with a Drupal profile that install the extension when creating a site. 

Any module or extension that use CiviCRM's deprecated function in the installation hook, upgrade hook, the E_USER_DEPRECATED warning will throw during installation, but Drush handles deprecated messages as an error rather than a warning.  

Since the old civix file and Base class are using the deprecated functions, we will also receive the error duration installation, for this reason, the deployment will always fail. This PR fixes this.  

### Note 

PR for fixing this issue in Drush has been created and merged to Druah 8.x https://github.com/drush-ops/drush/pull/4565, but we do not have a timescale for new Drush version to release, thus we fixed the extension. 
