### PR TITLE
ACU-537: Handle missing payment data

### DIFF
--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -123,7 +123,11 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
       $this->getDefinedNonEditableFormFields() : [];
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.civiawards', 'js/award-payment-form.js');
-    CRM_Core_Resources::singleton()->addSetting(['nonEditableFields' => $nonEditableFields]);
+    CRM_Core_Resources::singleton()->addSetting([
+      'civiawards-payments-tab' => [
+        'nonEditableFields' => json_encode($nonEditableFields),
+      ],
+    ]);
   }
 
   /**

--- a/ang/civiawards-payments-tab/directives/payments-table.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-table.directive.js
@@ -75,6 +75,7 @@
       var paymentCustomFields = getCustomFieldsAsNamesAndValues(payment);
       var targetContactName = _.chain(payment.target_contact_name)
         .toArray().first().value();
+      var paymentType = paymentTypes[paymentCustomFields.custom_Type];
 
       return _.extend(
         {},
@@ -82,7 +83,7 @@
         paymentCustomFields,
         {
           target_contact_name: targetContactName,
-          paymentTypeLabel: paymentTypes[paymentCustomFields.custom_Type].label
+          paymentTypeLabel: (paymentType && paymentType.label) || ''
         }
       );
     }

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -91,6 +91,33 @@
           expect($scope.payments).toEqual(expectedPayments);
         });
       });
+
+      describe('when the payment custom fields are missing', () => {
+        beforeEach(() => {
+          const paymentActivityBaseFields = ['id', 'activity_date_time',
+            'target_contact_name', 'status_id.label', 'status_id.name'];
+          apiResponses.Activity.get.values = _.map(
+            generateNewMockPayments(),
+            (payment) => _.pick(payment, paymentActivityBaseFields)
+          );
+
+          initController();
+        });
+
+        it('should not throw an error due to missing information', () => {
+          expect(() => $scope.$digest()).not.toThrow();
+        });
+
+        describe('after loading the payments', () => {
+          beforeEach(() => $scope.$digest());
+
+          it('should fill the Payment Type label as an empty string', () => {
+            expect($scope.payments).toContain(jasmine.objectContaining({
+              paymentTypeLabel: ''
+            }));
+          });
+        });
+      });
     });
 
     describe('payments filtering', () => {

--- a/js/award-payment-form.js
+++ b/js/award-payment-form.js
@@ -1,5 +1,7 @@
-(function ($, nonEditableFields) {
-  $(document).on('crmLoad', function () {
+(function ($, paymentsSettings) {
+  $(document).one('crmLoad', function () {
+    var nonEditableFields = JSON.parse(paymentsSettings.nonEditableFields);
+
     (function init () {
       makeFieldsNonEditable();
       insertDeleteButtonAfterCancel();
@@ -43,4 +45,4 @@
       });
     });
   });
-})(CRM.$, CRM.nonEditableFields, window);
+})(CRM.$, CRM['civiawards-payments-tab']);


### PR DESCRIPTION
## Overview
This PR fixes an issue where the list of payments would disappear when one of the payments custom data was missing.

## Before & After
Record 158 has no custom data.

### Before
<img width="1649" alt="Screen Shot 2021-02-23 at 3 51 00 PM" src="https://user-images.githubusercontent.com/1642119/108900713-57c41080-75f0-11eb-8147-b6071fb364a9.png">
Notice the error on the console.

### After
<img width="1432" alt="Screen Shot 2021-02-23 at 3 51 36 PM" src="https://user-images.githubusercontent.com/1642119/108900722-5a266a80-75f0-11eb-8d6a-a3cea396fcaf.png">

## Technical Details
The problem was caused by the `formatPayment` function trying to access the Payment Type's label. If the payment type value was not defined in the payment object it would try to access an undefined object and this would throw an error. To fix this we check if the payment type is defined before assigning the label property otherwise we use an empty string.
