### PR TITLE
CPS-556: Fix unit tests

### DIFF
--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -723,7 +723,7 @@
         is_error: 0,
         version: 3,
         count: 8,
-        values: _.cloneDeep(_.slice(RelationshipTypeData.values, 0, 4))
+        values: _.slice(RelationshipTypeData.getSequential(), 0, 4)
       };
     }
 

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -275,20 +275,12 @@
       it('displays all relationship type on the UI', () => {
         expect($scope.relationshipTypes).toEqual([
           {
-            text: 'Application Manager is',
-            id: '17_a_b'
+            text: 'Homeless Services Coordinator is',
+            id: '11_a_b'
           },
           {
-            text: 'Application Manager',
-            id: '17_b_a'
-          },
-          {
-            text: 'Benefits Specialist is',
-            id: '14_a_b'
-          },
-          {
-            text: 'Benefits Specialist',
-            id: '14_b_a'
+            text: 'Homeless Services Coordinator',
+            id: '11_b_a'
           },
           {
             text: 'Health Services Coordinator is',
@@ -299,12 +291,20 @@
             id: '12_b_a'
           },
           {
-            text: 'Homeless Services Coordinator is',
-            id: '11_a_b'
+            text: 'Benefits Specialist is',
+            id: '14_a_b'
           },
           {
-            text: 'Homeless Services Coordinator',
-            id: '11_b_a'
+            text: 'Benefits Specialist',
+            id: '14_b_a'
+          },
+          {
+            text: 'Senior Services Coordinator is',
+            id: '16_a_b'
+          },
+          {
+            text: 'Senior Services Coordinator',
+            id: '16_b_a'
           }
         ]);
       });


### PR DESCRIPTION
## Overview
This PR fixes Javascript unit tests after they broke from changes done in the Civicase repo.

## Before
<img width="1175" alt="Screen Shot 2021-04-20 at 12 27 29 PM" src="https://user-images.githubusercontent.com/1642119/115431876-ca5a0280-a1d3-11eb-908f-590e33a64bd1.png">

## After
<img width="1135" alt="Screen Shot 2021-04-20 at 12 26 44 PM" src="https://user-images.githubusercontent.com/1642119/115431897-cfb74d00-a1d3-11eb-8360-1c585ec8171d.png">

## Technical Details

The review panels directive spec file was failing due to two changes done to the relationship types mock data files in civicase:

* https://github.com/compucorp/uk.co.compucorp.civicase/commit/daf2749c0a32987f85746a803f4bce06c894ef00#diff-90f2ea50f82e507ff64d5ac2572bc9aff3d6e6985e99e1690cc084b6f3065401R68-R86 this changed the mock data from a straight object, to a service that returns copies of the relationship types that can be used in unit tests. We changed `RelationshipTypeData.values` to `RelationshipTypeData.getSequential()`. `getSequential` already returns a copy of the objects so there was no need to clone them.
* https://github.com/compucorp/uk.co.compucorp.civicase/commit/cecd54dff8ac4e24bc4012cef3f0fda9226b5a5e#diff-90f2ea50f82e507ff64d5ac2572bc9aff3d6e6985e99e1690cc084b6f3065401R25-R48 added a couple of relationship types since the new type IDs were lower than the existing ones we were getting them first. To fix this issue we updated the expected relationship types. We don't need to check for specific ones so this change is ok.