### PR TITLE
RSESPRT-57: Handle disabled review fields while Creating/Editing awards

### DIFF
--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -16,7 +16,7 @@
   });
 
   module.controller('CiviAwardCreateEditAwardController', function (
-    $location, $q, $scope, $window, CaseStatus,
+    $location, $q, $scope, $window, CaseStatus, isTruthy,
     civicaseCrmApi, crmStatus, Select2Utils, ts) {
     var existingCaseTypeDefintion = null;
 
@@ -326,13 +326,22 @@
      * @returns {object[]} list of selected review field ids
      */
     function prepareReviewFields () {
-      return _.map($scope.additionalDetails.selectedReviewFields, function (reviewField) {
-        return {
-          id: reviewField.id,
-          required: reviewField.required ? '1' : '0',
-          weight: reviewField.weight
-        };
-      });
+      return _.chain($scope.additionalDetails.selectedReviewFields)
+        .filter(function (reviewField) {
+          reviewField = _.find($scope.reviewFields, function (field) {
+            return field.id === reviewField.id;
+          });
+
+          return isTruthy(reviewField.is_active);
+        })
+        .map(function (reviewField) {
+          return {
+            id: reviewField.id,
+            required: reviewField.required ? '1' : '0',
+            weight: reviewField.weight
+          };
+        })
+        .value();
     }
 
     /**

--- a/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
@@ -26,11 +26,14 @@
     <tbody>
       <tr
         ng-repeat="reviewField in model.reviewFields | filter: model.searchText"
+        ng-attr-title="{{reviewField.is_active === '0' ? 'This field is disabled.' : ''}}"
+        ng-class="{ disabled: !model.isTruthy(reviewField.is_active) }"
         ng-click="model.toggleReviewField(reviewField)">
         <td>{{reviewField.label}}</td>
         <td align="center">
           <input
             ng-checked="!!model.findReviewFieldByID(reviewField.id)"
+            ng-disabled="!model.isTruthy(reviewField.is_active)"
             type="checkbox"/>
         </td>
         <td>{{reviewField.data_type}}</td>

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
@@ -25,8 +25,10 @@
   <tbody>
     <tr
       ng-repeat="reviewField in additionalDetails.selectedReviewFields | orderBy: 'weight'"
-      ng-if="additionalDetails.selectedReviewFields.length > 0">
-      <td>{{getReviewFieldData(reviewField.id, 'label')}}</td>
+      ng-if="additionalDetails.selectedReviewFields.length > 0 && isTruthy(getReviewFieldData(reviewField.id, 'is_active'))">
+      <td>
+        {{getReviewFieldData(reviewField.id, 'label')}}
+      </td>
       <td>
         <a
           class="crm-weight-arrow" ng-if="$index > 0"

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
@@ -18,6 +18,7 @@
     $scope.openReviewFieldSelectionPopup = openReviewFieldSelectionPopup;
     $scope.removeReviewFieldFromSelection = removeReviewFieldFromSelection;
     $scope.findReviewFieldByID = findReviewFieldByID;
+    $scope.isTruthy = isTruthy;
     $scope.toggleRequiredState = toggleRequiredState;
     $scope.moveUp = moveUp;
     $scope.moveDown = moveDown;
@@ -217,6 +218,10 @@
      * @param {object} reviewField review field object to be toggled
      */
     function toggleReviewField (reviewField) {
+      if (!isTruthy(reviewField.is_active)) {
+        return;
+      }
+
       var field = findReviewFieldByID(reviewField.id);
 
       if (field) {

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -337,6 +337,7 @@
       describe('when editing an award', () => {
         beforeEach(() => {
           createController({ ifNewAward: false });
+          $scope.reviewFields = ReviewFieldsMockData;
           $scope.awardStages = CaseStatus.getAll();
           $scope.basicDetails.selectedAwardStages = { 1: true };
 
@@ -398,6 +399,30 @@
           });
         });
       });
+
+      describe('when editing an award with a disabled review field', () => {
+        beforeEach(() => {
+          createController({ ifNewAward: false });
+          $scope.reviewFields = ReviewFieldsMockData;
+          $scope.awardStages = CaseStatus.getAll();
+          $scope.basicDetails.selectedAwardStages = { 1: true };
+
+          setAwardDetails();
+          ReviewFieldsMockData[0].is_active = '0';
+          $scope.saveAwardInBG();
+          $scope.$digest();
+        });
+
+        afterEach(() => {
+          ReviewFieldsMockData[0].is_active = '1';
+        });
+
+        it('removes the disabled field while saving the additional award details', () => {
+          expect(civicaseCrmApi).toHaveBeenCalledWith('AwardDetail', 'create', jasmine.objectContaining({
+            review_fields: []
+          }));
+        });
+      });
     });
 
     describe('when saving a new award', () => {
@@ -405,6 +430,7 @@
         beforeEach(() => {
           createController({ ifNewAward: true, redirectTo: 'dashboard' });
           setAwardDetails();
+          $scope.reviewFields = ReviewFieldsMockData;
 
           $scope.saveNewAward();
           $scope.$digest();
@@ -423,6 +449,7 @@
         beforeEach(() => {
           createController({ ifNewAward: true, redirectTo: 'workflow' });
           setAwardDetails();
+          $scope.reviewFields = ReviewFieldsMockData;
 
           $scope.saveNewAward();
           $scope.$digest();
@@ -443,6 +470,7 @@
         beforeEach(() => {
           createController({ ifNewAward: true, redirectTo: 'dashboard' });
           setAwardDetails();
+          $scope.reviewFields = ReviewFieldsMockData;
 
           $scope.saveAndNavigateToPreviousPage();
           $scope.$digest();
@@ -468,6 +496,7 @@
         beforeEach(() => {
           createController({ ifNewAward: true, redirectTo: 'workflow' });
           setAwardDetails();
+          $scope.reviewFields = ReviewFieldsMockData;
 
           $scope.saveAndNavigateToPreviousPage();
           $scope.$digest();

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -89,6 +89,50 @@
           expect($scope.additionalDetails.selectedReviewFields).toEqual([]);
         });
       });
+
+      describe('and the review field is disabled', () => {
+        beforeEach(() => {
+          ReviewFieldsMockData[0].is_active = '0';
+        });
+
+        afterEach(() => {
+          ReviewFieldsMockData[0].is_active = '1';
+        });
+
+        describe('and the review was not selected before', () => {
+          beforeEach(() => {
+            $scope.additionalDetails = { selectedReviewFields: [] };
+
+            $scope.toggleReviewField(ReviewFieldsMockData[0]);
+          });
+
+          it('does not addd the clicked review field as selected', () => {
+            expect($scope.additionalDetails.selectedReviewFields).toEqual([]);
+          });
+        });
+
+        describe('and the review was selected before', () => {
+          beforeEach(() => {
+            $scope.additionalDetails = {
+              selectedReviewFields: [{
+                id: ReviewFieldsMockData[0].id,
+                required: false,
+                weight: 1
+              }]
+            };
+
+            $scope.toggleReviewField(ReviewFieldsMockData[0]);
+          });
+
+          it('does not remove the clicked review field from selected', () => {
+            expect($scope.additionalDetails.selectedReviewFields[0]).toEqual({
+              id: ReviewFieldsMockData[0].id,
+              required: false,
+              weight: 1
+            });
+          });
+        });
+      });
     });
 
     describe('when the REMOVE button is clicked from the review field list', () => {


### PR DESCRIPTION
## Overview
This PR helps to handle Disabled Review Fields in a better way. While creating/editing an award, the disabled review fields will now be disabled in the Review Field Selection popup.
But if the disabled field is already part of an Award, it wont be shown anymore and will be removed when the award is saved again.

## Before
Disabled review fields cannot be added/removed from the Review Field selection popup.
![2021-07-08 at 12 36 PM](https://user-images.githubusercontent.com/5058867/124877919-3127d480-dfe9-11eb-8610-40fe93d740d1.png)

## After
Disabled review fields can be added/removed from the Review Field selection popup.
![2021-07-08 at 12 35 PM](https://user-images.githubusercontent.com/5058867/124877754-0473bd00-dfe9-11eb-884d-3397d40f6c75.png)
