### PR TITLE
RSE-1797: Prevent unauthorized users from viewing draft review

### DIFF
--- a/CRM/CiviAwards/Form/AwardReview.php
+++ b/CRM/CiviAwards/Form/AwardReview.php
@@ -167,7 +167,7 @@ class CRM_CiviAwards_Form_AwardReview extends CRM_Core_Form {
     $isAddAction = $this->_action & CRM_Core_Action::ADD;
     $isUpdateAction = $this->_action & CRM_Core_Action::UPDATE;
     $hasSubmittedReview = $this->userAlreadySubmittedReview();
-    $canNotViewReview = $isViewAction && $this->isReviewFromSsp() && !$this->isReviewOwner();
+    $canNotViewReview = ($isViewAction || $isUpdateAction) && $this->isReviewFromSsp() && !$this->isReviewOwner();
 
     if ($this->isReviewFromSsp() && $this->isCaseApplicationDeleted()) {
       $action = $isViewAction ? 'view' : 'submit';


### PR DESCRIPTION
## Overview
In this PR we prevent unauthorized users from viewing a review drafted by another user. 

## Before
A user can view a draft review they did not create

## After
If a user tries to view a draft review they did not create, they will get an error message.
<img width="1348" alt="Screenshot 2022-08-15 at 12 50 43" src="https://user-images.githubusercontent.com/85277674/184630325-fcb9700f-0151-4a0e-b7d7-3d197a616eb8.png">
