### PR TITLE
ACU-539: Add Clear Filter button to Payments tab

### DIFF
--- a/ang/civiawards-payments-tab/directives/payment-filters.directive.html
+++ b/ang/civiawards-payments-tab/directives/payment-filters.directive.html
@@ -78,6 +78,10 @@
       </label>
     </div>
     <div class="col-sm-12 text-right">
+      <button ng-click="clearFilters()" class="btn btn-danger">
+        Clear
+      </button>
+
       <button type="submit" class="btn btn-primary">
         Filter
       </button>

--- a/ang/civiawards-payments-tab/directives/payment-filters.directive.js
+++ b/ang/civiawards-payments-tab/directives/payment-filters.directive.js
@@ -26,11 +26,19 @@
     $scope.filters = {};
     $scope.paymentStatusOptions = [];
     $scope.paymentTypeOptions = [];
+    $scope.clearFilters = clearFilters;
 
     (function init () {
       $scope.paymentStatusOptions = _.map(getPaymentStatuses(), Select2Utils.mapSelectOptions);
       $scope.paymentTypeOptions = _.map(paymentTypes, Select2Utils.mapSelectOptions);
     })();
+
+    /**
+     * Resets the filter object.
+     */
+    function clearFilters () {
+      $scope.filters = {};
+    }
 
     /**
      * @returns {object[]} Activity status related to payments.

--- a/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-case-tab-actions.directive.js
@@ -22,10 +22,11 @@
    * @param {Function} crmStatus crm status service
    * @param {Function} civicaseCrmLoadForm crm load form service
    * @param {object} AwardsPaymentActivityStatus awards payment activity status service
+   * @param {Function} civicaseCrmUrl civicrm url service
    */
   function civiawardsPaymentsCaseTabActionsController (
     ts, $scope, $rootScope, civicaseCrmApi, crmStatus, civicaseCrmLoadForm,
-    AwardsPaymentActivityStatus) {
+    AwardsPaymentActivityStatus, civicaseCrmUrl) {
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
 
     $scope.handleViewActivity = handleViewActivity;
@@ -40,7 +41,7 @@
      * @param {string} paymentId payment id
      */
     function handleViewActivity (paymentId) {
-      var url = CRM.url('civicrm/awardpayment', {
+      var url = civicaseCrmUrl('civicrm/awardpayment', {
         action: 'view',
         reset: 1,
         id: paymentId
@@ -55,7 +56,7 @@
      * @param {string} paymentId payment id
      */
     function handleEditActivity (paymentId) {
-      var url = CRM.url('civicrm/awardpayment', {
+      var url = civicaseCrmUrl('civicrm/awardpayment', {
         action: 'update',
         reset: 1,
         id: paymentId

--- a/ang/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.js
+++ b/ang/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.js
@@ -18,9 +18,10 @@
    * @param {object} $scope scope of the controller
    * @param {object} $rootScope rootscope of the application
    * @param {Function} civicaseCrmLoadForm crm load form service
+   * @param {Function} civicaseCrmUrl civicrm url service
    */
   function civiawardsPaymentsCaseTabAddPaymentController ($scope, $rootScope,
-    civicaseCrmLoadForm) {
+    civicaseCrmLoadForm, civicaseCrmUrl) {
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
 
     $scope.addPayment = addPayment;
@@ -31,7 +32,7 @@
      * @param {string} caseId case id
      */
     function addPayment (caseId) {
-      var url = CRM.url('civicrm/awardpayment', {
+      var url = civicaseCrmUrl('civicrm/awardpayment', {
         action: 'add',
         reset: 1,
         case_id: caseId

--- a/ang/civiawards-workflow/action-links/controllers/workflow-advanced.controller.js
+++ b/ang/civiawards-workflow/action-links/controllers/workflow-advanced.controller.js
@@ -1,4 +1,4 @@
-(function ($, _, angular, getCrmUrl) {
+(function ($, _, angular) {
   var module = angular.module('civiawards-workflow');
 
   module.controller('WorkflowAdvancedController', WorkflowAdvancedController);
@@ -6,8 +6,9 @@
   /**
    * @param {object} $scope scope object
    * @param {object} $window browsers window object
+   * @param {Function} civicaseCrmUrl civicrm url service
    */
-  function WorkflowAdvancedController ($scope, $window) {
+  function WorkflowAdvancedController ($scope, $window, civicaseCrmUrl) {
     $scope.clickHandler = clickHandler;
 
     /**
@@ -16,11 +17,11 @@
      * @param {object} workflow workflow object
      */
     function clickHandler (workflow) {
-      var url = getCrmUrl(
+      var url = civicaseCrmUrl(
         'civicrm/a/#/caseType/' + workflow.id
       );
 
       $window.location.href = url;
     }
   }
-})(CRM.$, CRM._, angular, CRM.url);
+})(CRM.$, CRM._, angular);

--- a/ang/civiawards/activity-forms/services/review-form.service.js
+++ b/ang/civiawards/activity-forms/services/review-form.service.js
@@ -1,12 +1,14 @@
-(function (_, angular, getCrmUrl) {
+(function (_, angular) {
   var module = angular.module('civiawards');
 
   module.service('ReviewActivityForm', ReviewActivityForm);
 
   /**
    * Review Activity Form service.
+   *
+   * @param {object} civicaseCrmUrl civicrm url service
    */
-  function ReviewActivityForm () {
+  function ReviewActivityForm (civicaseCrmUrl) {
     this.canHandleActivity = canHandleActivity;
     this.getActivityFormUrl = getActivityFormUrl;
 
@@ -40,7 +42,7 @@
         options.case_id = activity.case_id;
       }
 
-      return getCrmUrl('civicrm/awardreview', options);
+      return civicaseCrmUrl('civicrm/awardreview', options);
     }
   }
-})(CRM._, angular, CRM.url);
+})(CRM._, angular);

--- a/ang/civiawards/dashboard/configs/case-type-items.config.js
+++ b/ang/civiawards/dashboard/configs/case-type-items.config.js
@@ -1,4 +1,4 @@
-(function (angular, _, url) {
+(function (angular, _) {
   var module = angular.module('civiawards');
   var INSTANCE_NAME = 'applicant_management';
 
@@ -24,4 +24,4 @@
       }]);
     }
   });
-})(angular, CRM._, CRM.url);
+})(angular, CRM._);

--- a/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
@@ -1,4 +1,4 @@
-(function (angular, getCrmUrl) {
+(function (angular) {
   var module = angular.module('civiawards');
 
   module.controller('AddAwardDashboardActionButtonController', AddAwardDashboardActionButtonController);
@@ -12,9 +12,11 @@
    * @param {Function} canCreateOrEditAwards can create or edit awards function
    * @param {Function} isApplicationManagementScreen is application management screen function
    * @param {object} CaseTypeCategory case type category service
+   * @param {object} civicaseCrmUrl civicrm url service
    */
   function AddAwardDashboardActionButtonController ($scope, $routeParams,
-    $window, canCreateOrEditAwards, isApplicationManagementScreen, CaseTypeCategory) {
+    $window, canCreateOrEditAwards, isApplicationManagementScreen,
+    CaseTypeCategory, civicaseCrmUrl) {
     $scope.isVisible = isVisible;
     $scope.redirectToAwardsCreationScreen = redirectToAwardsCreationScreen;
 
@@ -31,10 +33,13 @@
      * Redirects the user to the awards creation screen.
      */
     function redirectToAwardsCreationScreen () {
-      var currentCaseTypeCategoryValue = CaseTypeCategory.findByName($routeParams.case_type_category).value;
-      var newAwardUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + currentCaseTypeCategoryValue + '/dashboard');
+      var currentCaseTypeCategoryValue =
+        CaseTypeCategory.findByName($routeParams.case_type_category).value;
+      var newAwardUrl = civicaseCrmUrl(
+        'civicrm/award/a/#/awards/new/' + currentCaseTypeCategoryValue + '/dashboard'
+      );
 
       $window.location.href = newAwardUrl;
     }
   }
-})(angular, CRM.url);
+})(angular);

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -1,4 +1,4 @@
-(function (_, $, angular, confirm, loadForm, getCrmUrl) {
+(function (_, $, angular, confirm, loadForm) {
   var module = angular.module('civiawards');
 
   module.directive('civiawardsReviewsCaseTabContent', function () {
@@ -25,9 +25,11 @@
    * @param {string} reviewScoringFieldsGroupName the review scoring fields group name.
    * @param {Function} ts the translation function.
    * @param {Function} crmStatus crm status service
+   * @param {Function} civicaseCrmUrl civicrm url service
    */
-  function civiawardsReviewsCaseTabContentController ($q, $scope, $sce, crmApi, reviewsActivityTypeName,
-    reviewScoringFieldsGroupName, ts, crmStatus) {
+  function civiawardsReviewsCaseTabContentController ($q, $scope, $sce, crmApi,
+    reviewsActivityTypeName, reviewScoringFieldsGroupName, ts, crmStatus,
+    civicaseCrmUrl) {
     var CRM_FORM_LOAD_EVENT = 'crmFormLoad';
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
     var REVIEW_FORM_URL = 'civicrm/awardreview';
@@ -120,7 +122,7 @@
      * successfully saving the form.
      */
     function handleAddReviewActivity () {
-      var formUrl = getCrmUrl(REVIEW_FORM_URL, {
+      var formUrl = civicaseCrmUrl(REVIEW_FORM_URL, {
         action: 'add',
         case_id: $scope.caseItem.id,
         reset: 1
@@ -137,7 +139,7 @@
      * @param {object} reviewActivity the review to edit.
      */
     function handleEditReviewActivity (reviewActivity) {
-      var formUrl = getCrmUrl(REVIEW_FORM_URL, {
+      var formUrl = civicaseCrmUrl(REVIEW_FORM_URL, {
         action: 'update',
         id: reviewActivity.id,
         reset: 1
@@ -154,7 +156,7 @@
      * @param {object} reviewActivity the review to view.
      */
     function handleViewReviewActivity (reviewActivity) {
-      var formUrl = getCrmUrl(REVIEW_FORM_URL, {
+      var formUrl = civicaseCrmUrl(REVIEW_FORM_URL, {
         action: 'view',
         id: reviewActivity.id,
         reset: 1
@@ -231,4 +233,4 @@
       });
     }
   }
-})(CRM._, CRM.$, angular, CRM.confirm, CRM.loadForm, CRM.url);
+})(CRM._, CRM.$, angular, CRM.confirm, CRM.loadForm);

--- a/ang/test/.eslintrc.json
+++ b/ang/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/ang/test/civiawards-base/services/applicant-management-workflow.service.spec.js
+++ b/ang/test/civiawards-base/services/applicant-management-workflow.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('applicant management workflow', () => {
     let $q, $rootScope, $window, civicaseCrmApiMock, CaseTypesMockData,

--- a/ang/test/civiawards-base/services/award-subtype.service.spec.js
+++ b/ang/test/civiawards-base/services/award-subtype.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function () {
   describe('AwardSubtype', function () {
     let AwardSubtype, AwardSubtypeMockData;

--- a/ang/test/civiawards-base/services/is-application-management-screen.factory.spec.js
+++ b/ang/test/civiawards-base/services/is-application-management-screen.factory.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function () {
   describe('isApplicationManagementScreen', function () {
     let $location, isApplicationManagementScreen;

--- a/ang/test/civiawards-payments-tab/configs/add-payments-tab.config.spec.js
+++ b/ang/test/civiawards-payments-tab/configs/add-payments-tab.config.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('AddPaymentsTabConfig', () => {
   let CaseDetailsTabsProvider, ts;
 

--- a/ang/test/civiawards-payments-tab/directives/payment-filters.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payment-filters.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('Payment Filters', () => {
   let $controller, $rootScope, $scope;
 
@@ -39,6 +37,27 @@ describe('Payment Filters', () => {
         jasmine.objectContaining({ id: '15', text: 'Cancelled (cancelled)' }),
         jasmine.objectContaining({ id: '16', text: 'Failed (incomplete)' })
       ]);
+    });
+  });
+
+  describe('when pressing the clear filter button', () => {
+    beforeEach(function () {
+      initController();
+
+      $scope.filters = {
+        activity_date_time: { BETWEEN: [new Date(), new Date()] },
+        custom_Payee_Ref: '2',
+        custom_Type: '1',
+        id: '1',
+        status_id: '11',
+        target_contact_id: '2'
+      };
+
+      $scope.clearFilters();
+    });
+
+    it('resets the filters', () => {
+      expect($scope.filters).toEqual({});
     });
   });
 

--- a/ang/test/civiawards-payments-tab/directives/payments-case-tab-actions.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-case-tab-actions.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, _) => {
   describe('PaymentsCaseTabActions', () => {
     let $q, $controller, $rootScope, $scope, mockPayments, crmStatus,

--- a/ang/test/civiawards-payments-tab/directives/payments-case-tab-actions.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-case-tab-actions.directive.spec.js
@@ -1,7 +1,7 @@
 (($, _) => {
   describe('PaymentsCaseTabActions', () => {
     let $q, $controller, $rootScope, $scope, mockPayments, crmStatus,
-      civicaseCrmApi, mockedConfirmElement, loadFormOnListener,
+      civicaseCrmApi, mockedConfirmElement, loadFormOnListener, civicaseCrmUrl,
       crmFormSuccessFunction, civicaseCrmLoadForm, AwardsPaymentActivityStatus;
     const CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
 
@@ -27,12 +27,14 @@
     }));
 
     beforeEach(inject((_$q_, _$controller_, _$rootScope_, _crmStatus_,
-      _civicaseCrmLoadForm_, _AwardsPaymentActivityStatus_, _mockPayments_) => {
+      _civicaseCrmLoadForm_, _AwardsPaymentActivityStatus_, _mockPayments_,
+      _civicaseCrmUrl_) => {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       crmStatus = _crmStatus_;
       civicaseCrmLoadForm = _civicaseCrmLoadForm_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
       AwardsPaymentActivityStatus = _AwardsPaymentActivityStatus_;
       mockPayments = _mockPayments_[0];
 
@@ -49,24 +51,38 @@
     }));
 
     describe('when viewing a payment', () => {
+      var expectedURL = 'view/payment/url';
+
       beforeEach(() => {
+        civicaseCrmUrl.and.returnValue(expectedURL);
         $scope.handleViewActivity(mockPayments.id);
       });
 
       it('opens a popup to view the activity', () => {
-        expect(civicaseCrmLoadForm)
-          .toHaveBeenCalledWith(`civicrm/awardpayment?action=view&id=${mockPayments.id}&reset=1`);
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardpayment', {
+          action: 'view',
+          reset: 1,
+          id: mockPayments.id
+        });
+        expect(civicaseCrmLoadForm).toHaveBeenCalledWith(expectedURL);
       });
     });
 
     describe('when editing a payment', () => {
+      var expectedURL = 'edit/payment/url';
+
       beforeEach(() => {
+        civicaseCrmUrl.and.returnValue(expectedURL);
         $scope.handleEditActivity(mockPayments.id);
       });
 
       it('opens a popup to edit the activity', () => {
-        expect(civicaseCrmLoadForm)
-          .toHaveBeenCalledWith(`civicrm/awardpayment?action=update&id=${mockPayments.id}&reset=1`);
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardpayment', {
+          action: 'update',
+          reset: 1,
+          id: mockPayments.id
+        });
+        expect(civicaseCrmLoadForm).toHaveBeenCalledWith(expectedURL);
       });
 
       describe('when saving the form', () => {

--- a/ang/test/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.spec.js
@@ -1,7 +1,7 @@
 ((_) => {
   describe('PaymentsCaseTabAddPayment', () => {
     let $controller, $rootScope, $scope, civicaseCrmLoadForm,
-      loadFormOnListener, crmFormSuccessFunction;
+      loadFormOnListener, crmFormSuccessFunction, civicaseCrmUrl;
 
     const CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
 
@@ -22,10 +22,12 @@
       });
     }));
 
-    beforeEach(inject((_$controller_, _$rootScope_, _civicaseCrmLoadForm_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _civicaseCrmLoadForm_,
+      _civicaseCrmUrl_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       civicaseCrmLoadForm = _civicaseCrmLoadForm_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
 
       spyOn($rootScope, '$broadcast');
     }));
@@ -37,14 +39,21 @@
     });
 
     describe('when clicking on add payment button', () => {
+      var expectedUrl = 'add/payment/url';
+
       beforeEach(() => {
         initController();
+        civicaseCrmUrl.and.returnValue(expectedUrl);
         $scope.addPayment($scope.caseId);
       });
 
       it('opens a popup to create a new payment for current application', () => {
-        expect(civicaseCrmLoadForm)
-          .toHaveBeenCalledWith('civicrm/awardpayment?action=add&case_id=5&reset=1');
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardpayment', {
+          action: 'add',
+          reset: 1,
+          case_id: $scope.caseId
+        });
+        expect(civicaseCrmLoadForm).toHaveBeenCalledWith(expectedUrl);
       });
 
       describe('when saving the form', () => {

--- a/ang/test/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-case-tab-add-payment.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('PaymentsCaseTabAddPayment', () => {
     let $controller, $rootScope, $scope, civicaseCrmLoadForm,

--- a/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
+++ b/ang/test/civiawards-payments-tab/directives/payments-table.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('PaymentsTable', () => {
     let $controller, $rootScope, $scope, apiResponses, civicaseCrmApi,

--- a/ang/test/civiawards-payments-tab/services/awards-payment-activity-status.service.spec.js
+++ b/ang/test/civiawards-payments-tab/services/awards-payment-activity-status.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('AwardsPaymentActivityStatus', () => {
   let AwardsPaymentActivityStatus;
 

--- a/ang/test/civiawards-payments-tab/services/payments-case-tab.service.spec.js
+++ b/ang/test/civiawards-payments-tab/services/payments-case-tab.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('PaymentsCaseTab', () => {
   let PaymentsCaseTab;
 

--- a/ang/test/civiawards-workflow/action-links/controlers/workflow-advanced.controller.spec.js
+++ b/ang/test/civiawards-workflow/action-links/controlers/workflow-advanced.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, getCrmUrl) => {
   describe('workflow duplicate controller', () => {
     let $controller, $rootScope, $scope, $window, CaseTypesMockData;

--- a/ang/test/civiawards-workflow/action-links/controlers/workflow-advanced.controller.spec.js
+++ b/ang/test/civiawards-workflow/action-links/controlers/workflow-advanced.controller.spec.js
@@ -1,33 +1,36 @@
-((_, getCrmUrl) => {
+((_) => {
   describe('workflow duplicate controller', () => {
-    let $controller, $rootScope, $scope, $window, CaseTypesMockData;
+    let $controller, $rootScope, $scope, $window, CaseTypesMockData,
+      civicaseCrmUrl;
 
     beforeEach(module('civiawards-workflow', 'civicase.data', ($provide) => {
       $provide.value('$window', { location: {} });
     }));
 
     beforeEach(inject((_$controller_, _$rootScope_, _$window_,
-      _CaseTypesMockData_) => {
+      _CaseTypesMockData_, _civicaseCrmUrl_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $window = _$window_;
       CaseTypesMockData = _CaseTypesMockData_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
     }));
 
     describe('when clicked', () => {
-      var workflowObject, expectedUrl;
+      var workflowObject;
+      var expectedUrl = 'workflow/click/url';
 
       beforeEach(() => {
         workflowObject = CaseTypesMockData.getSequential()[0];
 
         initController();
+        civicaseCrmUrl.and.returnValue(expectedUrl);
 
         $scope.clickHandler(workflowObject);
-
-        expectedUrl = getCrmUrl('civicrm/a/#/caseType/1');
       });
 
       it('redirects to the core screen to edit the workflow', () => {
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/a/#/caseType/1');
         expect($window.location.href).toBe(expectedUrl);
       });
     });
@@ -41,4 +44,4 @@
       $controller('WorkflowAdvancedController', { $scope: $scope });
     }
   });
-})(CRM._, CRM.url);
+})(CRM._);

--- a/ang/test/civiawards-workflow/filters/controllers/workflow-filter.controller.spec.js
+++ b/ang/test/civiawards-workflow/filters/controllers/workflow-filter.controller.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiawardReviewFieldsTable', () => {
     var $rootScope, $controller, $scope, AwardSubtypeMockData, Select2Utils;

--- a/ang/test/civiawards/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civiawards/activity-forms/activity-forms.config.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('Acitivity forms configuration', () => {
     let ActivityFormsProvider;

--- a/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
+++ b/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
@@ -1,11 +1,14 @@
-((_, getCrmUrl) => {
+((_) => {
   describe('ReviewActivityForm', () => {
-    let activityFormUrl, expectedActivityFormUrl, ReviewActivityForm, canHandle, reviewActivity;
+    let ReviewActivityForm, canHandle,
+      civicaseCrmUrl, reviewActivity;
 
     beforeEach(module('civiawards', 'civicase-base', 'civiawards.data'));
 
-    beforeEach(inject((_ReviewActivitiesMockData_, _ReviewActivityForm_) => {
+    beforeEach(inject((_ReviewActivitiesMockData_, _ReviewActivityForm_,
+      _civicaseCrmUrl_) => {
       ReviewActivityForm = _ReviewActivityForm_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
       reviewActivity = _.chain(_ReviewActivitiesMockData_)
         .first()
         .cloneDeep()
@@ -39,33 +42,31 @@
     describe('getting the activity form url', () => {
       describe('when getting the activity form url', () => {
         beforeEach(() => {
-          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity);
-          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
+          ReviewActivityForm.getActivityFormUrl(reviewActivity);
+        });
+
+        it('returns the url for the review activity form', () => {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardreview', {
             action: 'view',
             id: reviewActivity.id,
             reset: 1
           });
         });
-
-        it('returns the url for the review activity form', () => {
-          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
-        });
       });
 
       describe('when getting the update review form url', () => {
         beforeEach(() => {
-          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity, {
+          ReviewActivityForm.getActivityFormUrl(reviewActivity, {
             action: 'update'
-          });
-          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
-            action: 'update',
-            id: reviewActivity.id,
-            reset: 1
           });
         });
 
         it('returns the url for the review activity popup form', () => {
-          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardreview', {
+            action: 'update',
+            id: reviewActivity.id,
+            reset: 1
+          });
         });
       });
 
@@ -73,20 +74,19 @@
         beforeEach(() => {
           delete reviewActivity.id;
           reviewActivity.case_id = _.uniqueId();
-          activityFormUrl = ReviewActivityForm.getActivityFormUrl(reviewActivity, {
+          ReviewActivityForm.getActivityFormUrl(reviewActivity, {
             action: 'add'
           });
-          expectedActivityFormUrl = getCrmUrl('civicrm/awardreview', {
+        });
+
+        it('returns the url for the review activity popup form', () => {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/awardreview', {
             action: 'add',
             case_id: reviewActivity.case_id,
             reset: 1
           });
         });
-
-        it('returns the url for the review activity popup form', () => {
-          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
-        });
       });
     });
   });
-})(CRM._, CRM.url);
+})(CRM._);

--- a/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
+++ b/ang/test/civiawards/activity-forms/services/review-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, getCrmUrl) => {
   describe('ReviewActivityForm', () => {
     let activityFormUrl, expectedActivityFormUrl, ReviewActivityForm, canHandle, reviewActivity;

--- a/ang/test/civiawards/award-creation/directives/award-custom-field-sets.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award-custom-field-sets.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_, $) {
   describe('civiawardCustomFieldSets', () => {
     var civiawardCustomFieldSetsDirective, $compile, $rootScope, $scope;

--- a/ang/test/civiawards/award-creation/directives/award-stages-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award-stages-table.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiawardAwardStagesTable', () => {
     var $rootScope, $controller, $scope, CaseStatus, AwardMockData;

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiaward', () => {
     var $q, $controller, $rootScope, $scope, $window, $location, crmApi, crmStatus,

--- a/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/basic-details-form.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiawardBasicDetailsForm', () => {
     var $rootScope, $controller, $scope, AwardMockData,

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiawardReviewFieldsTable', () => {
     var $rootScope, $controller, $scope, $q, crmApi, ReviewFieldsMockData,

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civiawardReviewPanels', () => {
     let $rootScope, $controller, $scope, crmApi, $q, crmStatus, ts, ContactsData,

--- a/ang/test/civiawards/dashboard/configs/awards-dashboard-action-items.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/awards-dashboard-action-items.config.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('Awards Dashboard Action Items', () => {
     let DashboardActionItems;

--- a/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
+++ b/ang/test/civiawards/dashboard/configs/case-type-items.config.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   var AWARDS_CATEGORY_NAME = 'awards';
 

--- a/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, getCrmUrl) {
   describe('Add Award Dashboard Action Button', () => {
     let $location, $window, $scope, $controller, $rootScope, canCreateOrEditAwards, isApplicationManagementScreen;

--- a/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
@@ -1,6 +1,7 @@
-(function (_, getCrmUrl) {
+(function (_) {
   describe('Add Award Dashboard Action Button', () => {
-    let $location, $window, $scope, $controller, $rootScope, canCreateOrEditAwards, isApplicationManagementScreen;
+    let $location, $window, $scope, $controller, $rootScope, civicaseCrmUrl,
+      canCreateOrEditAwards, isApplicationManagementScreen;
 
     beforeEach(module('civiawards', ($provide) => {
       $window = { location: { href: '' } };
@@ -13,10 +14,12 @@
       $provide.value('isApplicationManagementScreen', isApplicationManagementScreen);
     }));
 
-    beforeEach(inject((_$location_, _$controller_, _$rootScope_) => {
+    beforeEach(inject((_$location_, _$controller_, _$rootScope_,
+      _civicaseCrmUrl_) => {
       $location = _$location_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
 
       initController();
     }));
@@ -69,14 +72,16 @@
 
     describe('when clicking the action button', () => {
       const awardCaseTypeCategoryId = 3;
-      const expectedUrl = getCrmUrl('civicrm/award/a/#/awards/new/' + awardCaseTypeCategoryId + '/dashboard');
+      const expectedUrl = 'action/button/url';
 
       beforeEach(() => {
         spyOn($location, 'url');
+        civicaseCrmUrl.and.returnValue(expectedUrl);
         $scope.redirectToAwardsCreationScreen();
       });
 
       it('redirects the user to the create award screen', () => {
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/award/a/#/awards/new/' + awardCaseTypeCategoryId + '/dashboard');
         expect($window.location.href).toBe(expectedUrl);
       });
     });
@@ -90,4 +95,4 @@
       $controller('AddAwardDashboardActionButtonController', { $scope: $scope });
     }
   });
-})(CRM._, CRM.url);
+})(CRM._);

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('More Filters Dashboard Action Button', () => {
     let $q, $location, $scope, $controller, $rootScope, dialogService,

--- a/ang/test/civiawards/reviews-tab/configs/add-reviews-tab.config.spec.js
+++ b/ang/test/civiawards/reviews-tab/configs/add-reviews-tab.config.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('Reviews Tab configuration', () => {
     let $window, CaseDetailsTabsProvider;

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, $, getCrmUrl) => {
   describe('Review Case Tab Content', () => {
     let $controller, $q, $rootScope, $scope, AwardAdditionalDetailsMockData,

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -1,8 +1,9 @@
-((_, $, getCrmUrl) => {
+((_, $) => {
   describe('Review Case Tab Content', () => {
     let $controller, $q, $rootScope, $scope, AwardAdditionalDetailsMockData,
       caseItem, crmApi, ReviewActivitiesMockData, ReviewFieldsMockData,
-      reviewsActivityTypeName, reviewScoringFieldsGroupName, crmStatus;
+      reviewsActivityTypeName, reviewScoringFieldsGroupName, crmStatus,
+      civicaseCrmUrl;
     const entityActionHandlers = {
       'Activity.get': activityGetHandler,
       'AwardDetail.getsingle': awardDetailGetSingleHandler,
@@ -17,7 +18,8 @@
 
     beforeEach(inject((_$controller_, _$q_, _$rootScope_, _ApplicationsMockData_,
       _AwardAdditionalDetailsMockData_, _ReviewActivitiesMockData_, _ReviewFieldsMockData_,
-      _reviewsActivityTypeName_, _reviewScoringFieldsGroupName_, _crmStatus_) => {
+      _reviewsActivityTypeName_, _reviewScoringFieldsGroupName_, _crmStatus_,
+      _civicaseCrmUrl_) => {
       $controller = _$controller_;
       $q = _$q_;
       $rootScope = _$rootScope_;
@@ -27,6 +29,8 @@
       ReviewFieldsMockData = _ReviewFieldsMockData_;
       reviewsActivityTypeName = _reviewsActivityTypeName_;
       reviewScoringFieldsGroupName = _reviewScoringFieldsGroupName_;
+      civicaseCrmUrl = _civicaseCrmUrl_;
+
       caseItem = _.first(_ApplicationsMockData_);
       $scope = $rootScope.$new();
       $scope.caseItem = caseItem;
@@ -131,16 +135,17 @@
 
       describe('when clicking the add new review button', () => {
         beforeEach(() => {
-          expectedUrl = getCrmUrl(REVIEW_FORM_URL, {
-            action: 'add',
-            case_id: $scope.caseItem.id,
-            reset: 1
-          });
-
+          expectedUrl = 'new/review/button/url';
+          civicaseCrmUrl.and.returnValue(expectedUrl);
           $scope.handleAddReviewActivity();
         });
 
         it('opens the form to create a new review', () => {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith(REVIEW_FORM_URL, {
+            action: 'add',
+            case_id: $scope.caseItem.id,
+            reset: 1
+          });
           expect(CRM.loadForm).toHaveBeenCalledWith(expectedUrl);
         });
 
@@ -157,32 +162,34 @@
 
       describe('when viewing a particular review', () => {
         beforeEach(() => {
-          expectedUrl = getCrmUrl(REVIEW_FORM_URL, {
-            action: 'view',
-            id: selectedReview.id,
-            reset: 1
-          });
-
+          expectedUrl = 'view/review/button/url';
+          civicaseCrmUrl.and.returnValue(expectedUrl);
           $scope.handleViewReviewActivity(selectedReview);
         });
 
         it('calls the form to view the selected review', () => {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith(REVIEW_FORM_URL, {
+            action: 'view',
+            id: selectedReview.id,
+            reset: 1
+          });
           expect(CRM.loadForm).toHaveBeenCalledWith(expectedUrl);
         });
       });
 
       describe('when editing a review', () => {
         beforeEach(() => {
-          expectedUrl = getCrmUrl(REVIEW_FORM_URL, {
-            action: 'update',
-            id: selectedReview.id,
-            reset: 1
-          });
-
+          expectedUrl = 'update/review/button/url';
+          civicaseCrmUrl.and.returnValue(expectedUrl);
           $scope.handleEditReviewActivity(selectedReview);
         });
 
         it('calls the form to edit the selected review', () => {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith(REVIEW_FORM_URL, {
+            action: 'update',
+            id: selectedReview.id,
+            reset: 1
+          });
           expect(CRM.loadForm).toHaveBeenCalledWith(expectedUrl);
         });
 
@@ -337,4 +344,4 @@
       $controller('civiawardsReviewsCaseTabContentController', dependencies);
     }
   });
-})(CRM._, CRM.$, CRM.url);
+})(CRM._, CRM.$);

--- a/ang/test/civiawards/shared/services/can-create-or-edit-awards.factory.spec.js
+++ b/ang/test/civiawards/shared/services/can-create-or-edit-awards.factory.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function () {
   describe('canCreateOrEditAwards', function () {
     let canCreateOrEditAwards, permissions;

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (CRM) {
   CRM['civiawards-base'] = {};
   CRM['civiawards-workflow'] = {};

--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -22,7 +22,7 @@ const OUTSIDE_NAMESPACE_REGEX = /^\.___outside-namespace/;
  * @param {string} selector selector
  * @returns {string} string
  */
-function removeOutsideNamespaceMarker(selector) {
+function removeOutsideNamespaceMarker (selector) {
   return selector.replace(OUTSIDE_NAMESPACE_REGEX, '');
 }
 
@@ -31,7 +31,7 @@ function removeOutsideNamespaceMarker(selector) {
  *
  * @returns {object} stream
  */
-function sassTask() {
+function sassTask () {
   return civicrmScssRoot.update()
     .then(() => {
       gulp.src('scss/civiawards.scss')
@@ -45,14 +45,14 @@ function sassTask() {
           includePaths: civicrmScssRoot.getPath(),
           precision: 10
         }).on('error', sass.logError))
-        .pipe(stripCssComments({preserve: false}))
+        .pipe(stripCssComments({ preserve: false }))
         .pipe(postcss([postcssPrefix({
           prefix: `${BOOTSTRAP_NAMESPACE} `,
           exclude: [/^body/, /page-civicrm-case/, OUTSIDE_NAMESPACE_REGEX]
         }), postcssDiscardDuplicates]))
-        .pipe(transformSelectors(removeOutsideNamespaceMarker, {splitOnCommas: true}))
-        .pipe(cleanCSS({sourceMap: true}))
-        .pipe(rename({suffix: '.min'}))
+        .pipe(transformSelectors(removeOutsideNamespaceMarker, { splitOnCommas: true }))
+        .pipe(cleanCSS({ sourceMap: true }))
+        .pipe(rename({ suffix: '.min' }))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('css/'));
     });


### PR DESCRIPTION
## Overview
As part of this PR, "Clear Filter" button to Payments tab.

## Before
![2021-03-11 at 2 43 PM](https://user-images.githubusercontent.com/5058867/110763687-2a29c900-8278-11eb-8b89-c4aa751a8563.png)

## After
![2021-03-11 at 2 42 PM](https://user-images.githubusercontent.com/5058867/110763623-1aaa8000-8278-11eb-9d96-8fd0381bf544.png)

## Technical Details
1. Added the button in `ang/civiawards-payments-tab/directives/payment-filters.directive.html` and `ang/civiawards-payments-tab/directives/payment-filters.directive.js`.

2. Removed all `/* eslint-env jasmine */` statements, as now `ang/test/` folder has its own `.eslintrc.json` file with this rule.

3. Removed all `CRM.url` statements and used `civicaseCrmUrl` service.