### PR TITLE
RSE-1763: Allow editing review when status is draft

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -100,18 +100,20 @@
 
       {* Review Status Section Starts *}
       {* View Mode *}
-      {if $isViewAction}
-        <div class="form-group {$form_group_class}">
-        <label class="{$form_group_label_class}">{ts}Status{/ts}</label>
-        <div class="{$form_group_field_class}">{$activityStatus}</div>
-        <div class="clear"></div>
-        </div>
-      {else} {*  End view mode *}
-        <div class="form-group {$form_group_class}">
-          <label class="{$form_group_label_class}">{$form.status_id.label}</label>
-          <div class="{$form_group_field_class}">{$form.status_id.html}</div>
-          <div class="clear"></div>
-        </div>
+      {if !$isReviewFromSsp}
+          {if $isViewAction}
+            <div class="form-group {$form_group_class}">
+              <label class="{$form_group_label_class}">{ts}Status{/ts}</label>
+              <div class="{$form_group_field_class}">{$activityStatus}</div>
+              <div class="clear"></div>
+            </div>
+          {else} {*  End view mode *}
+            <div class="form-group {$form_group_class}">
+              <label class="{$form_group_label_class}">{$form.status_id.label}</label>
+              <div class="{$form_group_field_class}">{$form.status_id.html}</div>
+              <div class="clear"></div>
+            </div>
+          {/if}
       {/if}
       {* Review Status Section Endss *}
 
@@ -120,8 +122,8 @@
         {if $isReviewFromSsp}
           {if !$isViewAction}
             <div class="clearfix">
-              <button type="submit" class="btn btn-primary default validate pull-right"> Submit Review </button>
-              <a class="btn btn-default pull-left" href="/ssp/awards/review-applications"> Cancel </a>
+              <a class="btn btn-default pull-left" href="/ssp/awards/review-applications">{ts} Cancel {/ts}</a>
+              {include file="CRM/common/formButtons.tpl"}
             </div>
           {else}
             <button disabled="true" class="btn btn-primary default validate pull-right">


### PR DESCRIPTION
## Overview

This PR adds ability to save draft 

## Before

- Save Draft and Save & Continue buttons did not exist. 
- Update action was not allowed on SSP screen. 
- User can only add a new review on SSP screen.

![screenshot-compuclient-rse-1743-k8e cc-test site-2022 07 19-13_51_21](https://user-images.githubusercontent.com/208713/179754587-4245f471-a935-4599-b4d2-5a614f6759d0.png)

## After

- Save Draft and Save & Continue buttons have been added.
- Update action is allowed when the activity is draft. 

![rse-1673](https://user-images.githubusercontent.com/208713/179754281-68e64b38-efaa-4c50-b1ab-3b880e6ea1c4.gif)

## Technical Details

- There is an issue with the margin between Cancel and Save Draft buttons, and this issue will need to be addressed in a separate PR in the _ssp_bootstrap_ theme.
- The status field only requires to display on the Admin screen, since SSP screen and admin screen are sharing the same form, the status is only added to the form when is not loading SSP and application will determine activity status based on the submitted buttons if the submission is from SSP screen.
