### PR TITLE
RSE-1276: Update menu items setup to use singular labels

### DIFF
--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -13,6 +13,16 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
   const AWARDS_CASE_TYPE_CATEGORY_NAME = 'awards';
 
   /**
+   * Award category label.
+   */
+  const AWARDS_CASE_TYPE_CATEGORY_LABEL = 'Awards';
+
+  /**
+   * Award category singular label.
+   */
+  const AWARDS_CASE_TYPE_CATEGORY_SINGULAR_LABEL = 'Award';
+
+  /**
    * Applicant management instance name.
    */
   const APPLICATION_MANAGEMENT_NAME = 'applicant_management';

--- a/CRM/CiviAwards/Helper/CaseTypeCategory.php
+++ b/CRM/CiviAwards/Helper/CaseTypeCategory.php
@@ -74,4 +74,18 @@ class CRM_CiviAwards_Helper_CaseTypeCategory {
     return AwardDetail::buildOptions('award_subtype');
   }
 
+  /**
+   * Get data for creating the menu.
+   *
+   * @return string[]
+   *   Category data.
+   */
+  public static function getDataForMenu() {
+    return [
+      'name' => self::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      'label' => self::AWARDS_CASE_TYPE_CATEGORY_LABEL,
+      'singular_label' => self::AWARDS_CASE_TYPE_CATEGORY_SINGULAR_LABEL,
+    ];
+  }
+
 }

--- a/CRM/CiviAwards/Service/ApplicantManagementMenu.php
+++ b/CRM/CiviAwards/Service/ApplicantManagementMenu.php
@@ -10,8 +10,9 @@ class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Servic
   /**
    * {@inheritDoc}
    */
-  public function getSubmenus($caseTypeCategoryName, array $permissions = NULL) {
-    $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
+  public function getSubmenus(array $caseTypeCategory, array $permissions = NULL) {
+    $singularLabelForMenu = ucfirst(strtolower($caseTypeCategory['singular_label']));
+    $caseTypeCategoryName = $caseTypeCategory['name'];
     $categoryId = civicrm_api3('OptionValue', 'getsingle', [
       'option_group_id' => 'case_type_categories',
       'name' => $caseTypeCategoryName,
@@ -38,9 +39,9 @@ class CRM_CiviAwards_Service_ApplicantManagementMenu extends CRM_Civicase_Servic
         'has_separator' => 1,
       ],
       [
-        'label' => ts("Manage " . $labelForMenu),
+        'label' => ts('Manage %1 Types', ['1' => $singularLabelForMenu]),
         'name' => "manage_{$caseTypeCategoryName}_workflows",
-        'url' => 'civicrm/workflow/a?case_type_category=' . $categoryId . '#/list',
+        'url' => 'civicrm/workflow/a?case_type_category=' . $categoryId . '&p=al#/list',
         'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
         'permission_operator' => 'OR',
       ],

--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -13,11 +13,7 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
    */
   public function apply() {
     $applicationMenu = new ApplicantManagementMenu();
-    $applicationMenu->createItems([
-      'name' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
-      'label' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_LABEL,
-      'singular_label' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_SINGULAR_LABEL,
-    ]);
+    $applicationMenu->createItems(CaseTypeCategoryHelper::getDataForMenu());
   }
 
 }

--- a/CRM/CiviAwards/Setup/CreateAwardsMenus.php
+++ b/CRM/CiviAwards/Setup/CreateAwardsMenus.php
@@ -13,7 +13,11 @@ class CRM_CiviAwards_Setup_CreateAwardsMenus {
    */
   public function apply() {
     $applicationMenu = new ApplicantManagementMenu();
-    $applicationMenu->createItems(CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME);
+    $applicationMenu->createItems([
+      'name' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_NAME,
+      'label' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_LABEL,
+      'singular_label' => CaseTypeCategoryHelper::AWARDS_CASE_TYPE_CATEGORY_SINGULAR_LABEL,
+    ]);
   }
 
 }

--- a/CRM/CiviAwards/Upgrader/Steps/Step1011.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1011.php
@@ -15,7 +15,7 @@ class CRM_CiviAwards_Upgrader_Steps_Step1011 {
    */
   public function apply() {
     (new ApplicantManagementMenu())->resetCaseCategorySubmenusUrl(
-      CRM_CiviAwards_Helper_CaseTypeCategory::AWARDS_CASE_TYPE_CATEGORY_NAME
+      CRM_CiviAwards_Helper_CaseTypeCategory::getDataForMenu()
     );
 
     CRM_Core_BAO_Navigation::resetNavigation();


### PR DESCRIPTION
## Overview
This PR updates the menu setup code because of changes done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/760 

## Before & After
This does not change anything visually, only the code is updated so it follows the changes done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/760

## Technical Details

`ApplicantManagementMenu`  class  extends `CRM_Civicase_Service_CaseCategoryMenu` and this class was updated to accept the name, label, and singular label to use when creating case category menu items. We now pass the missing arguments.