### PR TITLE
RSE-1766: Show activity status in the list

### DIFF
--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.html
@@ -27,11 +27,12 @@
     <table class="table">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Date Submitted</th>
+          <th>{{:: ts('Name')}}</th>
+          <th>{{:: ts('Date Submitted')}}</th>
           <th ng-repeat="reviewField in reviewActivities[0].reviewFields">
-            {{reviewField.label}}
+            {{:: ts(reviewField.label)}}
           </th>
+          <th>{{:: ts('Status')}}</th>
           <th width="20">&nbsp;</th>
         </tr>
       </thead>
@@ -47,6 +48,7 @@
               ng-bind-html="trustAsHtml(reviewField.value.display)">
             </span>
           </td>
+          <td>{{reviewActivity.status_label}}</td>
           <td>
             <div
               class="btn-group btn-group-md"

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -73,6 +73,10 @@
         case_id: $scope.caseItem.id,
         options: { limit: 0 },
         sequential: 1,
+        'api.OptionValue.getsingle': {
+          option_group_id: 'activity_status',
+          value: '$value.status_id'
+        },
         'api.CustomValue.gettreevalues': {
           entity_id: '$value.id',
           entity_type: 'Activity',
@@ -106,12 +110,14 @@
       var sortOrder = _.sortBy(scoringFieldsSortOrder, 'weight');
 
       return _.map(angular.copy(activitiesData), function (activity) {
+        activity.status_label = activity['api.OptionValue.getsingle'].label;
         activity.reviewFields = sortOrder.map(function (scoringFieldSortOrder) {
           return _.find(activity['api.CustomValue.gettreevalues'].values[0].fields, function (field) {
             return field.id === scoringFieldSortOrder.id;
           });
         });
 
+        delete activity['api.OptionValue.getsingle'];
         delete activity['api.CustomValue.gettreevalues'];
 
         return activity;

--- a/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
+++ b/ang/test/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.spec.js
@@ -56,6 +56,10 @@
           case_id: $scope.caseItem.id,
           options: { limit: 0 },
           sequential: 1,
+          'api.OptionValue.getsingle': {
+            option_group_id: 'activity_status',
+            value: '$value.status_id'
+          },
           'api.CustomValue.gettreevalues': {
             entity_id: '$value.id',
             entity_type: 'Activity',
@@ -81,6 +85,8 @@
               delete activity.reviewFields;
             });
             reviewMockData = _.each(angular.copy(ReviewActivitiesMockData), function (activity) {
+              activity.status_label = activity['api.OptionValue.getsingle'].label;
+              delete activity['api.OptionValue.getsingle'];
               delete activity['api.CustomValue.gettreevalues'];
             });
           });

--- a/ang/test/mocks/data/reviews.data.js
+++ b/ang/test/mocks/data/reviews.data.js
@@ -21,6 +21,13 @@
       source_contact_id: '2',
       source_contact_name: 'Compu Admin',
       source_contact_sort_name: 'Admin, Compu',
+      'api.OptionValue.getsingle': {
+        id: '282',
+        option_group_id: '26',
+        label: 'Completed',
+        value: '2',
+        name: 'Completed'
+      },
       'api.CustomValue.gettreevalues': {
         is_error: 0,
         version: 3,
@@ -103,6 +110,13 @@
       source_contact_id: '2',
       source_contact_name: 'Compu Admin',
       source_contact_sort_name: 'Admin, Compu',
+      'api.OptionValue.getsingle': {
+        id: '282',
+        option_group_id: '26',
+        label: 'Draft',
+        value: '10',
+        name: 'Draft'
+      },
       'api.CustomValue.gettreevalues': {
         is_error: 0,
         version: 3,
@@ -185,6 +199,13 @@
       source_contact_id: '2',
       source_contact_name: 'Compu Admin',
       source_contact_sort_name: 'Admin, Compu',
+      'api.OptionValue.getsingle': {
+        id: '282',
+        option_group_id: '26',
+        label: 'Completed',
+        value: '2',
+        name: 'Completed'
+      },
       'api.CustomValue.gettreevalues': {
         is_error: 0,
         version: 3,


### PR DESCRIPTION
## Overview

This PR adds activity status in the list on the review tab. 

## Before

![screenshot-stripe localhost_8012-2022 07 13-15_25_44](https://user-images.githubusercontent.com/208713/178757896-e6aa4718-e059-4186-ac08-e7de436e3f10.png)

## After

![screenshot-stripe localhost_8012-2022 07 13-15_19_17](https://user-images.githubusercontent.com/208713/178757679-4d16a92d-4d08-4207-af72-a24ffa822cb7.png)
