### PR TITLE
RSESPRT-61: Show all review fields

### DIFF
--- a/CRM/CiviAwards/Service/AwardProfile.php
+++ b/CRM/CiviAwards/Service/AwardProfile.php
@@ -124,6 +124,7 @@ class CRM_CiviAwards_Service_AwardProfile {
     }
     $result = civicrm_api3('UFField', 'get', [
       'uf_group_id' => $profileID,
+      'options' => ['limit' => 0],
     ]);
 
     if ($result['count'] == 0) {


### PR DESCRIPTION
## Overview
The Review Fields table only shows 25 records, this PR fixes the same.

## Before
Only 25 records were shown.

## After
All records are shown.

## Technical Details
In `CRM/CiviAwards/Service/AwardProfile.php`, added `'options' => ['limit' => 0],`, so that `AwardDetail` returns all review fields.