### PR TITLE
RSE-1779: Fix award panel with multiple role configuration

### DIFF
--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -258,6 +258,7 @@ class CRM_CiviAwards_Service_AwardPanelContact {
     $caseTable = CRM_Case_BAO_Case::getTableName();
     $contactTable = CRM_Contact_BAO_Contact::getTableName();
     $contactEmailTable = CRM_Core_BAO_Email::getTableName();
+    $caseRolesCondition = '(\'' . implode("','", $roles) . '\')';
     $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
     $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
 
@@ -276,13 +277,12 @@ class CRM_CiviAwards_Service_AwardPanelContact {
       WHERE r.is_active = 1 AND rt.is_active = 1
       AND (r.end_date IS NULL OR r.end_date >= %4)
       AND (r.start_date IS NULL OR r.start_date <= %4)
-      AND rt.name_b_a IN (%2) AND r.contact_id_b IN (%3)
+      AND rt.name_b_a IN {$caseRolesCondition} AND r.contact_id_b IN (%3)
     ";
 
     $params = [
       1 => [$awardId, 'Integer'],
       4 => [date('Y-m-d'), 'String'],
-      2 => [implode(',', $roles), 'String'],
       3 => [implode(',', $contactId), 'CommaSeparatedIntegers'],
     ];
     $result = CRM_Core_DAO::executeQuery($query, $params);

--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -292,9 +292,9 @@ class CRM_CiviAwards_Service_AwardPanelContact {
         'id' => $result->contact_id,
         'email' => $result->email,
         'display_name' => $result->display_name,
-        'case_ids' => array_merge(
+        'case_ids' => array_unique(array_merge(
           ($caseRoles[$result->contact_id]['case_ids'] ?? []), [$result->case_id]
-        ),
+        )),
       ];
     }
 


### PR DESCRIPTION
## Overview
This PR fixes the issue with contact not being granted access to review applications if the award panel is configured with multiple roles.

## Before
`AwardReviewPanel.getcontactaccess` API doesn't return access to an application for contact if the award panel is configured with multiple roles.
![award7](https://user-images.githubusercontent.com/85277674/180430971-3dbc8c48-5200-41e5-b9ce-562ccd1a1846.gif)


## After
`AwardReviewPanel.getcontactaccess`API now return access to an application for contact if the award panel is configured with multiple roles.
![award78gif](https://user-images.githubusercontent.com/85277674/180431542-a6d13848-8880-460e-beca-06c0357c8921.gif)

## Technical Details
This issue happened because the multiple case roles are not imploded properly. e.g `['john', 'doe']` is transformed to `'john, doe'` instead of `'john', 'doe'`.

Also, we remove duplicate case_ids for contact.
<img width="1176" alt="Screenshot 2022-07-22 at 10 31 49" src="https://user-images.githubusercontent.com/85277674/180435446-69aa8652-eea3-4ce5-a716-3a4c8698a681.png">
<img width="652" alt="Screenshot 2022-07-22 at 10 29 33" src="https://user-images.githubusercontent.com/85277674/180435732-81d73b8e-f80d-4d11-901d-236a3aae0f00.png">

