### PR TITLE
ACU-519: Update Awards Payment Activity Status Labels

### DIFF
--- a/CRM/CiviAwards/Setup/UpdateAwardPaymentActivityStatusLabel.php
+++ b/CRM/CiviAwards/Setup/UpdateAwardPaymentActivityStatusLabel.php
@@ -6,7 +6,7 @@
 class CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel {
 
   /**
-   * Updates the Applicant review activity status label.
+   * Updates the Applicant payment activity status label.
    */
   public function apply() {
     $this->updateActivityStatusLabels();
@@ -22,7 +22,7 @@ class CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel {
     return [
       [
         'name' => 'applied_for_incomplete',
-        'new_label' => 'Applied',
+        'new_label' => 'Applied for',
       ],
       [
         'name' => 'approved_complete',
@@ -48,13 +48,13 @@ class CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel {
   }
 
   /**
-   * Updates the Applicant review activity status label.
+   * Updates the Applicant payment activity status label.
    */
   private function updateActivityStatusLabels() {
     $activityStatusesMap = $this->getActivityStatusesMap();
 
     foreach ($activityStatusesMap as $activityStatus) {
-      $result = civicrm_api3('OptionValue', 'get', [
+      civicrm_api3('OptionValue', 'get', [
         'sequential' => 1,
         'option_group_id' => "activity_status",
         'name' => $activityStatus['name'],

--- a/CRM/CiviAwards/Setup/UpdateAwardPaymentActivityStatusLabel.php
+++ b/CRM/CiviAwards/Setup/UpdateAwardPaymentActivityStatusLabel.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Class for updating the Award payment activity status labels.
+ */
+class CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel {
+
+  /**
+   * Updates the Applicant review activity status label.
+   */
+  public function apply() {
+    $this->updateActivityStatusLabels();
+  }
+
+  /**
+   * Returns the award payment category statuses map.
+   *
+   * @return array
+   *   Activity statuses map.
+   */
+  private function getActivityStatusesMap() {
+    return [
+      [
+        'name' => 'applied_for_incomplete',
+        'new_label' => 'Applied',
+      ],
+      [
+        'name' => 'approved_complete',
+        'new_label' => 'Approved',
+      ],
+      [
+        'name' => 'exported_complete',
+        'new_label' => 'Exported',
+      ],
+      [
+        'name' => 'paid_complete',
+        'new_label' => 'Paid',
+      ],
+      [
+        'name' => 'cancelled_cancelled',
+        'new_label' => 'Cancelled',
+      ],
+      [
+        'name' => 'failed_incomplete',
+        'new_label' => 'Failed',
+      ],
+    ];
+  }
+
+  /**
+   * Updates the Applicant review activity status label.
+   */
+  private function updateActivityStatusLabels() {
+    $activityStatusesMap = $this->getActivityStatusesMap();
+
+    foreach ($activityStatusesMap as $activityStatus) {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => "activity_status",
+        'name' => $activityStatus['name'],
+        'api.OptionValue.create' => [
+          'id' => '$value.id',
+          'label' => $activityStatus['new_label'],
+        ],
+      ]);
+    }
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -14,6 +14,7 @@ use CRM_CiviAwards_Setup_CreateAwardPaymentActivityTypes as CreateAwardPaymentAc
 use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForAwardsCategory as RemoveCustomGroupSupportForAwardsCategory;
 use CRM_CiviAwards_Uninstall_RemoveCustomGroupSupportForApplicantManagement as RemoveCustomGroupSupportForApplicantManagement;
 use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
+use CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel as UpdateAwardPaymentActivityStatusLabel;
 
 /**
  * Collection of upgrade steps.
@@ -41,6 +42,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new AddApplicationManagementWordReplacement(),
       new CreateAwardsMenus(),
       new CreateAwardPaymentActivityTypes(),
+      new UpdateAwardPaymentActivityStatusLabel(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/Upgrader/Steps/Step1010.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1010.php
@@ -1,0 +1,22 @@
+<?php
+
+use CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel as UpdateAwardPaymentActivityStatusLabel;
+
+/**
+ * Updates the Applicant review activity status label.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1010 {
+
+  /**
+   * Installs the Award Payment related field sets and activity types.
+   *
+   * @return bool
+   *   return value.
+   */
+  public function apply() {
+    (new UpdateAwardPaymentActivityStatusLabel())->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
As part of this PR Awards Payment Activity Status Labels are updated.

## Before
Payment activity title shows activity status type within brackets.

## After
The status type has been removed now from the label.

## Technical Details
1. Created `CRM/CiviAwards/Setup/UpdateAwardPaymentActivityStatusLabel.php` to implement this feature.
2. Also added `CRM/CiviAwards/Upgrader/Steps/Step1010.php` upgrader.