### PR TITLE
RSE-1763: Use pushUserContext on Admin page

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -268,7 +268,13 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
 
     $url = $this->getRedirectUrlForSubmitReview($activityId);
     CRM_Core_Session::setStatus(ts('Your review has been ' . strtolower($status) . ' successfully.'), ts('Review ' . $status), 'success');
-    CRM_Utils_System::redirect($url);
+
+    if ($this->isReviewFromSsp()) {
+      CRM_Utils_System::redirect($url);
+    }
+
+    $session = CRM_Core_Session::singleton();
+    $session->pushUserContext($url);
   }
 
   /**


### PR DESCRIPTION
## Overview

This PR fixes regression on the review form on the backend. 

## Before

After saving the form, the view modal displayed instead of redirect user to the list.

![rse-1673](https://user-images.githubusercontent.com/208713/180021067-fa4f5035-f4e8-4496-b08a-d4c982728b4e.gif)

## After

After saving the form, the form modal disappears. 

![rse-1673-2](https://user-images.githubusercontent.com/208713/180020808-3905c52a-2aed-4a4c-8395-9f4a037cc4c2.gif)
