### PR TITLE
RSE-1762: Allow contact to review award applications they can access based on configured role

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -211,10 +211,10 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $loggedInContact = CRM_Core_Session::getLoggedInContactID();
     $awardId = $this->getCaseTypeId();
     $awardPanelContact = new AwardPanelContact();
-    $contactAccessService = new AwardApplicationContactAccess();
+    $contactAccessService = new AwardApplicationContactAccess($awardPanelContact);
 
     try {
-      $contactAccess = $contactAccessService->get($loggedInContact, $awardId, $awardPanelContact);
+      $contactAccess = $contactAccessService->get($loggedInContact, $awardId);
 
       return !empty($contactAccess) ? TRUE : FALSE;
     }
@@ -479,9 +479,9 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
       // Alter display name of contact to "Anonymous [case-id]" if award
       // ssp review panel has anonymize_application set to true.
       $userID = CRM_Core_Session::getLoggedInContactID();
-      $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
-      $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
-      $contactAccess = $contactAccessService->getReviewAccess($userID, $this->caseId, $awardPanelContact);
+      $awardPanelContact = new AwardPanelContact();
+      $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess($awardPanelContact);
+      $contactAccess = $contactAccessService->getReviewAccess($userID, $this->caseId);
       if (!empty($contactAccess) && $contactAccess['anonymize_application']) {
         return 'Anonymous ' . $this->caseId;
       }

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -65,8 +65,11 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 
     $visibilitySettings = [];
     foreach ($awardPanels as $awardPanelId) {
-      if (!empty($this->awardPanelContact->get($awardPanelId, [$contactId]))) {
-        $visibilitySettings[] = $this->getAwardVisibilitySettings($awardPanelId);
+      $awardPanelContacts = $this->awardPanelContact->get($awardPanelId, [$contactId]);
+      if (!empty($awardPanelContacts)) {
+        $awardVisibility = $this->getAwardVisibilitySettings($awardPanelId);
+        $awardVisibility['case_ids'] = $awardPanelContacts[$contactId]['case_ids'] ?? [];
+        $visibilitySettings[] = $awardVisibility;
       }
     }
 
@@ -113,6 +116,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     $response = [];
     foreach ($visibilitySettings as $visibilitySetting) {
       $response[] = [
+        'case_ids' => $visibilitySetting['case_ids'] ?? [],
         'application_tags' => isset($visibilitySetting['application_tags']) ? $visibilitySetting['application_tags'] : [],
         'application_status' => isset($visibilitySetting['application_status']) ? $visibilitySetting['application_status'] : [],
         'status_to_move_to' => !empty($visibilitySetting['is_application_status_restricted']) ? $visibilitySetting['restricted_application_status'] : [],

--- a/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
+++ b/CRM/CiviAwards/Service/AwardApplicationContactAccess.php
@@ -9,20 +9,35 @@ use CRM_CiviAwards_Service_AwardPanelContact as AwardReviewPanelContact;
 class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 
   /**
+   * Award Panel contact service.
+   *
+   * @var CRM_CiviAwards_Service_AwardPanelContact
+   */
+  private $awardPanelContact;
+
+  /**
+   * Constructor function.
+   *
+   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
+   *   Award Panel contact service.
+   */
+  public function __construct(AwardReviewPanelContact $awardPanelContact) {
+    $this->awardPanelContact = $awardPanelContact;
+  }
+
+  /**
    * Returns the contact access to the Award Applications.
    *
    * @param int $contactId
    *   Contact Id.
    * @param int $awardId
    *   Award Id.
-   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
-   *   Award Panel contact service.
    *
    * @return array|void
    *   The contact access to the Award applications.
    */
-  public function get($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
-    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
+  public function get($contactId, $awardId) {
+    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId));
     foreach ($visibilitySettings as &$visibilitySetting) {
       unset($visibilitySetting['status_to_move_to'], $visibilitySetting['anonymize_application']);
     }
@@ -37,13 +52,11 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   Contact Id.
    * @param int $awardId
    *   Award Id.
-   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
-   *   Award Panel contact service.
    *
    * @return array
    *   Visibility settings.
    */
-  private function getContactVisibilitySettings($contactId, $awardId, AwardReviewPanelContact $awardPanelContact) {
+  private function getContactVisibilitySettings($contactId, $awardId) {
     $awardPanels = $this->getAwardPanels($awardId);
 
     if (empty($awardPanels)) {
@@ -52,7 +65,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
 
     $visibilitySettings = [];
     foreach ($awardPanels as $awardPanelId) {
-      if (!empty($awardPanelContact->get($awardPanelId, [$contactId]))) {
+      if (!empty($this->awardPanelContact->get($awardPanelId, [$contactId]))) {
         $visibilitySettings[] = $this->getAwardVisibilitySettings($awardPanelId);
       }
     }
@@ -120,16 +133,14 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
    *   Contact Id.
    * @param int $applicationId
    *   Award Id.
-   * @param CRM_CiviAwards_Service_AwardPanelContact $awardPanelContact
-   *   Award Panel contact service.
    *
    * @return array
    *   Review access array.
    */
-  public function getReviewAccess($contactId, $applicationId, AwardReviewPanelContact $awardPanelContact) {
+  public function getReviewAccess($contactId, $applicationId) {
     $applicationDetails = $this->getApplicationDetails($applicationId);
     $awardId = $applicationDetails['case_type_id'];
-    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId, $awardPanelContact));
+    $visibilitySettings = $this->processVisibilitySettings($this->getContactVisibilitySettings($contactId, $awardId));
 
     $caseTags = !empty($applicationDetails['tag_id']) ? array_keys($applicationDetails['tag_id']) : [];
     $caseStatus = [$applicationDetails['status_id']];
@@ -193,7 +204,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccess {
     $awardReviewPanelObject->find(TRUE);
 
     if (!empty($awardReviewPanelObject->visibility_settings)) {
-      return unserialize($awardReviewPanelObject->visibility_settings);
+      return unserialize((string) $awardReviewPanelObject->visibility_settings);
     }
 
     return NULL;

--- a/api/v3/AwardReviewPanel.php
+++ b/api/v3/AwardReviewPanel.php
@@ -41,9 +41,9 @@ function _civicrm_api3_award_review_panel_getcontactaccess_spec(array &$spec) {
  *   API result descriptor.
  */
 function civicrm_api3_award_review_panel_getcontactaccess(array $params) {
-  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
   $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
-  $contactAccess = $contactAccessService->get($params['contact_id'], $params['award_id'], $awardPanelContact);
+  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess($awardPanelContact);
+  $contactAccess = $contactAccessService->get($params['contact_id'], $params['award_id']);
 
   return civicrm_api3_create_success($contactAccess);
 }
@@ -84,8 +84,8 @@ function _civicrm_api3_award_review_panel_getreviewaccess_spec(array &$spec) {
  *   API result descriptor.
  */
 function civicrm_api3_award_review_panel_getreviewaccess(array $params) {
-  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess();
   $awardPanelContact = new CRM_CiviAwards_Service_AwardPanelContact();
+  $contactAccessService = new CRM_CiviAwards_Service_AwardApplicationContactAccess($awardPanelContact);
   $contactAccess = $contactAccessService->getReviewAccess($params['contact_id'], $params['application_id'], $awardPanelContact);
 
   return civicrm_api3_create_success($contactAccess);

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -110,14 +110,17 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
 
     $expectedResult = [
       [
+        'case_ids' => [],
         'application_tags' => [1, 2],
         'application_status' => [5, 6],
       ],
       [
+        'case_ids' => [],
         'application_tags' => [6, 8],
         'application_status' => [9, 3],
       ],
       [
+        'case_ids' => [],
         'application_tags' => [],
         'application_status' => [],
       ],

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -18,9 +18,9 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
    */
   public function testGetThrowsExceptionWhenNoAwardPanelsExistForAward() {
     $caseType = CaseTypeFabricator::fabricate();
-    $applicationContactAccess = new ApplicationContactAccess();
     $contactId = 1;
     $awardPanelContact = new AwardPanelContact();
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     $this->setExpectedException(
       'Exception',
@@ -34,9 +34,9 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
    */
   public function testGetThrowsExceptionWhenNoContactDoesBelongToAnyAwardPanels() {
     $caseType = CaseTypeFabricator::fabricate();
-    $applicationContactAccess = new ApplicationContactAccess();
     $contactId = 1;
     $awardPanelContact = new AwardPanelContact();
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     $params = [
       [
@@ -71,7 +71,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
    */
   public function testGetReturnsTheContactAccessForContact() {
     $caseType = CaseTypeFabricator::fabricate();
-    $applicationContactAccess = new ApplicationContactAccess();
     $contactId = 1;
 
     $params = [
@@ -107,6 +106,8 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
+
     $expectedResult = [
       [
         'application_tags' => [1, 2],
@@ -122,7 +123,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       ],
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->get($contactId, $caseType['id']));
   }
 
   /**
@@ -131,7 +132,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   public function testGetReviewAccessForContactAndPanelSettingIsForAllCaseTags() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
     $caseData = CaseFabricator::fabricateWithTags(
       ['Tag 1', 'Tag 2'],
       ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
@@ -174,6 +174,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     // Panel 1 and Panel 3 meets the case status and tags criteria.
     // So Contact will view combined status to move to for both panels
@@ -184,7 +185,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id']));
   }
 
   /**
@@ -193,7 +194,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   public function testGetReviewAccessForContactAndAndPanelSettingIsForSpecificCaseTags() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
     $caseData = CaseFabricator::fabricateWithTags(
       ['Tag 1', 'Tag 2'],
       ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
@@ -251,6 +251,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     // Panel 1, Panel 3, Panel 4 meets the case status and case tags criteria.
     // So Contact will view combined status to move to for the panels
@@ -261,7 +262,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id']));
   }
 
   /**
@@ -270,7 +271,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   public function testGetReviewAccessForContactAndPanelSettingIsForAllTagsAndContactCanNotViewAnonymisedData() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
     $caseData = CaseFabricator::fabricateWithTags(
       ['Tag 1', 'Tag 2'],
       ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
@@ -304,6 +304,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     // Panel 1 and Panel 2 meets the case status and tag criteria.
     // So Contact will view combined status to move to for both panels
@@ -314,7 +315,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => TRUE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id']));
   }
 
   /**
@@ -323,7 +324,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   public function testGetReviewAccessForContactWhenContactBelongsToPanelWhereAllTagsAndStatusIsAllowed() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
     $caseData = CaseFabricator::fabricateWithTags(
       ['Tag 1', 'Tag 2'],
       ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
@@ -367,6 +367,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     // Panel 1 and Panel 3 meets the case status criteria.
     // So Contact will view combined status to move to for both panels
@@ -377,7 +378,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['case']['id']));
   }
 
   /**
@@ -386,7 +387,6 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
   public function testContactIsAbleToMoveToRelevantStatusWhenCaseHasNoTagsAndPanelTagsIsEmpty() {
     $caseType = CaseTypeFabricator::fabricate();
     $caseStatus = 1;
-    $applicationContactAccess = new ApplicationContactAccess();
     $caseData = CaseFabricator::fabricate(
       ['status_id' => $caseStatus, 'case_type_id' => $caseType['id']]
     );
@@ -420,6 +420,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
     }
 
     $awardPanelContact = $this->getAwardPanelContactObject($awardPanel, $contactId);
+    $applicationContactAccess = new ApplicationContactAccess($awardPanelContact);
 
     // If a case has no tags it is accessible by panel user
     // when panel also does not contain any tags.
@@ -428,7 +429,7 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
       'anonymize_application' => FALSE,
     ];
 
-    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['id'], $awardPanelContact));
+    $this->assertEquals($expectedResult, $applicationContactAccess->getReviewAccess($contactId, $caseData['id']));
   }
 
   /**

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardPanelContactTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardPanelContactTest.php
@@ -1,13 +1,15 @@
 <?php
 
+use CRM_CiviAwards_Test_Fabricator_Case as CaseFabricator;
 use CRM_CiviAwards_Test_Fabricator_Contact as ContactFabricator;
-use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
 use CRM_CiviAwards_Service_AwardPanelContact as AwardPanelContact;
-use CRM_CiviAwards_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_CiviAwards_Test_Fabricator_CaseType as CaseTypeFabricator;
 use CRM_CiviAwards_Test_Fabricator_Relationship as RelationshipFabricator;
+use CRM_CiviAwards_Test_Fabricator_AwardReviewPanel as AwardReviewPanelFabricator;
+use CRM_CiviAwards_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
 
 /**
- * CRM_CiviAwards_Service_AwardPanelContactTest.
+ * Class to test AwardPanelContact service.
  *
  * @group headless
  */
@@ -518,6 +520,246 @@ class CRM_CiviAwards_Service_AwardPanelContactTest extends BaseHeadlessTest {
   }
 
   /**
+   * Test Get returns contacts assigned To Role.
+   */
+  public function testGetReturnsContactsAssignedToRole() {
+    [$role, $caseType, $awardPanel] = $this->setupAwardPanel();
+
+    $client = ContactFabricator::fabricate();
+    $reviewer = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $client['id'],
+    ]);
+    $this->assignRoleToCase($client['id'], $reviewer['id'], $case['id'], $role);
+
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel, [$reviewer['id']]);
+
+    $expectedResult = [
+      $reviewer['id'] => [
+        'id' => $reviewer['id'],
+        'display_name' => $reviewer['display_name'],
+        'email' => NULL,
+        'case_ids' => [$case['id']],
+      ],
+    ];
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  /**
+   * Test Get will not returns role contacts if relationship has not started.
+   */
+  public function testGetWillNotReturnContactsAssignedToRoleWhenRelationshipHasNotStarted() {
+    // Create a new role: reviewer.
+    [$role, $caseType, $awardPanel] = $this->setupAwardPanel();
+
+    $client = ContactFabricator::fabricate();
+    $reviewer = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $client['id'],
+    ]);
+    $this->assignRoleToCase(
+      $client['id'],
+      $reviewer['id'],
+      $case['id'],
+      $role,
+      ['start_date' => date("Y-m-d", strtotime("tomorrow"))]
+    );
+
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel, [$reviewer['id']]);
+
+    $expectedResult = [];
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  /**
+   * Test Get will not returns role contacts if relationship has ended.
+   */
+  public function testGetWillNotReturnContactsAssignedToRoleWhenRelationshipHasEnded() {
+    // Create a new role: reviewer.
+    [$role, $caseType, $awardPanel] = $this->setupAwardPanel();
+
+    $client = ContactFabricator::fabricate();
+    $reviewer = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $client['id'],
+    ]);
+    $this->assignRoleToCase(
+      $client['id'],
+      $reviewer['id'],
+      $case['id'],
+      $role,
+      ['end_date' => date("Y-m-d", strtotime("yesterday"))]
+    );
+
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel, [$reviewer['id']]);
+
+    $expectedResult = [];
+
+    $this->assertEquals($expectedResult, $contacts);
+  }
+
+  /**
+   * Test Get returns only allowed cases when permission is granted by role.
+   */
+  public function testGetReturnsOnlyAllowedCaseIdsWhenPermissionIsGrnatedByRole() {
+    [$role, $caseType, $awardPanel] = $this->setupAwardPanel();
+
+    $clientA = ContactFabricator::fabricate();
+    $clientB = ContactFabricator::fabricate();
+    $clientC = ContactFabricator::fabricate();
+    $reviewer = ContactFabricator::fabricate();
+
+    $caseA = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $clientA['id'],
+    ]);
+    $caseB = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $clientB['id'],
+    ]);
+    $caseC = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType,
+      'contact_id' => $clientC['id'],
+    ]);
+    $this->assignRoleToCase($clientA['id'], $reviewer['id'], $caseA['id'], $role);
+    $this->assignRoleToCase($clientB['id'], $reviewer['id'], $caseB['id'], $role);
+
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel, [$reviewer['id']]);
+
+    $expectedResult = [$caseA['id'], $caseB['id']];
+
+    $this->assertEquals($expectedResult, ...array_column($contacts, 'case_ids'));
+  }
+
+  /**
+   * Test Get when permission is granted by relationship and role.
+   *
+   * I.e. permission granted by relationship superceeds case_role since
+   * relationship is not limited to specific case(s).
+   */
+  public function testGetAllowsAllCasesWhenPermissionIsGrantedByRelationshipAndRole() {
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+
+    $roleParams = [
+      'name_a_b' => 'Reviewer is',
+      'name_b_a' => 'Reviewer',
+    ];
+    $role = RelationshipTypeFabricator::fabricate($roleParams);
+
+    $caseType = CaseTypeFabricator::fabricate();
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+
+    // Contact B is Manager to Contact A.
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $contactA['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    $params = [
+      'case_type_id' => $caseType['id'],
+      'contact_settings' => [
+        'case_roles' => [$role['name_b_a']],
+        'relationship' => [
+          [
+            'contact_id' => [$contactB['id']],
+            'is_a_to_b' => 1,
+            'relationship_type_id' => $relationshipTypeA['id'],
+          ],
+        ],
+      ],
+    ];
+
+    $case = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType['id'],
+      'contact_id' => $contactB['id'],
+    ]);
+    $this->assignRoleToCase($contactB['id'], $contactA['id'], $case['id'], $role['id']);
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id, [$contactA['id']]);
+
+    $expectedContactIds = [$contactA['id']];
+
+    $this->assertEquals($expectedContactIds, array_column($contacts, 'id'));
+    // case_ids is empty, i.e. all case can be reviewed by the contact.
+    $this->assertCount(0, array_column($contacts, 'case_ids'));
+  }
+
+  /**
+   * Test Get allows all cases when permission is granted by group and role.
+   *
+   * I.e. permission granted by grouup superceeds case_role since
+   * group is not limited to specific case(s).
+   */
+  public function testGetAllowsAllCasesWhenPermissionIsGrantedByGroupAndRole() {
+    $roleParams = [
+      'name_a_b' => 'Reviewer is',
+      'name_b_a' => 'Reviewer',
+    ];
+    $role = RelationshipTypeFabricator::fabricate($roleParams);
+
+    $caseType = CaseTypeFabricator::fabricate();
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+
+    $groupA = $this->createGroup('Group A');
+    $this->addContactToGroup($groupA, $contactA['id']);
+
+    $case = CaseFabricator::fabricate([
+      'status_id' => 1,
+      'case_type_id' => $caseType['id'],
+      'contact_id' => $contactB['id'],
+    ]);
+    $this->assignRoleToCase($contactB['id'], $contactA['id'], $case['id'], $role['id']);
+
+    $params = [
+      'case_type_id' => $caseType['id'],
+      'contact_settings' => [
+        'case_roles' => [$role['name_b_a']],
+        'include_groups' => [$groupA],
+      ],
+    ];
+
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+
+    $awardPanelContact = new AwardPanelContact();
+    $contacts = $awardPanelContact->get($awardPanel->id, [$contactA['id']]);
+
+    $expectedContactIds = [$contactA['id']];
+
+    $this->assertEquals($expectedContactIds, array_column($contacts, 'id'));
+    // case_ids is empty, i.e. all case can be reviewed by the contact.
+    $this->assertCount(0, array_column($contacts, 'case_ids'));
+  }
+
+  /**
    * Add contact to group.
    *
    * @param int $groupId
@@ -566,6 +808,55 @@ class CRM_CiviAwards_Service_AwardPanelContactTest extends BaseHeadlessTest {
       $contact = array_intersect_key($contact, $expectedKeys);
     }
 
+  }
+
+  /**
+   * Assigns a role to case.
+   *
+   * @param int $contactIdA
+   *   The contact A ID.
+   * @param int $contactIdB
+   *   The contact B ID.
+   * @param int $caseId
+   *   The case ID.
+   * @param int $relationshipTypeId
+   *   The relationship type ID.
+   * @param array $extraParams
+   *   Extra relationship data.
+   */
+  private function assignRoleToCase($contactIdA, $contactIdB, $caseId, $relationshipTypeId, array $extraParams = []) {
+    $params = [
+      'is_active' => 1,
+      'contact_id_a' => $contactIdA,
+      'contact_id_b' => $contactIdB,
+      'relationship_type_id' => $relationshipTypeId,
+    ];
+    $relationship = RelationshipFabricator::fabricate($params);
+    civicrm_api3('Relationship', 'create', array_merge([
+      'id' => $relationship['id'],
+      'case_id' => $caseId,
+    ], $extraParams));
+  }
+
+  /**
+   * Sets up award panel data, with role and case type.
+   */
+  public function setupAwardPanel() {
+    // Create a new role: reviewer.
+    $roleParams = ['name_a_b' => 'Reviewer is', 'name_b_a' => 'Reviewer'];
+    $role = RelationshipTypeFabricator::fabricate($roleParams);
+
+    $caseType = CaseTypeFabricator::fabricate();
+    // Create a new review panel: that grants access to the reviewer role.
+    $params = [
+      'case_type_id' => $caseType['id'],
+      'contact_settings' => [
+        'case_roles' => [$role['name_b_a']],
+      ],
+    ];
+    $awardPanel = AwardReviewPanelFabricator::fabricate($params);
+
+    return [$role['id'], $caseType['id'], $awardPanel->id];
   }
 
 }


### PR DESCRIPTION
## Overview
This PR allows contact to review award applications they can access based on configured case roles in the award review panel.

## Before
`AwardReviewPanel.getcontactaccess` API action only returns access for contact configured by relationship and group in the award panel.

## After
`AwardReviewPanel.getcontactaccess` API action returns access for contact configured by relationship, group and case roles in the award panel.

![award4](https://user-images.githubusercontent.com/85277674/179992812-99d45d3a-1c2b-4dc8-95bd-460b7969fc72.gif)

If a contact has access to review an application via case_role configuration, the specific case ids where the contact has been assigned the role are returned by the `AwardReviewPanel.getcontactaccess` API action.

---

![award5](https://user-images.githubusercontent.com/85277674/179999078-05c3cdd5-1513-4139-824d-2b4577fc9415.gif)
If within the same review panel configuration, a contact has access to review an application by case_roles and relationship/ or group, the contact access would not be limited to any specific case id, so the case_ids array returned by `AwardReviewPanel.getcontactaccess` API action would be empty.
