### PR TITLE
ACU-532: Fix Award Manager Permission Issues With Award Payment

### DIFF
--- a/CRM/CiviAwards/Hook/AclGroup/ActivityTypeCustomGroupAccess.php
+++ b/CRM/CiviAwards/Hook/AclGroup/ActivityTypeCustomGroupAccess.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Base class for activity type custom group access.
+ */
+abstract class CRM_CiviAwards_Hook_AclGroup_ActivityTypeCustomGroupAccess {
+
+  /**
+   * Activity Type Id.
+   *
+   * @return int
+   *   Activity type Id.
+   */
+  abstract protected function getActivityTypeId();
+
+  /**
+   * Returns the Custom groups attached to the activity type.
+   */
+  protected function getActivityTypeCustomGroups() {
+    $activityTypeCustomGroups = [];
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'extends' => 'Activity',
+      'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $this->getActivityTypeId() . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+    ]);
+
+    if (!empty($result['values'])) {
+      $activityTypeCustomGroups = $result['values'];
+    }
+
+    return $activityTypeCustomGroups;
+  }
+
+  /**
+   * Modifies/sets the ACL custom groups that the current user has access to.
+   *
+   * @param array $currentGroups
+   *   Current ACL Groups user has access to.
+   */
+  protected function setAccessibleCustomGroups(array &$currentGroups) {
+    $activityTypeCustomGroups = $this->getActivityTypeCustomGroups();
+    if (!$activityTypeCustomGroups) {
+      return;
+    }
+
+    foreach ($activityTypeCustomGroups as $activityTypeCustomGroup) {
+      $currentGroups[] = $activityTypeCustomGroup['id'];
+    }
+
+    $currentGroups = array_unique($currentGroups);
+  }
+
+}

--- a/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroups.php
+++ b/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroups.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM_CiviAwards_Hook_AclGroup_ActivityTypeCustomGroupAccess as ActivityTypeCustomGroupAccess;
+use CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes as CreateAwardPaymentActivityTypes;
+use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
+
+/**
+ * Class CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups.
+ */
+class CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups extends ActivityTypeCustomGroupAccess {
+
+  /**
+   * Modifies ACL groups for user with access payment set permission.
+   *
+   * Allows a user with access payment set permission to have access to the
+   * payment information custom group and custom fields belonging to this group.
+   *
+   * @param string $type
+   *   The type of permission needed.
+   * @param int $contactID
+   *   The contactID for whom the check is made.
+   * @param string $tableName
+   *   The tableName which is being permissioned.
+   * @param array $allGroups
+   *   The set of all the objects for the above table.
+   * @param array $currentGroups
+   *   The set of objects that are currently permissioned for this contact.
+   */
+  public function run($type, $contactID, $tableName, array &$allGroups, array &$currentGroups) {
+    if (!$this->shouldRun($tableName)) {
+      return;
+    }
+    $this->setAccessibleCustomGroups($currentGroups);
+  }
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $tableName
+   *   The tableName which is being permissioned.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($tableName) {
+    return $tableName == CRM_Core_BAO_CustomGroup::getTableName() && CRM_Core_Permission::check(AwardPermission::PAYMENT_FIELD_SET_PERM);
+  }
+
+  /**
+   * Returns the activity type Id.
+   *
+   * @return int
+   *   Activity Type ID.
+   */
+  protected function getActivityTypeId() {
+    return $this->getAwardPaymentActivityTypeId();
+  }
+
+  /**
+   * Returns the payment activity type Id.
+   *
+   * @return int
+   *   Activity type Id.
+   */
+  private function getAwardPaymentActivityTypeId() {
+    try {
+      $result = civicrm_api3('OptionValue', 'getsingle', [
+        'option_group_id' => 'activity_type',
+        'name' => CreateAwardPaymentActivityTypes::AWARD_PAYMENT_ACTIVITY_TYPE,
+      ]);
+
+      return $result['value'];
+    }
+    catch (Exception $e) {
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroups.php
+++ b/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroups.php
@@ -59,7 +59,7 @@ class CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups extends ActivityTy
   /**
    * Returns the payment activity type Id.
    *
-   * @return int
+   * @return int|null
    *   Activity type Id.
    */
   private function getAwardPaymentActivityTypeId() {
@@ -69,9 +69,10 @@ class CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups extends ActivityTy
         'name' => CreateAwardPaymentActivityTypes::AWARD_PAYMENT_ACTIVITY_TYPE,
       ]);
 
-      return $result['value'];
+      return !empty($result['value']) ? $result['value'] : NULL;
     }
     catch (Exception $e) {
+      return NULL;
     }
   }
 

--- a/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
+++ b/CRM/CiviAwards/Hook/AlterAPIPermissions/Award.php
@@ -224,7 +224,7 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
    * @param string $optionValueName
    *   Option value name.
    *
-   * @return int
+   * @return int|null
    *   Activity type Id.
    */
   private function getActivityTypeId($optionValueName) {
@@ -234,9 +234,10 @@ class CRM_CiviAwards_Hook_AlterAPIPermissions_Award {
         'name' => $optionValueName,
       ]);
 
-      return $result['value'];
+      return !empty($result['value']) ? $result['value'] : NULL;
     }
     catch (Exception $e) {
+      return NULL;
     }
 
   }

--- a/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
+++ b/CRM/CiviAwards/Setup/CreateApplicantReviewActivityType.php
@@ -6,6 +6,7 @@
 class CRM_CiviAwards_Setup_CreateApplicantReviewActivityType {
 
   const APPLICANT_REVIEW = 'Applicant Review';
+  const CUSTOM_GROUP_NAME = 'Applicant_Review';
 
   /**
    * Adds the Applicant review activity type and category.

--- a/CRM/CiviAwards/Setup/CreateAwardPaymentActivityTypes.php
+++ b/CRM/CiviAwards/Setup/CreateAwardPaymentActivityTypes.php
@@ -13,6 +13,7 @@ class CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes {
   const AWARD_PAYMENTS_ACTIVITY_CATEGORY = 'Awards Payments';
   const AWARD_PAYMENT_ACTIVITY_TYPE = 'Awards Payment';
   const AWARD_PAYMENT_REQUEST_ACTIVITY_TYPE = 'Awards Payment Request';
+  const CUSTOM_GROUP_NAME = 'Awards_Payment_Information';
 
   /**
    * Adds the Applicant review activity type and category.

--- a/civiawards.php
+++ b/civiawards.php
@@ -198,10 +198,18 @@ function civiawards_civicrm_permission(&$permissions) {
     ts('Allows a user to create or edit awards'),
   ];
 
-  $permissions['access review custom field set'] = [
+  $permissions[CRM_CiviAwards_Hook_AlterAPIPermissions_Award::REVIEW_FIELD_SET_PERM] = [
     ts('CiviAwards: Access review fields '),
     ts(
       "This allows the user to view any review field sets on the reserved review activity type.
+       Note that this can also be done through ACLs or allocating the user 'Access all custom data' permission"
+    ),
+  ];
+
+  $permissions[CRM_CiviAwards_Hook_AlterAPIPermissions_Award::PAYMENT_FIELD_SET_PERM] = [
+    ts('CiviAwards: Access Payment custom fields '),
+    ts(
+      "This allows the user to view any payment field sets on the related payment activity types.
        Note that this can also be done through ACLs or allocating the user 'Access all custom data' permission"
     ),
   ];

--- a/civiawards.php
+++ b/civiawards.php
@@ -238,6 +238,7 @@ function civiawards_civicrm_alterAPIPermissions($entity, $action, &$params, &$pe
 function civiawards_civicrm_aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
   $hooks = [
     new CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups(),
+    new CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups(),
   ];
 
   foreach ($hooks as $hook) {

--- a/tests/phpunit/CRM/CiviAwards/Hook/AclGroup/AllowAccessToApplicantReviewGroupsTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Hook/AclGroup/AllowAccessToApplicantReviewGroupsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
+use CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroups as AllowAccessToApplicantReviewGroups;
+use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
+
+/**
+ * Test class for the AllowAccessToApplicantReviewGroups ACL Hook.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Hook_AclGroup_AllowAccessToApplicantReviewGroupsTest extends BaseHeadlessTest {
+
+  use CRM_CiviAwards_Helper_SessionTrait;
+
+  /**
+   * Test Applicant review custom group is set.
+   */
+  public function testApplicantReviewCustomGroupIsSetAsPartOfAccessibleCustomGroups() {
+    $this->setPermissions([AwardPermission::REVIEW_FIELD_SET_PERM]);
+    $applicantReviewHook = new AllowAccessToApplicantReviewGroups();
+    $allGroups = [];
+    $currentGroups = [];
+    $applicantReviewHook->run('', '', CRM_Core_BAO_CustomGroup::getTableName(), $allGroups, $currentGroups);
+    $this->assertCount(1, $currentGroups);
+    $this->assertContains($this->getApplicantReviewCustomGroupId(), $currentGroups);
+  }
+
+  /**
+   * Test Applicant review custom group not set.
+   */
+  public function testApplicantReviewCustomGroupIsNotSetWhenUserDoesNotHavePermission() {
+    $this->setPermissions();
+    $applicantReviewHook = new AllowAccessToApplicantReviewGroups();
+    $allGroups = [];
+    $currentGroups = [];
+    $applicantReviewHook->run('', '', CRM_Core_BAO_CustomGroup::getTableName(), $allGroups, $currentGroups);
+    $this->assertEmpty($currentGroups);
+  }
+
+  /**
+   * Get the applicant custom group Id.
+   */
+  private function getApplicantReviewCustomGroupId() {
+    $result = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => CreateApplicantReviewActivityType::CUSTOM_GROUP_NAME,
+    ]);
+
+    return $result['id'];
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroupsTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Hook/AclGroup/AllowAccessToPaymentGroupsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
+use CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes as CreateAwardPaymentActivityTypes;
+use CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups as AllowAccessToPaymentGroups;
+
+/**
+ * Test class for the AllowAccessToPaymentGroups ACL Hook.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroupsTest extends BaseHeadlessTest {
+
+  use CRM_CiviAwards_Helper_SessionTrait;
+
+  /**
+   * Test Payment custom group is set.
+   */
+  public function testPaymentCustomGroupIsSetAsPartOfAccessibleCustomGroups() {
+    $this->setPermissions([AwardPermission::PAYMENT_FIELD_SET_PERM]);
+    $paymentGroupHook = new AllowAccessToPaymentGroups();
+    $allGroups = [];
+    $currentGroups = [];
+    $paymentGroupHook->run('', '', CRM_Core_BAO_CustomGroup::getTableName(), $allGroups, $currentGroups);
+    $this->assertCount(1, $currentGroups);
+    $this->assertContains($this->getPaymentInformationCustomGroupId(), $currentGroups);
+  }
+
+  /**
+   * Test Payment custom group not set.
+   */
+  public function testPaymentCustomGroupIsNotSetWhenUserDoesNotHavePermission() {
+    $this->setPermissions();
+    $paymentGroupHook = new AllowAccessToPaymentGroups();
+    $allGroups = [];
+    $currentGroups = [];
+    $paymentGroupHook->run('', '', CRM_Core_BAO_CustomGroup::getTableName(), $allGroups, $currentGroups);
+    $this->assertEmpty($currentGroups);
+  }
+
+  /**
+   * Get the applicant custom group Id.
+   */
+  private function getPaymentInformationCustomGroupId() {
+    $result = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => CreateAwardPaymentActivityTypes::CUSTOM_GROUP_NAME,
+    ]);
+
+    return $result['id'];
+  }
+
+}

--- a/tests/phpunit/CRM/CiviAwards/Hook/AlterAPIPermissions/AwardTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Hook/AlterAPIPermissions/AwardTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateApplicantReviewActivityType as CreateApplicantReviewActivityType;
+use CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes as CreateAwardPaymentActivityTypes;
+use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
+
+/**
+ * Test class for the Award Alter Permissions Hook.
+ *
+ * @group headless
+ */
+class CRM_CiviAwards_Hook_AlterAPIPermissions_AwardTest extends BaseHeadlessTest {
+
+  use CRM_CiviAwards_Helper_SessionTrait;
+
+  /**
+   * Test Exception is thrown when user does not have access review perm.
+   */
+  public function testExceptionIsThrownWhenAccessingCustomReviewSetFieldsWithoutAccessReviewSetPermission() {
+    $this->setPermissions([]);
+    $this->expectException(CiviCRM_API3_Exception::class);
+    $this->expectExceptionMessage(
+      'API permission check failed for CustomField/get call; insufficient permission: require ( ' . AwardPermission::REVIEW_FIELD_SET_PERM . ' or access all custom data )'
+    );
+
+    civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => CreateApplicantReviewActivityType::CUSTOM_GROUP_NAME,
+      'check_permissions' => TRUE,
+    ]);
+  }
+
+  /**
+   * Test Exception is thrown when user does not have access payment set perm.
+   */
+  public function testExceptionIsThrownWhenAccessingPaymentReviewSetFieldsWithoutAccessPaymentSetPermission() {
+    $this->setPermissions([]);
+    $this->expectException(CiviCRM_API3_Exception::class);
+    $this->expectExceptionMessage(
+      'API permission check failed for CustomField/get call; insufficient permission: require ( ' . AwardPermission::PAYMENT_FIELD_SET_PERM . ' or access all custom data )'
+    );
+
+    civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => CreateAwardPaymentActivityTypes::CUSTOM_GROUP_NAME,
+      'check_permissions' => TRUE,
+    ]);
+  }
+
+  /**
+   * Test no error is thrown when user has access review perm.
+   */
+  public function testReviewFieldSetCanBeAccessedWithAccessReviewSetPermission() {
+    $this->setPermissions([AwardPermission::REVIEW_FIELD_SET_PERM]);
+
+    $result = civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => CreateApplicantReviewActivityType::CUSTOM_GROUP_NAME,
+      'check_permissions' => TRUE,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+  }
+
+  /**
+   * Test no error is thrown when user has access payment set perm.
+   */
+  public function testPaymentFieldSetCanBeAccessedWithAccessPaymentSetPermission() {
+    $this->setPermissions([AwardPermission::PAYMENT_FIELD_SET_PERM]);
+
+    $result = civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => CreateAwardPaymentActivityTypes::CUSTOM_GROUP_NAME,
+      'check_permissions' => TRUE,
+    ]);
+
+    $this->assertEquals(0, $result['is_error']);
+  }
+
+}


### PR DESCRIPTION
## Overview
When a user with the Award Manager role access the award payment listing page or the create/edit form popup, Previously  created award payments are not visible on the listing screen and also on the form, the custom fields belonging to the Award payment information are not visible. 

## Before
Payments Listing Screen
<img width="1280" alt="Manage Cases | CaseLatest 2021-02-24 13-00-20" src="https://user-images.githubusercontent.com/6951813/108997776-4c302280-76a0-11eb-9b6a-7e29c82ddacf.png">

Payment Create/Edit Screen
<img width="1280" alt="Manage Cases | CaseLatest 2021-02-24 13-00-05" src="https://user-images.githubusercontent.com/6951813/108997785-518d6d00-76a0-11eb-8b11-0bbb29b78be1.png">
 
## After
Payments Listing Screen
<img width="1280" alt="Manage Cases | CaseLatest 2021-02-24 13-03-10" src="https://user-images.githubusercontent.com/6951813/108998121-bb0d7b80-76a0-11eb-88ad-02f28a18eec7.png">

Payment Create/Edit Screen
<img width="1280" alt="Manage Cases | CaseLatest 2021-02-24 13-03-28" src="https://user-images.githubusercontent.com/6951813/108998159-c5c81080-76a0-11eb-9607-01f3c210217c.png">


## Technical Details
- The listing page is created from FE by using the CustomField API to fetch custom fields belonging to the Award Payments group. The permission required to access this API is the `administer CiviCRM and access all custom data` permissions. The Award manager would not have these permissions, so when the custom fields to be accessed is associated with the Payment Information activity type, the newly created `access payment custom field set` permission which the Award manager will have access to. Similar thing was done for Award review fields. 
-  For the Awards payment custom fields to show for the Award manager on the payment form, the Award manger needs to have an ACl that has access to these fields or have the ` access all custom data` permission, because the Award manager would not have access to these, a new hook `CRM_CiviAwards_Hook_AclGroup_AllowAccessToPaymentGroups` was added to allow the user with the `access payment custom field set` permission to have access to these groups as part of the allowed ACL groups for the user.