### PR TITLE
CPS-597: Fix Issue With Payment Tab Not Enabled When Award finance Is Activated.

### DIFF
--- a/CRM/CiviAwardsPaymentsTab/Hook/AddCiviCaseDependentAngularModules/PaymentsTabModule.php
+++ b/CRM/CiviAwardsPaymentsTab/Hook/AddCiviCaseDependentAngularModules/PaymentsTabModule.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 
 /**
  * Add Payments Tab module.
@@ -31,23 +32,12 @@ class CRM_CiviAwardsPaymentsTab_Hook_AddCiviCaseDependentAngularModules_Payments
    *   True for awards that support finances.
    */
   private function shouldRun() {
-    $caseTypeCategoryName = CRM_Utils_Request::retrieve('case_type_category', 'String');
+    [$caseCategoryId, $caseCategoryName] = CaseUrlHelper::getCategoryParamsFromUrl();
+    $financeManagement = new FinanceManagementSettingService();
+    $financeManagementValue = $financeManagement->get($caseCategoryId);
+    $supportsFinanceTabModule = !empty($financeManagementValue);
 
-    try {
-      $caseTypeCategory = civicrm_api3('OptionValue', 'getsingle', [
-        'option_group_id' => 'case_type_categories',
-        'name' => $caseTypeCategoryName,
-      ]);
-
-      $financeManagement = new FinanceManagementSettingService();
-      $financeManagementValue = $financeManagement->get($caseTypeCategory['value']);
-      $supportsFinanceTabModule = !empty($financeManagementValue);
-
-      return $supportsFinanceTabModule;
-    }
-    catch (\Exception $exception) {
-      return FALSE;
-    }
+    return $supportsFinanceTabModule;
   }
 
 }


### PR DESCRIPTION
## Overview
When the `Enable Finance Management` setting is turned on for an Applicant management case category, the payment tab on the applications for that award is not displayed. 

## Before
The issue described above exists:
<img width="1280" alt="Manage Applications  CiviQA 2021-05-07 16-58-12" src="https://user-images.githubusercontent.com/6951813/117477389-dd036400-af55-11eb-820f-842adf197cae.png">


## After
When the `Enable Finance Management` setting is turned on for an Applicant management case category, the payment tab on the applications for that award is now displayed.

<img width="1280" alt="Manage Applications  CiviQA 2021-05-07 16-54-53" src="https://user-images.githubusercontent.com/6951813/117477467-f0163400-af55-11eb-81f9-3d298c05f24c.png">


## Technical Details
This issues is a regression caused by recent changes due to changing the case category name in the URL to the category value. 
The `AddCiviCaseDependentAngularModules_PaymentsTabModule` hook class responsible for adding the payment module for an award is not ran because the `shouldRun` method is relying on getting the case category name from the URL. The fix was to refactor the function to use the category value.
