### PR TITLE
ACU-519: Remove status filters from payment status labels

### DIFF
--- a/CRM/CiviAwards/Upgrader/Steps/Step1010.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1010.php
@@ -1,0 +1,76 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes as CreateAwardPaymentActivityTypes;
+
+/**
+ * Removes the status filter from payment status labels.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1010 {
+
+  /**
+   * Runs the update.
+   *
+   * @return bool
+   *   TRUE when successfull.
+   */
+  public function apply() {
+    $this->removeStatusFilterFromPaymentStatusLabels();
+
+    return TRUE;
+  }
+
+  /**
+   * Loops through all payment statuses and sets their intended label.
+   */
+  private function removeStatusFilterFromPaymentStatusLabels() {
+    $paymentStatuses = $this->getPaymentStatusesToUpdate();
+
+    foreach ($paymentStatuses as $paymentStatus) {
+      civicrm_api3('OptionValue', 'getsingle', [
+        'name' => $paymentStatus['name'],
+        'option_group_id' => 'activity_status',
+        'grouping' => CreateAwardPaymentActivityTypes::AWARD_PAYMENTS_ACTIVITY_CATEGORY,
+        'api.OptionValue.create' => [
+          'id' => '$value.id',
+          'label' => $paymentStatus['new_label'],
+        ],
+      ]);
+    }
+  }
+
+  /**
+   * Returns a list of payments statuses with the intended label for each one.
+   *
+   * @return array
+   *   A list of payment status names and the labels they should have.
+   */
+  private function getPaymentStatusesToUpdate() {
+    return [
+      [
+        'name' => 'applied_for_incomplete',
+        'new_label' => 'Applied for',
+      ],
+      [
+        'name' => 'approved_complete',
+        'new_label' => 'Approved',
+      ],
+      [
+        'name' => 'exported_complete',
+        'new_label' => 'Exported',
+      ],
+      [
+        'name' => 'paid_complete',
+        'new_label' => 'Paid',
+      ],
+      [
+        'name' => 'cancelled_cancelled',
+        'new_label' => 'Cancelled',
+      ],
+      [
+        'name' => 'failed_incomplete',
+        'new_label' => 'Failed',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR removes the status filter from all payment status labels. The reason for removing the filters is that they were not meant to be added to the labels even thought it was defined as such in the specs. This has been corrected as an improvement.

## Before
```json
[
  {
      "id": "988",
      "label": "Applied for (incomplete)",
      "name": "applied_for_incomplete"
  },
  {
      "id": "989",
      "label": "Approved (complete)",
      "name": "approved_complete"
  },
  {
      "id": "990",
      "label": "Exported (complete)",
      "name": "exported_complete"
  },
  {
      "id": "991",
      "label": "Paid (complete)",
      "name": "paid_complete"
  },
  {
      "id": "992",
      "label": "Cancelled (cancelled)",
      "name": "cancelled_cancelled"
  },
  {
      "id": "993",
      "label": "Failed (incomplete)",
      "name": "failed_incomplete"
  }
]
```
## After
```json
[
  {
      "id": "988",
      "label": "Applied for",
      "name": "applied_for_incomplete"
  },
  {
      "id": "989",
      "label": "Approved",
      "name": "approved_complete"
  },
  {
      "id": "990",
      "label": "Exported",
      "name": "exported_complete"
  },
  {
      "id": "991",
      "label": "Paid",
      "name": "paid_complete"
  },
  {
      "id": "992",
      "label": "Cancelled",
      "name": "cancelled_cancelled"
  },
  {
      "id": "993",
      "label": "Failed",
      "name": "failed_incomplete"
  }
]
```

Actual status filters remain the same.

## Technical Details

We created an upgrader instead of updating the `CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes` class because these values have already been merged to master.