### PR TITLE
RSESPRT-45: Fix Limitation Between Custom Groups and Custom Types

### DIFF
--- a/CRM/CiviAwards/Helper/CustomGroupPostProcess.php
+++ b/CRM/CiviAwards/Helper/CustomGroupPostProcess.php
@@ -26,6 +26,7 @@ class CRM_CiviAwards_Helper_CustomGroupPostProcess extends CRM_Civicase_Helper_I
     $params = [
       'return' => ['case_type_id'],
       'case_type_id.case_type_category' => $caseCategoryValue,
+      'options' => ['limit' => 0],
     ];
 
     $subTypes = array_filter($subTypes);

--- a/CRM/CiviAwards/Helper/CustomGroupPostProcess.php
+++ b/CRM/CiviAwards/Helper/CustomGroupPostProcess.php
@@ -78,6 +78,7 @@ class CRM_CiviAwards_Helper_CustomGroupPostProcess extends CRM_Civicase_Helper_I
       'extends' => 'Case',
       'extends_entity_column_id' => ['IN' => [$caseCategoryId]],
       'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+      'options' => ['limit' => 0],
     ]);
 
     return $result['values'];


### PR DESCRIPTION
## Overview
This PR solves a limitation between the number of Case Types and Custom Groups associations.

Is the implementation for Awards package of the changes made on CiviCase, the please refer to that PR for getting the details: https://github.com/compucorp/uk.co.compucorp.civicase/pull/791