### PR TITLE
RSE-1774: Remove duplicate html element

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -93,7 +93,6 @@
             <div class="ssp-form-control-description text-muted"> {$element.help_post} </div>
           {/if}
           <div class="{$form_group_field_class}">{$form[$element.name].html}</div>
-          <div class="{$form_group_field_class}">{$form[$element.name].html}</div>
           <div class="clear"></div>
         </div>
       {/foreach}


### PR DESCRIPTION
## Overview

This PR removes the duplicate HTML element added by this [PR](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/245/files#diff-08562e00252a4422ec1fe073f1724c

## Before
![screenshot-stripe localhost_8012-2022 07 14-14_56_47](https://user-images.githubusercontent.com/208713/179001019-746fd254-d14f-4b90-96e7-2bf26daed13f.png)

## After
![screenshot-stripe localhost_8012-2022 07 14-14_57_39 (1)](https://user-images.githubusercontent.com/208713/179001238-1f4aa880-1a8a-4ce9-a3d4-c3a84bb34cc5.png)

