### PR TITLE
CPS-202: Use Category ID on 

### DIFF
--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -1,54 +1,28 @@
 <?php
 
+use CRM_Civicase_Service_CaseMenu_RouteFactory as RouteFactory;
+
 /**
  * Applicant Management Menu class.
  */
 class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Service_CaseCategoryMenu {
 
   /**
-   * Creates the Sub Menus for the Applicant Management Instance.
-   *
-   * @param string $caseTypeCategoryName
-   *   Case category name.
-   * @param array $permissions
-   *   Permissions.
-   * @param int $caseCategoryMenuId
-   *   Menu ID.
+   * {@inheritDoc}
    */
-  protected function createCaseCategorySubmenus($caseTypeCategoryName, array $permissions, $caseCategoryMenuId) {
-    $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
-
-    $submenus = [
-      [
-        'label' => ts('Dashboard'),
-        'name' => "{$caseTypeCategoryName}_dashboard",
-        'url' => "/civicrm/case/a/?case_type_category={$caseTypeCategoryName}#/case?case_type_category={$caseTypeCategoryName}",
-        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
-        'permission_operator' => 'OR',
-      ],
-      [
-        'label' => ts('Manage Applications'),
-        'name' => "manage_{$caseTypeCategoryName}_applications",
-        'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
-        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
-        'permission_operator' => 'OR',
-        'has_separator' => 1,
-      ],
-      [
-        'label' => ts("Manage " . $labelForMenu),
-        'name' => "manage_{$caseTypeCategoryName}_workflows",
-        'url' => 'civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',
-        'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
-        'permission_operator' => 'OR',
-      ],
+  public function getSubRoutes(string $caseTypeCategoryName) {
+    return [
+      RouteFactory::create('dashboard', $caseTypeCategoryName),
+      RouteFactory::create('all', $caseTypeCategoryName)
+        ->setOverwrittenProperties([
+          'label' => ts('Manage Applications'),
+          'name' => "manage_{$caseTypeCategoryName}_applications",
+        ]),
+      RouteFactory::create('manage_workflows', $caseTypeCategoryName)
+        ->setOverwrittenProperties([
+          'label' => ts("Manage " . $caseTypeCategoryName),
+        ]),
     ];
-
-    foreach ($submenus as $i => $item) {
-      $item['weight'] = $i;
-      $item['parent_id'] = $caseCategoryMenuId;
-      $item['is_active'] = 1;
-      civicrm_api3('Navigation', 'create', $item);
-    }
   }
 
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1011.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1011.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_CiviAwards_Service_ApplicantManagementMenu as ApplicantManagementMenu;
+
+/**
+ * Update menus with new URL.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1011 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    (new ApplicantManagementMenu())->updateSubmenus(
+      CRM_CiviAwards_Helper_CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME
+    );
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+}

--- a/ang/civiawards/award-creation/directives/award.directive.html
+++ b/ang/civiawards/award-creation/directives/award.directive.html
@@ -14,7 +14,7 @@
         Continue
       </button>
       <button
-        ng-click="navigateToDashboard()" class="btn btn-secondary-outline">
+        ng-click="navigateToPreviousPage()" class="btn btn-secondary-outline">
         Cancel
       </button>
     </div>

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -256,11 +256,10 @@
      * Navigate to the Previous Page
      */
     function navigateToPreviousPage () {
-      var caseTypeCategoryName = CaseTypeCategory.findById($scope.caseTypeCategoryId).name;
-      var url = '/civicrm/workflow/a?case_type_category=' + caseTypeCategoryName + '#/list';
+      var url = '/civicrm/workflow/a?case_type_category=' + $scope.caseTypeCategoryId + '#/list';
 
       if ($scope.redirectTo === 'dashboard') {
-        url = '/civicrm/case/a/?case_type_category=' + caseTypeCategoryName + '#/case?case_type_category=' + caseTypeCategoryName;
+        url = '/civicrm/case/a/?case_type_category=' + $scope.caseTypeCategoryId + '#/case?case_type_category=' + $scope.caseTypeCategoryId;
       }
 
       $window.location.href = url;

--- a/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
@@ -33,10 +33,8 @@
      * Redirects the user to the awards creation screen.
      */
     function redirectToAwardsCreationScreen () {
-      var currentCaseTypeCategoryValue =
-        CaseTypeCategory.findByName($routeParams.case_type_category).value;
       var newAwardUrl = civicaseCrmUrl(
-        'civicrm/award/a/#/awards/new/' + currentCaseTypeCategoryValue + '/dashboard'
+        'civicrm/award/a/#/awards/new/' + $routeParams.case_type_category + '/dashboard'
       );
 
       $window.location.href = newAwardUrl;

--- a/ang/civiawards/dashboard/directives/edit-award-button.controller.js
+++ b/ang/civiawards/dashboard/directives/edit-award-button.controller.js
@@ -13,11 +13,8 @@
    */
   function EditAwardButtonController ($scope, $routeParams,
     canCreateOrEditAwards, CaseTypeCategory) {
-    var currentCaseTypeCategoryValue =
-      CaseTypeCategory.findByName($routeParams.case_type_category).value;
-
     $scope.canEditAwards = canCreateOrEditAwards;
     $scope.editAwardUrl = 'civicrm/award/a/#/awards/' +
-     currentCaseTypeCategoryValue + '/' + $scope.caseType.id + '/' + 'dashboard';
+      $routeParams.case_type_category + '/' + $scope.caseType.id + '/' + 'dashboard';
   }
 })(angular);

--- a/ang/test/civiawards-base/services/is-application-management-screen.factory.spec.js
+++ b/ang/test/civiawards-base/services/is-application-management-screen.factory.spec.js
@@ -15,7 +15,7 @@
     describe('when the user is viewing an applicant management screen', () => {
       beforeEach(() => {
         $location.search.and.returnValue({
-          case_type_category: 'awards'
+          case_type_category: '3'
         });
       });
 
@@ -27,7 +27,7 @@
     describe('when the user is viewing a non applicant management screen', () => {
       beforeEach(() => {
         $location.search.and.returnValue({
-          case_type_category: 'case'
+          case_type_category: '1'
         });
       });
 

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -453,7 +453,7 @@
         });
 
         it('redirects to award dashboard page', () => {
-          expect($window.location.href).toBe('/civicrm/case/a/?case_type_category=awards#/case?case_type_category=awards');
+          expect($window.location.href).toBe('/civicrm/case/a/?case_type_category=3#/case?case_type_category=3');
         });
 
         it('shows a notification after save is successfull', () => {
@@ -478,7 +478,7 @@
         });
 
         it('redirects to manage awards page', () => {
-          expect($window.location.href).toBe('/civicrm/workflow/a?case_type_category=awards#/list');
+          expect($window.location.href).toBe('/civicrm/workflow/a?case_type_category=3#/list');
         });
 
         it('shows a notification after save is successfull', () => {

--- a/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.spec.js
@@ -9,7 +9,7 @@
       isApplicationManagementScreen = jasmine.createSpy('isApplicationManagementScreen');
 
       $provide.value('$window', $window);
-      $provide.value('$routeParams', { case_type_category: 'awards' });
+      $provide.value('$routeParams', { case_type_category: '3' });
       $provide.value('canCreateOrEditAwards', canCreateOrEditAwards);
       $provide.value('isApplicationManagementScreen', isApplicationManagementScreen);
     }));

--- a/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
+++ b/ang/test/civiawards/dashboard/directives/more-filters-dashboard-action-button.controller.spec.js
@@ -36,7 +36,7 @@
 
       describe('when viewing the awards dashboard', () => {
         beforeEach(() => {
-          $location.search('case_type_category', 'awards');
+          $location.search('case_type_category', '3');
           initController();
           $rootScope.$digest();
 
@@ -50,7 +50,7 @@
 
       describe('when viewing any other dashboard', () => {
         beforeEach(() => {
-          $location.search('case_type_category', 'cases');
+          $location.search('case_type_category', '1');
           initController();
           $rootScope.$digest();
 

--- a/ang/test/civiawards/reviews-tab/configs/add-reviews-tab.config.spec.js
+++ b/ang/test/civiawards/reviews-tab/configs/add-reviews-tab.config.spec.js
@@ -16,7 +16,7 @@
 
     describe('when viewing award applications', () => {
       beforeEach(module(() => {
-        $window.location.search = '?case_type_category=awards';
+        $window.location.search = '?case_type_category=3';
       }, 'civiawards'));
 
       beforeEach(inject);


### PR DESCRIPTION
## Overview
This PR aligns CiviAwards code with the changes introduced on CiviCase, for allowing the usage of long Case Category names.

## Technical Details
PR for CiviCase: https://github.com/compucorp/uk.co.compucorp.civicase/pull/756

The changes here include.
- Use of new Routes classes on `ApplicantManagementMenu`: https://github.com/compucorp/uk.co.compucorp.civiawards/commit/011e20b1293211c1749c5a1345ba6084234a3fee
- Add upgrader for updating existing menus: https://github.com/compucorp/uk.co.compucorp.civiawards/commit/8e351634d4819a06d082ce06858eeb6df3dfa1cd
- And the replacements for the frontend, both on code https://github.com/compucorp/uk.co.compucorp.civiawards/commit/0761e8d2f1879499f81de551958cc765a202ba74 and tests https://github.com/compucorp/uk.co.compucorp.civiawards/commit/1284538f98495a957e8da827177059cf3ab0448a