### PR TITLE
ACU-535: Fix Disabled Payment Fields

### DIFF
--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -124,7 +124,9 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.civiawards', 'js/award-payment-form.js');
     CRM_Core_Resources::singleton()->addSetting([
-      'nonEditableFields' => json_encode($nonEditableFields),
+      'civiawards-payments-tab' => [
+        'nonEditableFields' => json_encode($nonEditableFields),
+      ],
     ]);
   }
 

--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -123,7 +123,9 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
       $this->getDefinedNonEditableFormFields() : [];
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.civiawards', 'js/award-payment-form.js');
-    CRM_Core_Resources::singleton()->addSetting(['nonEditableFields' => $nonEditableFields]);
+    CRM_Core_Resources::singleton()->addSetting([
+      'nonEditableFields' => json_encode($nonEditableFields),
+    ]);
   }
 
   /**

--- a/js/award-payment-form.js
+++ b/js/award-payment-form.js
@@ -1,5 +1,5 @@
 (function ($, nonEditableFieldsString) {
-  $(document).on('crmLoad', function () {
+  $(document).one('crmLoad', function () {
     var nonEditableFields = JSON.parse(nonEditableFieldsString);
 
     (function init () {

--- a/js/award-payment-form.js
+++ b/js/award-payment-form.js
@@ -1,5 +1,7 @@
-(function ($, nonEditableFields) {
+(function ($, nonEditableFieldsString) {
   $(document).on('crmLoad', function () {
+    var nonEditableFields = JSON.parse(nonEditableFieldsString);
+
     (function init () {
       makeFieldsNonEditable();
       insertDeleteButtonAfterCancel();
@@ -43,4 +45,4 @@
       });
     });
   });
-})(CRM.$, CRM.nonEditableFields, window);
+})(CRM.$, CRM.nonEditableFields);

--- a/js/award-payment-form.js
+++ b/js/award-payment-form.js
@@ -1,6 +1,6 @@
-(function ($, nonEditableFieldsString) {
+(function ($, paymentsSettings) {
   $(document).one('crmLoad', function () {
-    var nonEditableFields = JSON.parse(nonEditableFieldsString);
+    var nonEditableFields = JSON.parse(paymentsSettings.nonEditableFields);
 
     (function init () {
       makeFieldsNonEditable();
@@ -45,4 +45,4 @@
       });
     });
   });
-})(CRM.$, CRM.nonEditableFields);
+})(CRM.$, CRM['civiawards-payments-tab']);


### PR DESCRIPTION
## Overview
This PR fixes an issue where fields would be disabled for certain payments and for others the fields would still be disabled when they should be enabled.

## Before
![pr](https://user-images.githubusercontent.com/1642119/109073218-78619880-76cc-11eb-8c0a-18538e891226.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/109034208-c9a66380-769d-11eb-9564-7d5ea072ac4a.gif)

## Technical Details

There were two issues that prevented fields from being enabled for the right payments:

1. The `crmLoad` load event that we were listening to on `js/award-payment-form.js` was triggering multiple times because this script is loaded every time a new form is opened, but the event listener would trigger even for forms that have already been closed. This would make all the events to act on the current visible form and disable their fields.
2. We were passing the `nonEditableFields` as an array. When adding CiviCRM Settings as objects or array they get extended instead of replaced. As an example, if the first form passed the value `[1,2,3,4]`, but the second form passed the value `[]`, the resulting value would still be `[1,2,3,4]` because it would try to extend any new values with the current one.

To fix issue No. 1 we use the event listener `.one` instead of `.on`. This means that the event will only be handled once and then forgotten.

To fix issue No. 2 we passed the value of `nonEditableFields` as a JSON string and parsed it on the front-end. This ensures that the value is always replaced.

We also moved the `nonEditableFields` setting so it's inside the `civiawards-payments-tab` to avoid collisions with other extensions.
