### PR TITLE
RSE-1758: Create and Assign new relationship type Application Reviewer to Award case types

### DIFF
--- a/CRM/CiviAwards/Setup/CreateApplicationReviewerRelationship.php
+++ b/CRM/CiviAwards/Setup/CreateApplicationReviewerRelationship.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Class CreateApplicationReviewerRelationship.
+ */
+class CRM_CiviAwards_Setup_CreateApplicationReviewerRelationship {
+
+  /**
+   * Adds a new application reviewer relationship.
+   */
+  public function apply() {
+    $this->addApplicationReviewerRelationship();
+  }
+
+  /**
+   * Adds a new relationship type .
+   *
+   * The relationship will be used
+   * for a “default” reviewer case role for all
+   * awards cases when they are created.
+   */
+  public function addApplicationReviewerRelationship() {
+    $labelAtoB = 'Application reviewer of';
+    $labelBtoA = 'Has application reviewed by';
+    $description = 'Default relationship type for application reviewers';
+
+    $result = civicrm_api3('RelationshipType', 'get', [
+      'name_a_b' => $labelAtoB,
+      'name_b_a' => $labelBtoA,
+    ]);
+
+    if ($result['count'] > 0) {
+      return;
+    }
+
+    civicrm_api3('RelationshipType', 'create', [
+      'name_a_b' => $labelAtoB,
+      'label_a_b' => $labelAtoB,
+      'name_b_a' => $labelBtoA,
+      'label_b_a' => $labelBtoA,
+      'description' => $description,
+      'is_reserved' => 1,
+      'is_active' => 1,
+    ]);
+  }
+
+}

--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -22,6 +22,7 @@ use CRM_CiviAwards_Disable_DeactivateAwardsMenus as DeactivateAwardsMenus;
 use CRM_CiviAwards_Setup_CreateAwardsMenus as CreateAwardsMenus;
 use CRM_CiviAwards_Setup_UpdateAwardPaymentActivityStatusLabel as UpdateAwardPaymentActivityStatusLabel;
 use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
+use CRM_CiviAwards_Setup_CreateApplicationReviewerRelationship as CreateApplicationReviewerRelationship;
 
 /**
  * Collection of upgrade steps.
@@ -51,6 +52,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
       new CreateAwardPaymentActivityTypes(),
       new UpdateAwardPaymentActivityStatusLabel(),
       new AddSingularLabels(),
+      new CreateApplicationReviewerRelationship(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/CiviAwards/Upgrader/Steps/Step1012.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1012.php
@@ -1,0 +1,22 @@
+<?php
+
+use CRM_CiviAwards_Setup_CreateApplicationReviewerRelationship as CreateApplicationReviewerRelationship;
+
+/**
+ * Creates the application reviewer relatioinship.
+ */
+class CRM_CiviAwards_Upgrader_Steps_Step1012 {
+
+  /**
+   * Creates the application reviewer relatioinship.
+   *
+   * @return bool
+   *   return value.
+   */
+  public function apply() {
+    (new CreateApplicationReviewerRelationship())->apply();
+
+    return TRUE;
+  }
+
+}

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -294,6 +294,8 @@
           caseRoles: [{
             name: 'Application Manager',
             manager: 1
+          }, {
+            name: 'Has application reviewed by',
           }]
         }
       };

--- a/ang/civiawards/award-creation/directives/award.directive.js
+++ b/ang/civiawards/award-creation/directives/award.directive.js
@@ -295,7 +295,7 @@
             name: 'Application Manager',
             manager: 1
           }, {
-            name: 'Has application reviewed by',
+            name: 'Has application reviewed by'
           }]
         }
       };

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -281,6 +281,8 @@
                 caseRoles: [{
                   name: 'Application Manager',
                   manager: 1
+                }, {
+                  name: 'Has application reviewed by'
                 }]
               })
             });
@@ -397,6 +399,8 @@
                 name: 'Application Manager',
                 creator: '0',
                 manager: '1'
+              }, {
+                name: 'Has application reviewed by'
               }],
               statuses: ['Open'],
               restrictActivityAsgmtToCmsUser: _.first(AwardMockData).definition.restrictActivityAsgmtToCmsUser,

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -400,7 +400,9 @@
                 creator: '0',
                 manager: '1'
               }, {
-                name: 'Has application reviewed by'
+                name: 'Has application reviewed by',
+                creator: '0',
+                manager: '0'
               }],
               statuses: ['Open'],
               restrictActivityAsgmtToCmsUser: _.first(AwardMockData).definition.restrictActivityAsgmtToCmsUser,

--- a/ang/test/mocks/data/award.data.js
+++ b/ang/test/mocks/data/award.data.js
@@ -61,6 +61,11 @@
           name: 'Application Manager',
           creator: '0',
           manager: '1'
+        },
+        {
+          name: 'Has application reviewed by',
+          creator: '0',
+          manager: '0'
         }
       ]
     },


### PR DESCRIPTION
## Overview
This PR adds a new relationship type for application reviewers and the new relationship type is assigned as a role to award case types by default.

## Before
Awards case types created before now, only have the `Applicant` and `Application manager` roles by default.
![award1](https://user-images.githubusercontent.com/85277674/178751737-f9a2fa93-11fc-46b2-b982-6f7c9e988afc.gif)


## After
New Award case types created after are assigned the `Applicant`, `Application manager` and `Has application reviewed by` roles by default
![award2](https://user-images.githubusercontent.com/85277674/178752592-b0e7afd2-5e45-4393-a3ec-d5a205c68512.gif)