### PR TITLE
MAE-903: Allow sync function to be called from a static context

### DIFF
--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -265,7 +265,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
    * @param CRM_Queue_TaskContext $context
    *   Queue task context.
    */
-  public function syncLogTables(CRM_Queue_TaskContext $context) {
+  public static function syncLogTables(CRM_Queue_TaskContext $context) {
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
 


### PR DESCRIPTION
## Overview
During the CiviCRM Upgrade task either from the UI or when the command `drush cvupdb` is executed, the task fails with the following error:

 unable to call callback ["CRM_CiviAwards_Upgrader”, "syncLogTables"]

This error happens because the `syncLogTables` method was invoked statically even though it was not declared as a static method.

We fix this issue in this PR by changing the function to a static method.