### PR TITLE
CPS-559: Handle Missing Data in Review Panel

### DIFF
--- a/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
+++ b/ang/civiawards/award-creation/directives/review-panels/review-panels.directive.js
@@ -278,11 +278,38 @@
       var reviewPanelDataCopied = _.clone(reviewPanelData);
 
       _.each(reviewPanelDataCopied, function (reviewPanel) {
+        reviewPanel = removeObsoleteData(reviewPanel);
+
         reviewPanel.formattedContactSettings = getFormattedContactSettings(reviewPanel);
         reviewPanel.formattedVisibilitySettings = getFormattedVisibilitySettings(reviewPanel);
       });
 
       return reviewPanelDataCopied;
+    }
+
+    /**
+     * Remove obsolete data from the review panel.
+     *
+     * @param {Array} reviewPanel list of review panels fetched from API
+     * @returns {Array} list of review panels
+     */
+    function removeObsoleteData (reviewPanel) {
+      reviewPanel.visibility_settings.application_status = _.filter(reviewPanel.visibility_settings.application_status, function (statusId) {
+        return !!caseStatusesIndexed[statusId];
+      });
+      reviewPanel.visibility_settings.application_tags = _.filter(reviewPanel.visibility_settings.application_tags, function (tagId) {
+        return !!tagsIndexed[tagId];
+      });
+
+      reviewPanel.contact_settings.include_groups = _.filter(reviewPanel.contact_settings.include_groups, function (groupId) {
+        return !!groupsIndexed[groupId];
+      });
+
+      reviewPanel.contact_settings.exclude_groups = _.filter(reviewPanel.contact_settings.exclude_groups, function (groupId) {
+        return !!groupsIndexed[groupId];
+      });
+
+      return reviewPanel;
     }
 
     /**

--- a/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-panels/review-panels.directive.spec.js
@@ -388,6 +388,29 @@
 
           beforeEach(() => {
             const reviewPanel1 = _.extend(ReviewPanelsMockData[0], {
+              contact_settings: {
+                exclude_groups: ['1'],
+                include_groups: ['2'],
+                relationship: [
+                  {
+                    is_a_to_b: '1',
+                    relationship_type_id: '14',
+                    contact_id: ['4', '2']
+                  },
+                  {
+                    is_a_to_b: '0',
+                    relationship_type_id: '14',
+                    contact_id: ['3', '1']
+                  }
+                ]
+              },
+              visibility_settings: {
+                application_status: ['1'],
+                anonymize_application: '1',
+                application_tags: ['1', '12', '15'],
+                is_application_status_restricted: '1',
+                restricted_application_status: ['1', '2']
+              },
               formattedContactSettings: {
                 include: ['Group 2'],
                 exclude: ['Group 1'],

--- a/ang/test/mocks/data/review-panels.data.js
+++ b/ang/test/mocks/data/review-panels.data.js
@@ -7,8 +7,8 @@
       title: 'New Panel',
       case_type_id: '62',
       contact_settings: {
-        exclude_groups: ['1'],
-        include_groups: ['2'],
+        exclude_groups: ['1', '1001'],
+        include_groups: ['2', '1002'],
         relationship: [
           {
             is_a_to_b: '1',
@@ -23,9 +23,9 @@
         ]
       },
       visibility_settings: {
-        application_status: ['1'],
+        application_status: ['1', '1001'],
         anonymize_application: '1',
-        application_tags: ['1', '12', '15'],
+        application_tags: ['1', '12', '15', '1001'],
         is_application_status_restricted: '1',
         restricted_application_status: ['1', '2']
       },


### PR DESCRIPTION
## Overview
This PR solves the problem observed on Award's Review Panels, when one or more of the related contacts groups, tags, or statuses were deleted.
In these cases, the review panel was not visible on the Award review screen.

## Before
When the review panel was referencing a deleted contact group, this error was displayed on the frontend code:
![image](https://user-images.githubusercontent.com/74304572/116546727-29c6b980-a91c-11eb-91a2-37c96fab1a35.png)
preventing the panel rendering. 

## After
The panel is correctly displayed.
![image](https://user-images.githubusercontent.com/74304572/116547577-47e0e980-a91d-11eb-8dcb-be57bf76c4aa.png)

## Technical Details
- A method for filtering the invalid or obsolete data was added. The method is called when first loaded the Panel, then data is cleaned on the presentation, and also if an edit action occurs, it is saved without this information.
- For doing the unit test, it was needed to make available the method `formatReviewPanelDataForUI`, since is the one in charge of sanitizing the panel, and is called before the edit activity.
