### PR TITLE
RSE-1202: Update Panel relationship label

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panel-popup.html
@@ -48,7 +48,7 @@
 
         <div class="form-group">
           <label class="col-sm-12 control-label">
-            Additional Contacts to add to Group
+            Additional Contacts to add to Panel
           </label>
         </div>
 


### PR DESCRIPTION
## Overview
This PR fixes the label of the Relationship selector on the Awards Create Panel tab from
`Additional Contacts to add to Group` to `Additional Contacts to add to Panel`.

