### PR TITLE
RSE-1774: Add or update review status

### DIFF
--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -10,5 +10,5 @@ chmod +x phpcs.phar
 
 # Clone Drupal Coder repo
 if [ ! -d drupal/coder ]; then
-  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+  git clone --depth 1 --branch 8.3.13 https://git.drupalcode.org/project/coder.git drupal/coder
 fi

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -98,6 +98,14 @@
       {/foreach}
       {* Form fields section Ends *}
 
+      {* Review Status Section Starts *}
+      <div class="form-group {$form_group_class}">
+        <label class="{$form_group_label_class}">{$form.status_id.label}</label>
+        <div class="{$form_group_field_class}">{$form.status_id.html}</div>
+        <div class="clear"></div>
+      </div>
+      {* Review Status Section Endss *}
+
       {* Form action section Starts *}
       {if !$errorMessage}
         {if $isReviewFromSsp}


### PR DESCRIPTION
## Overview

This PR adds status (Completed/Draft) options field to review applicant and ability to add and update. 

## Before

When save a review, the activity status always set to Completed

## After

Use can pick the option between Completed or Draft 

![rse-11742](https://user-images.githubusercontent.com/208713/178720127-5e7732c2-b2ff-44e0-9839-d113a89c5c73.gif)

## Technical Details

We only fetch the activity status that links contains the link to `Applicant Review` category type. In this stage, if the Draft activity status does not contain `Applicant Review` category type, then the option will not be displayed. 

We also filtered out other activity statuses that may link to Applicant Review category and only display options `Completed `and `Draft  `