### PR TITLE
CPS-533: Show all review fields

### DIFF
--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -16,8 +16,8 @@
   });
 
   module.controller('CiviAwardCreateEditAwardController', function (
-    $location, $q, $scope, $window, CaseTypeCategory, CaseStatus, crmApi, crmStatus,
-    Select2Utils, ts) {
+    $location, $q, $scope, $window, CaseTypeCategory, CaseStatus,
+    civicaseCrmApi, crmStatus, Select2Utils, ts) {
     var DEFAULT_ACTIVITY_TYPES = [
       { name: 'Applicant Review' },
       { name: 'Email' },
@@ -139,7 +139,7 @@
      * @returns {Promise} promise
      */
     function fetchAwardInformation () {
-      return crmApi({
+      return civicaseCrmApi({
         caseType: ['CaseType', 'getsingle', { sequential: true, id: $scope.awardId }],
         additionalDetails: ['AwardDetail', 'getsingle', { sequential: true, case_type_id: $scope.awardId }]
       });
@@ -302,7 +302,7 @@
         params.id = $scope.awardId;
       }
 
-      return crmApi('CaseType', 'create', params).then(function (caseTypeData) {
+      return civicaseCrmApi('CaseType', 'create', params).then(function (caseTypeData) {
         return caseTypeData.values[0];
       });
     }
@@ -365,7 +365,7 @@
         params.id = $scope.awardDetailsID;
       }
 
-      return crmApi('AwardDetail', 'create', params)
+      return civicaseCrmApi('AwardDetail', 'create', params)
         .then(function (awardData) {
           return {
             caseType: award,

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
@@ -10,7 +10,7 @@
   });
 
   module.controller('CiviawardReviewFieldsTableController', function (
-    $rootScope, $scope, CaseStatus, crmApi, dialogService, ts,
+    $rootScope, $scope, civicaseCrmApi, dialogService, ts,
     reviewScoringFieldsGroupName, isTruthy) {
     $scope.reviewFields = [];
     $scope.resourcesBaseUrl = CRM.config.resourceBase;
@@ -202,7 +202,7 @@
      * @returns {Promise} promise containing all review fields
      */
     function fetchAllReviewFields () {
-      return crmApi([['CustomField', 'get', {
+      return civicaseCrmApi([['CustomField', 'get', {
         sequential: true,
         custom_group_id: reviewScoringFieldsGroupName,
         options: { limit: 0 }

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
@@ -203,7 +203,9 @@
      */
     function fetchAllReviewFields () {
       return crmApi([['CustomField', 'get', {
-        sequential: true, custom_group_id: reviewScoringFieldsGroupName
+        sequential: true,
+        custom_group_id: reviewScoringFieldsGroupName,
+        options: { limit: 0 }
       }]]).then(function (customFieldData) {
         return customFieldData[0].values;
       });

--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -14,7 +14,7 @@
   });
 
   module.controller('CiviawardReviewPanelsController', function (
-    $q, $scope, ts, dialogService, crmApi, crmStatus, Select2Utils,
+    $q, $scope, ts, dialogService, civicaseCrmApi, crmStatus, Select2Utils,
     CaseStatus, isTruthy) {
     var relationshipTypesIndexed = {};
     var contactsIndexed = {};
@@ -53,7 +53,7 @@
      * @returns {Promise} api call promise
      */
     function getTags () {
-      return crmApi('Tag', 'get', {
+      return civicaseCrmApi('Tag', 'get', {
         sequential: 1,
         used_for: 'Cases',
         options: { limit: 0 }
@@ -147,7 +147,7 @@
         return $q.resolve([]);
       }
 
-      return crmApi('Contact', 'get', {
+      return civicaseCrmApi('Contact', 'get', {
         sequential: 1,
         return: ['display_name'],
         id: { IN: contactIdsToFetch },
@@ -221,7 +221,7 @@
       }).on('crmConfirm:yes', function () {
         $scope.submitInProgress = true;
 
-        var promise = crmApi('AwardReviewPanel', 'delete', {
+        var promise = civicaseCrmApi('AwardReviewPanel', 'delete', {
           id: reviewPanel.id
         }).then(refreshReviewPanelsList)
           .then(function () {
@@ -253,7 +253,7 @@
       }).on('crmConfirm:yes', function () {
         $scope.submitInProgress = true;
 
-        var promise = crmApi('AwardReviewPanel', 'create', {
+        var promise = civicaseCrmApi('AwardReviewPanel', 'create', {
           id: reviewPanel.id,
           is_active: isTruthy(reviewPanel.is_active) ? '0' : '1'
         }).then(refreshReviewPanelsList)
@@ -358,7 +358,7 @@
      * @returns {Promise} promise
      */
     function fetchGroups () {
-      return crmApi('Group', 'get', {
+      return civicaseCrmApi('Group', 'get', {
         sequential: 1,
         return: ['id', 'title'],
         options: { limit: 0 }
@@ -391,7 +391,7 @@
      * @returns {Promise} promise
      */
     function fetchExistingReviewPanels (awardId) {
-      return crmApi('AwardReviewPanel', 'get', {
+      return civicaseCrmApi('AwardReviewPanel', 'get', {
         sequential: 1,
         case_type_id: awardId,
         options: { limit: 0 }
@@ -425,7 +425,7 @@
      * @returns {Promise} promise
      */
     function fetchRelationshipsTypes () {
-      return crmApi('RelationshipType', 'get', {
+      return civicaseCrmApi('RelationshipType', 'get', {
         sequential: 1,
         is_active: 1,
         options: { sort: 'label_a_b', limit: 0 }
@@ -586,7 +586,7 @@
 
       $scope.submitInProgress = true;
 
-      var promise = crmApi('AwardReviewPanel', 'create', getParamsForSavingReviewPanel())
+      var promise = civicaseCrmApi('AwardReviewPanel', 'create', getParamsForSavingReviewPanel())
         .then(function () {
           dialogService.close('ReviewPanels');
           resetReviewPanelPopup();

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -20,7 +20,7 @@
    * @param {object} $q the $q service.
    * @param {object} $scope the scope object.
    * @param {object} $sce angular Strict Contextual Escaping service.
-   * @param {Function} crmApi the CiviCRM API service.
+   * @param {Function} civicaseCrmApi the CiviCRM API service.
    * @param {string} reviewsActivityTypeName the reviews activity type name.
    * @param {string} reviewScoringFieldsGroupName the review scoring fields group name.
    * @param {Function} ts the translation function.
@@ -28,9 +28,9 @@
    * @param {Function} civicaseCrmUrl civicrm url service
    * @param {Function} civicaseCrmLoadForm service to load civicrm forms
    */
-  function civiawardsReviewsCaseTabContentController ($q, $scope, $sce, crmApi,
-    reviewsActivityTypeName, reviewScoringFieldsGroupName, ts, crmStatus,
-    civicaseCrmUrl, civicaseCrmLoadForm) {
+  function civiawardsReviewsCaseTabContentController ($q, $scope, $sce,
+    civicaseCrmApi, reviewsActivityTypeName, reviewScoringFieldsGroupName, ts,
+    crmStatus, civicaseCrmUrl, civicaseCrmLoadForm) {
     var CRM_FORM_LOAD_EVENT = 'crmFormLoad';
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
     var REVIEW_FORM_URL = 'civicrm/awardreview';
@@ -57,7 +57,7 @@
      * @returns {Promise} resolves after the review has been deleted.
      */
     function deleteReviewActivity (reviewActivityId) {
-      return crmApi('Activity', 'delete', {
+      return civicaseCrmApi('Activity', 'delete', {
         id: reviewActivityId
       });
     }
@@ -68,7 +68,7 @@
      * @returns {Promise} resolves after fetching the reviews.
      */
     function getReviewActivities () {
-      return crmApi('Activity', 'get', {
+      return civicaseCrmApi('Activity', 'get', {
         activity_type_id: reviewsActivityTypeName,
         case_id: $scope.caseItem.id,
         options: { limit: 0 },
@@ -90,7 +90,7 @@
      * @returns {Promise} resolves after fetching the award's details.
      */
     function getAwardDetails () {
-      return crmApi('AwardDetail', 'getsingle', {
+      return civicaseCrmApi('AwardDetail', 'getsingle', {
         case_type_id: $scope.caseItem.case_type_id
       });
     }

--- a/ang/civiawards/shared/directives/contacts-group-dropdown.directive.js
+++ b/ang/civiawards/shared/directives/contacts-group-dropdown.directive.js
@@ -1,7 +1,7 @@
 (function (angular, $, _) {
   var module = angular.module('civiawards');
 
-  module.directive('civiawardContactsGroupDropdown', function (crmApi, isTruthy) {
+  module.directive('civiawardContactsGroupDropdown', function (civicaseCrmApi, isTruthy) {
     return {
       link: civiawardContactsGroupDropdownLink,
       restrict: 'A',
@@ -100,7 +100,7 @@
        * @returns {Promise} promise
        */
       function fetchGroupsData () {
-        return crmApi('Group', 'get', {
+        return civicaseCrmApi('Group', 'get', {
           options: { limit: 0 }
         }).then(function (groupsData) {
           return groupsData.values;

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -1,25 +1,25 @@
 (function (_) {
   describe('civiaward', () => {
-    var $q, $controller, $rootScope, $scope, $window, $location, crmApi, crmStatus,
+    var $q, $controller, $rootScope, $scope, $window, $location, civicaseCrmApi, crmStatus,
       CaseStatus, AwardMockData, AwardAdditionalDetailsMockData, ReviewFieldsMockData;
 
     beforeEach(module('civicase-base', 'civiawards.templates',
       'crmUtil', 'civiawards', 'civicase.data', 'civiawards.data', ($provide) => {
-        $provide.value('crmApi', jasmine.createSpy('crmApi'));
+        $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
         $provide.value('$window', { location: {} });
         $provide.value('$location', jasmine.createSpyObj('$location', ['path']));
       }));
 
-    beforeEach(inject((_$q_, _$controller_, _$window_, _$location_, _$rootScope_, _crmApi_,
-      _CaseStatus_, _AwardMockData_, _AwardAdditionalDetailsMockData_, _ReviewFieldsMockData_,
-      _crmStatus_) => {
+    beforeEach(inject((_$q_, _$controller_, _$window_, _$location_,
+      _$rootScope_, _civicaseCrmApi_, _CaseStatus_, _AwardMockData_,
+      _AwardAdditionalDetailsMockData_, _ReviewFieldsMockData_, _crmStatus_) => {
       $q = _$q_;
       $window = _$window_;
       $location = _$location_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       crmStatus = _crmStatus_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       CaseStatus = _CaseStatus_;
       AwardMockData = _AwardMockData_;
       AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
@@ -29,7 +29,7 @@
       spyOn($scope, '$emit');
       spyOn(CRM, 'alert').and.callThrough();
 
-      crmApi.and.callFake(mockCrmApiService);
+      civicaseCrmApi.and.callFake(mockCrmApiService);
       $scope.$digest();
       $scope.basic_details_form = { awardName: { $pristine: true } };
     }));
@@ -93,7 +93,7 @@
 
       describe('when editing existing award', function () {
         beforeEach(() => {
-          crmApi.and.returnValue($q.resolve({
+          civicaseCrmApi.and.returnValue($q.resolve({
             caseType: AwardMockData[0],
             additionalDetails: AwardAdditionalDetailsMockData
           }));
@@ -127,7 +127,7 @@
           const award = _.chain(AwardMockData).first().cloneDeep().value();
           award.definition.statuses = ['Open', 'Closed'];
 
-          crmApi.and.returnValue($q.resolve({
+          civicaseCrmApi.and.returnValue($q.resolve({
             caseType: award
           }));
 
@@ -148,7 +148,7 @@
           const award = _.chain(AwardMockData).first().cloneDeep().value();
           delete award.definition.statuses;
 
-          crmApi.and.returnValue($q.resolve({
+          civicaseCrmApi.and.returnValue($q.resolve({
             caseType: award
           }));
 
@@ -261,7 +261,7 @@
           });
 
           it('saves the basic award details', () => {
-            expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', {
+            expect(civicaseCrmApi).toHaveBeenCalledWith('CaseType', 'create', {
               sequential: true,
               title: 'title',
               description: 'description',
@@ -278,7 +278,7 @@
           });
 
           it('saves default activity types for the award', () => {
-            expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+            expect(civicaseCrmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
               definition: jasmine.objectContaining({
                 activityTypes: [
                   { name: 'Applicant Review' },
@@ -292,7 +292,7 @@
           });
 
           it('saves the additional award details', () => {
-            expect(crmApi).toHaveBeenCalledWith('AwardDetail', 'create', {
+            expect(civicaseCrmApi).toHaveBeenCalledWith('AwardDetail', 'create', {
               sequential: true,
               case_type_id: _.first(AwardMockData).id,
               start_date: AwardAdditionalDetailsMockData.start_date,
@@ -363,7 +363,7 @@
         });
 
         it('saves the basic award details', () => {
-          expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('CaseType', 'create', {
             sequential: true,
             title: 'title',
             description: 'description',
@@ -382,7 +382,7 @@
         });
 
         it('creates the award with default activity types', () => {
-          expect(crmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
+          expect(civicaseCrmApi).toHaveBeenCalledWith('CaseType', 'create', jasmine.objectContaining({
             definition: jasmine.objectContaining({
               activityTypes: [
                 { name: 'Applicant Review' },
@@ -505,7 +505,7 @@
         weight: 1
       }];
 
-      crmApi.and.callFake(mockCrmApiService);
+      civicaseCrmApi.and.callFake(mockCrmApiService);
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -1,25 +1,26 @@
 (function (_) {
   describe('civiawardReviewFieldsTable', () => {
-    var $rootScope, $controller, $scope, $q, crmApi, ReviewFieldsMockData,
+    var $rootScope, $controller, $scope, $q, civicaseCrmApi, ReviewFieldsMockData,
       AwardAdditionalDetailsMockData, dialogService;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'civicase.data', 'civiawards.data', function ($provide) {
-      $provide.value('crmApi', jasmine.createSpy('crmApi'));
+      $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
       $provide.value('dialogService', jasmine.createSpyObj('dialogService', ['open', 'close']));
     }));
 
-    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _crmApi_, _ReviewFieldsMockData_, _AwardAdditionalDetailsMockData_, _dialogService_) => {
+    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_,
+      _ReviewFieldsMockData_, _AwardAdditionalDetailsMockData_, _dialogService_) => {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       ReviewFieldsMockData = _ReviewFieldsMockData_;
       AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
       $scope = $rootScope.$new();
 
       dialogService.dialogs = {};
-      crmApi.and.returnValue($q.resolve([
+      civicaseCrmApi.and.returnValue($q.resolve([
         { values: ReviewFieldsMockData }
       ]));
 
@@ -33,7 +34,7 @@
       });
 
       it('fetches all review fields', () => {
-        expect(crmApi).toHaveBeenCalledWith([['CustomField', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith([['CustomField', 'get', {
           sequential: true,
           custom_group_id: 'Applicant_Review',
           options: { limit: 0 }

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -34,7 +34,9 @@
 
       it('fetches all review fields', () => {
         expect(crmApi).toHaveBeenCalledWith([['CustomField', 'get', {
-          sequential: true, custom_group_id: 'Applicant_Review'
+          sequential: true,
+          custom_group_id: 'Applicant_Review',
+          options: { limit: 0 }
         }]]);
       });
 

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -1,23 +1,23 @@
 (function (_) {
   describe('civiawardReviewPanels', () => {
-    let $rootScope, $controller, $scope, crmApi, $q, crmStatus, ts, ContactsData,
-      dialogService, RelationshipTypeData, GroupData, ReviewPanelsMockData,
-      entityActionHandlers, TagsMockData, statusOptions;
+    let $rootScope, $controller, $scope, civicaseCrmApi, $q, crmStatus, ts,
+      ContactsData, dialogService, RelationshipTypeData, GroupData,
+      ReviewPanelsMockData, entityActionHandlers, TagsMockData, statusOptions;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'crmUtil', 'civicase.data', 'civiawards.data', function ($provide) {
-      $provide.value('crmApi', getCrmApiMock());
+      $provide.value('civicaseCrmApi', getCrmApiMock());
 
       $provide.value('dialogService', jasmine.createSpyObj('dialogService', ['open', 'close']));
     }));
 
-    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _crmApi_, _crmStatus_,
+    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_, _crmStatus_,
       _ts_, _dialogService_, _RelationshipTypeData_, _GroupData_,
       _ReviewPanelsMockData_, _ContactsData_, _TagsMockData_) => {
       setApiActionHandlers();
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       crmStatus = _crmStatus_;
       $q = _$q_;
       ts = _ts_;
@@ -130,7 +130,7 @@
           });
 
           it('does not save the review panel', () => {
-            expect(crmApi).not.toHaveBeenCalledWith('AwardReviewPanel', 'create', jasmine.any(Object));
+            expect(civicaseCrmApi).not.toHaveBeenCalledWith('AwardReviewPanel', 'create', jasmine.any(Object));
           });
         });
 
@@ -142,7 +142,7 @@
           });
 
           it('does not save the review panel', () => {
-            expect(crmApi).not.toHaveBeenCalledWith('AwardReviewPanel', 'create', jasmine.any(Object));
+            expect(civicaseCrmApi).not.toHaveBeenCalledWith('AwardReviewPanel', 'create', jasmine.any(Object));
           });
         });
       });
@@ -173,7 +173,7 @@
         });
 
         it('saves a new review panel', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
             id: null,
             title: 'New Review Panel',
             is_active: '1',
@@ -265,7 +265,7 @@
       });
 
       it('fetches all relationship types', () => {
-        expect(crmApi).toHaveBeenCalledWith('RelationshipType', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('RelationshipType', 'get', {
           sequential: 1,
           is_active: 1,
           options: { sort: 'label_a_b', limit: 0 }
@@ -344,7 +344,7 @@
       });
 
       it('fetches all groups', () => {
-        expect(crmApi).toHaveBeenCalledWith('Group', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Group', 'get', {
           sequential: 1,
           return: ['id', 'title'],
           options: { limit: 0 }
@@ -359,7 +359,7 @@
       });
 
       it('fetches all tags for cases', () => {
-        expect(crmApi).toHaveBeenCalledWith('Tag', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
           used_for: 'Cases',
           options: { limit: 0 }
@@ -376,7 +376,7 @@
         });
 
         it('fetches all exisiting review panels for the award', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
             sequential: 1,
             case_type_id: '10',
             options: { limit: 0 }
@@ -426,7 +426,7 @@
         });
 
         it('shows the contacts name in the contact list', () => {
-          expect(crmApi).toHaveBeenCalledWith('Contact', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('Contact', 'get', {
             sequential: 1,
             return: ['display_name'],
             id: { IN: ['4', '2', '3', '1'] },
@@ -444,7 +444,7 @@
         });
 
         it('fetches all exisiting review panels for the award', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
             sequential: 1,
             case_type_id: '10',
             options: { limit: 0 }
@@ -476,7 +476,7 @@
         });
 
         it('does not fetch any contact information', () => {
-          expect(crmApi).not.toHaveBeenCalledWith('Contact', 'get', jasmine.any(Object));
+          expect(civicaseCrmApi).not.toHaveBeenCalledWith('Contact', 'get', jasmine.any(Object));
         });
       });
     });
@@ -563,13 +563,13 @@
 
         it('deletes the review panel', () => {
           expect(crmConfirmOnFn).toHaveBeenCalledWith('crmConfirm:yes', jasmine.any(Function));
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'delete', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'delete', {
             id: '46'
           });
         });
 
         it('refreshes the review panel list', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
             sequential: 1,
             case_type_id: '10',
             options: { limit: 0 }
@@ -615,14 +615,14 @@
 
         it('enables the review panel', () => {
           expect(crmConfirmOnFn).toHaveBeenCalledWith('crmConfirm:yes', jasmine.any(Function));
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
             id: '46',
             is_active: '1'
           });
         });
 
         it('refreshes the review panel list', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
             sequential: 1,
             case_type_id: '10',
             options: { limit: 0 }
@@ -668,14 +668,14 @@
 
         it('disables the review panel', () => {
           expect(crmConfirmOnFn).toHaveBeenCalledWith('crmConfirm:yes', jasmine.any(Function));
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'create', {
             id: '46',
             is_active: '0'
           });
         });
 
         it('refreshes the review panel list', () => {
-          expect(crmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardReviewPanel', 'get', {
             sequential: 1,
             case_type_id: '10',
             options: { limit: 0 }
@@ -789,7 +789,7 @@
      * "EntityName.ActionName".
      */
     function getCrmApiMock () {
-      return jasmine.createSpy('crmApi')
+      return jasmine.createSpy('civicaseCrmApi')
         .and.callFake((entityName, action, params) => {
           const entityAction = `${entityName}.${action}`;
           const entityActionHandler = entityActionHandlers[entityAction];

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -1,7 +1,7 @@
 ((_, $) => {
   describe('Review Case Tab Content', () => {
     let $controller, $q, $rootScope, $scope, AwardAdditionalDetailsMockData,
-      caseItem, crmApi, ReviewActivitiesMockData, ReviewFieldsMockData,
+      caseItem, civicaseCrmApi, ReviewActivitiesMockData, ReviewFieldsMockData,
       reviewsActivityTypeName, reviewScoringFieldsGroupName, crmStatus,
       civicaseCrmUrl, civicaseCrmLoadForm;
     const entityActionHandlers = {
@@ -11,9 +11,9 @@
     };
 
     beforeEach(module('civiawards', 'civiawards.data', ($provide) => {
-      crmApi = getCrmApiMock();
+      civicaseCrmApi = getCrmApiMock();
 
-      $provide.value('crmApi', crmApi);
+      $provide.value('civicaseCrmApi', civicaseCrmApi);
     }));
 
     beforeEach(inject((_$controller_, _$q_, _$rootScope_, _ApplicationsMockData_,
@@ -45,13 +45,13 @@
       });
 
       it('requests the award details for the application award type', () => {
-        expect(crmApi).toHaveBeenCalledWith('AwardDetail', 'getsingle', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('AwardDetail', 'getsingle', {
           case_type_id: $scope.caseItem.case_type_id
         });
       });
 
       it('requests all review activities for the application', () => {
-        expect(crmApi).toHaveBeenCalledWith('Activity', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'get', {
           activity_type_id: reviewsActivityTypeName,
           case_id: $scope.caseItem.id,
           options: { limit: 0 },
@@ -108,12 +108,12 @@
 
     describe('on case updated', () => {
       beforeEach(() => {
-        crmApi.calls.reset();
+        civicaseCrmApi.calls.reset();
         $scope.$emit('updateCaseData');
       });
 
       it('reloads the list of reviews', () => {
-        expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
       });
     });
 
@@ -156,7 +156,7 @@
           });
 
           it('reloads the reviews', () => {
-            expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
+            expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
           });
         });
       });
@@ -200,7 +200,7 @@
           });
 
           it('reloads the reviews', () => {
-            expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
+            expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
           });
         });
       });
@@ -220,7 +220,7 @@
           });
 
           it('deletes the selected review', () => {
-            expect(crmApi).toHaveBeenCalledWith('Activity', 'delete', {
+            expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'delete', {
               id: selectedReview.id
             });
           });
@@ -312,7 +312,7 @@
      * "EntityName.ActionName".
      */
     function getCrmApiMock () {
-      return jasmine.createSpy('crmApi')
+      return jasmine.createSpy('civicaseCrmApi')
         .and.callFake((entityName, action, params) => {
           const entityAction = `${entityName}.${action}`;
           const entityActionHandler = entityActionHandlers[entityAction];


### PR DESCRIPTION
## Overview
While creating awards, the "Add Review Field" popup, only used to show 25 custom fields, now it shows all of them.

## Before
Only 25 records were shown.

## After
All records were shown.

## Technical Details
Added `options: { limit: 0 }` to the api call in `review-fields-table.directive.js`.
Also replaced all instances of `crmApi` with `civicaseCrmApi`.