### PR TITLE
RSE-1776: Reserve draft status and assign Applicant Review category

### DIFF
--- a/CRM/CiviAwards/Upgrader/Steps/Step1012.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1012.php
@@ -40,6 +40,7 @@ class CRM_CiviAwards_Upgrader_Steps_Step1012 {
     civicrm_api3('OptionValue', 'create', [
       'id' => $value['id'],
       'grouping' => implode(", ", $grouping),
+      'is_reserved' => TRUE,
     ]);
   }
 

--- a/CRM/CiviAwards/Upgrader/Steps/Step1012.php
+++ b/CRM/CiviAwards/Upgrader/Steps/Step1012.php
@@ -3,20 +3,44 @@
 use CRM_CiviAwards_Setup_CreateApplicationReviewerRelationship as CreateApplicationReviewerRelationship;
 
 /**
- * Creates the application reviewer relatioinship.
+ * Creates the application reviewer relationship.
  */
 class CRM_CiviAwards_Upgrader_Steps_Step1012 {
 
   /**
-   * Creates the application reviewer relatioinship.
+   * Creates the application reviewer relationship.
    *
    * @return bool
    *   return value.
    */
   public function apply() {
     (new CreateApplicationReviewerRelationship())->apply();
+    $this->configDraftActivityStatus();
 
     return TRUE;
+  }
+
+  /**
+   * Adds Applicant Review category to activity draft status.
+   */
+  private function configDraftActivityStatus() {
+    $value = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id' => "activity_status",
+      'name' => "Draft",
+    ]);
+
+    $applicantReview = 'Applicant Review';
+    $grouping = explode(", ", $value['grouping']);
+    if (in_array($applicantReview, $grouping)) {
+      return;
+    }
+
+    $grouping[count($grouping) + 1] = $applicantReview;
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $value['id'],
+      'grouping' => implode(", ", $grouping),
+    ]);
   }
 
 }


### PR DESCRIPTION
## Overview

This PR adds an upgrader to assign the Applicant Review category to Activity's draft status and reserve it, so it cannot be deleted. 

## Before

![screenshot-stripe localhost_8012-2022 07 21-10_12_39](https://user-images.githubusercontent.com/208713/180177124-bb3e7c8d-0c23-4889-b67e-275e9c346681.png)

![screenshot-stripe localhost_8012-2022 07 21-10_05_40](https://user-images.githubusercontent.com/208713/180177097-aa603c7e-0944-42d1-bc2e-de8d9c656f1b.png)

## After
![screenshot-compuclient-rse-1776-hgk cc-test site-2022 07 21-10_11_04](https://user-images.githubusercontent.com/208713/180177179-7351fc87-c38f-4c40-86ed-7f1b73d60176.png)

![screenshot-compuclient-rse-1776-hgk cc-test site-2022 07 21-10_11_41](https://user-images.githubusercontent.com/208713/180177130-035943e9-739b-46a3-8a6d-cf929666ca99.png)

