### PR TITLE
ACU-536: Fix Payment Edit action visibility

### DIFF
--- a/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.html
+++ b/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.html
@@ -19,7 +19,10 @@
       <a href ng-click="handleViewActivity(payment.id)">
         {{ ts('View') }}
       </a>
-      <a href ng-click="handleEditActivity(payment.id)">
+      <a
+        ng-if="isEditActionVisible(payment)"
+        href
+        ng-click="handleEditActivity(payment.id)">
         {{ ts('Edit') }}
       </a>
       <a

--- a/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.js
@@ -32,6 +32,7 @@
     $scope.handleEditActivity = handleEditActivity;
     $scope.handleDeleteActivity = handleDeleteActivity;
     $scope.isDeleteActionVisible = isDeleteActionVisible;
+    $scope.isEditActionVisible = isEditActionVisible;
 
     /**
      * Open View Payment Form
@@ -106,6 +107,16 @@
      */
     function isDeleteActionVisible (payment) {
       return AwardsPaymentActivityStatus.isDeleteVisible({ status_name: payment['status_id.name'] });
+    }
+
+    /**
+     * Checks if the delete action should be visible.
+     *
+     * @param {object} payment payment activity object
+     * @returns {boolean} if visible
+     */
+    function isEditActionVisible (payment) {
+      return AwardsPaymentActivityStatus.isEditVisible({ status_name: payment['status_id.name'] });
     }
   }
 })(angular, CRM.confirm);

--- a/ang/civiawards-payments-tab/services/awards-payment-activity-status.service.js
+++ b/ang/civiawards-payments-tab/services/awards-payment-activity-status.service.js
@@ -19,5 +19,14 @@
 
       return !_.includes(notEditableStatuses, activityStatus);
     };
+
+    this.isEditVisible = function (activity) {
+      var activityStatus = activity.status_name;
+      var notEditableStatuses = [
+        'exported_complete'
+      ];
+
+      return !_.includes(notEditableStatuses, activityStatus);
+    };
   }
 })(CRM._, angular);

--- a/ang/test/civiawards-payments-tab/services/awards-payment-activity-status.service.spec.js
+++ b/ang/test/civiawards-payments-tab/services/awards-payment-activity-status.service.spec.js
@@ -14,12 +14,22 @@ describe('AwardsPaymentActivityStatus', () => {
       expect(AwardsPaymentActivityStatus.isDeleteVisible({ status_name: 'paid_complete' }))
         .toBe(false);
     });
+
+    it('shows the edit action', () => {
+      expect(AwardsPaymentActivityStatus.isEditVisible({ status_name: 'paid_complete' }))
+        .toBe(true);
+    });
   });
 
   describe('when payment has failed', () => {
     it('hides the delete action', () => {
       expect(AwardsPaymentActivityStatus.isDeleteVisible({ status_name: 'failed_incomplete' }))
         .toBe(false);
+    });
+
+    it('shows the edit action', () => {
+      expect(AwardsPaymentActivityStatus.isEditVisible({ status_name: 'failed_incomplete' }))
+        .toBe(true);
     });
   });
 
@@ -28,11 +38,21 @@ describe('AwardsPaymentActivityStatus', () => {
       expect(AwardsPaymentActivityStatus.isDeleteVisible({ status_name: 'exported_complete' }))
         .toBe(false);
     });
+
+    it('hides the edit action', () => {
+      expect(AwardsPaymentActivityStatus.isEditVisible({ status_name: 'exported_complete' }))
+        .toBe(false);
+    });
   });
 
   describe('when payment is not complete, failed or exported', () => {
     it('hides the delete action', () => {
       expect(AwardsPaymentActivityStatus.isDeleteVisible({ status_name: 'applied_for_incomplete' }))
+        .toBe(true);
+    });
+
+    it('shows the edit action', () => {
+      expect(AwardsPaymentActivityStatus.isEditVisible({ status_name: 'applied_for_incomplete' }))
         .toBe(true);
     });
   });


### PR DESCRIPTION
## Overview
The Edit action button in Payments tab of Case Details was visible for Exported payments, this has been fixed now.

## Before
![2021-02-22 at 6 46 PM](https://user-images.githubusercontent.com/5058867/108713454-41f61300-753e-11eb-9782-a0550c18de6c.png)

## After
![2021-02-22 at 6 45 PM](https://user-images.githubusercontent.com/5058867/108713406-30147000-753e-11eb-9413-2bd496fa105d.png)

## Technical Details
Added `isEditVisible` function to `AwardsPaymentActivityStatus` to fix this.