### PR TITLE
RSE-1762: Update condition of active relationship

### DIFF
--- a/CRM/CiviAwards/Service/AwardPanelContact.php
+++ b/CRM/CiviAwards/Service/AwardPanelContact.php
@@ -140,12 +140,16 @@ class CRM_CiviAwards_Service_AwardPanelContact {
         ON rt.id = r.relationship_type_id
       LEFT JOIN {$contactEmailTable} ce
         ON (c.id = ce.contact_id AND ce.is_primary = 1)
-      WHERE r.is_active = 1 AND rt.is_active = 1
+      WHERE rt.is_active = 1 AND 
+      (
+        (r.start_date IS NULL AND r.end_date IS NULL AND r.is_active = 1) OR
+        (r.start_date <= %3 AND r.end_date IS NULL) OR 
+        (r.start_date IS NULL AND r.end_date > %3) OR 
+        (r.start_date <= %3 AND r.end_date > %3)
+      )
       AND rt.id = %2
       {$contactCondition}
       {$filterContactCondition}
-      AND (r.start_date IS NULL OR r.start_date <= %3)
-      AND (r.end_date IS NULL OR r.end_date >= %3)
       ORDER by c.id ASC
     ";
 
@@ -274,9 +278,13 @@ class CRM_CiviAwards_Service_AwardPanelContact {
         ON (c.id = r.contact_id_b)
       LEFT JOIN {$contactEmailTable} ce
         ON (c.id = ce.contact_id AND ce.is_primary = 1)
-      WHERE r.is_active = 1 AND rt.is_active = 1
-      AND (r.end_date IS NULL OR r.end_date >= %4)
-      AND (r.start_date IS NULL OR r.start_date <= %4)
+      WHERE rt.is_active = 1 AND 
+      (
+        (r.start_date IS NULL AND r.end_date IS NULL AND r.is_active = 1) OR
+        (r.start_date <= %4 AND r.end_date IS NULL) OR 
+        (r.start_date IS NULL AND r.end_date > %4) OR 
+        (r.start_date <= %4 AND r.end_date > %4)
+      )
       AND rt.name_b_a IN {$caseRolesCondition} AND r.contact_id_b IN (%3)
     ";
 


### PR DESCRIPTION
## Overview
In this PR we redefine when a `case role relationship` and `contact relationship` of an award review panel is active; an award review panel is active when: 

> The start date and the end date are null, but the is_active IS TRUE
> 
> OR
> 
> The start date is in the past (<= today) or is null and
> 
> the end date is in the future (> today) or is null
> 
> irrespective of the is_active field.

This would ensure consistency with how an active relationship is defined in  SSP https://github.com/compucorp/ssp_core/blob/master/modules/ssp_core_organisations/includes/misc.inc#L272
