### PR TITLE
MAE-893: Use PHP8.0 container in Test workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,19 +42,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
-          git clone --depth 1 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
-
-      - name: Switch Civicase Branch
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase
-        run: |
-          if [[ $(git ls-remote --heads origin ${GITHUB_HEAD_REF}) ]]
-          then
-              git checkout ${GITHUB_HEAD_REF}
-          elif [[ $(git ls-remote --heads origin ${GITHUB_BASE_REF}) ]]
-          then
-              git checkout ${GITHUB_BASE_REF}
-          fi
-        shell: bash
+          git clone --depth 1 -b MAE-823-align-with-civi-5.51.3 https://github.com/compucorp/uk.co.compucorp.civicase.git
 
       - name: Install CiviAwards and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -31,7 +31,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Build Drupal site
         run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
 
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.51.3
+          path: site/web/sites/all/modules/civicrm
+
       - uses: actions/checkout@v2
         with:
             path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civiawards

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download CiviAwards dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
+          git clone -b MAE-847-php8 --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
           git clone --depth 1 -b MAE-823-align-with-civi-5.51.3 https://github.com/compucorp/uk.co.compucorp.civicase.git
 

--- a/CRM/CiviAwards/Form/AwardPayment.php
+++ b/CRM/CiviAwards/Form/AwardPayment.php
@@ -47,7 +47,7 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
    *
    * @var array
    */
-  private $activity;
+  private $activity = [];
 
   /**
    * {@inheritDoc}
@@ -85,7 +85,7 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
     }
 
     $this->setActivityStatuses();
-    $this->isActivityStatusExported = $this->activity['status_id'] == $this->getValueForActivityStatus('exported_complete');
+    $this->isActivityStatusExported = array_key_exists('status_id', $this->activity) && $this->activity['status_id'] == $this->getValueForActivityStatus('exported_complete');
     if ($this->isActivityStatusExported && $this->_action == CRM_Core_Action::UPDATE) {
       throw new Exception('Action not supported!');
     }
@@ -554,7 +554,7 @@ class CRM_CiviAwards_Form_AwardPayment extends CRM_Core_Form {
    *   Make editable or not.
    */
   private function activityStatusIsLocked() {
-    $activityStatus = $this->activity['status_id'];
+    $activityStatus = $this->activity['status_id'] ?? NULL;
     $notEditableStatuses = [
       $this->getValueForActivityStatus('paid_complete'),
       $this->getValueForActivityStatus('failed_incomplete'),

--- a/CRM/CiviAwards/Test/Fabricator/CaseCategory.php
+++ b/CRM/CiviAwards/Test/Fabricator/CaseCategory.php
@@ -6,13 +6,13 @@
 class CRM_CiviAwards_Test_Fabricator_CaseCategory {
 
   /**
-   * Fabricates a Case Category.
+   * Fabricate a case category.
    *
    * @param array $params
    *   Parameters.
    *
-   * @return mixed
-   *   API result.
+   * @return array
+   *   Results.
    */
   public static function fabricate(array $params = []) {
     $params = self::mergeDefaultParams($params);
@@ -22,17 +22,21 @@ class CRM_CiviAwards_Test_Fabricator_CaseCategory {
   }
 
   /**
-   * Merges default parameters.
+   * Merge to default parameters.
    *
    * @param array $params
    *   Parameters.
    *
    * @return array
-   *   API result.
+   *   Resulting merged parameters.
    */
   private static function mergeDefaultParams(array $params) {
+    $name = 'n' . rand(1000, 9999);
     $defaultParams = [
       'option_group_id' => 'case_type_categories',
+      'label' => $name,
+      'name' => $name,
+      'is_active' => 1,
     ];
 
     return array_merge($defaultParams, $params);

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,16 +1,59 @@
 <?php
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
-abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+/**
+ * Base test class.
+ */
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
 
+  /**
+   * {@inheritDoc}
+   */
   public function setUpHeadless() {
-    return \Civi\Test::headless()
+    return Test::headless()
       ->install('uk.co.compucorp.civicase')
       ->installMe(__DIR__)
       ->apply();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getMockBuilder($className) {
+    $mockBuilder = (new class($this, $className) extends PHPUnit_Framework_MockObject_MockBuilder {
+
+      /**
+       * {@inheritDoc}
+       */
+      public function getMock() {
+        static::setSupressedErrorHandler();
+
+        try {
+          return parent::getMock();
+        } finally {
+          restore_error_handler();
+        }
+      }
+
+      /**
+       * Supress depreciation warnings.
+       */
+      public static function setSupressedErrorHandler() {
+        $previousHandler = set_error_handler(function ($code, $description, $file = NULL, $line = NULL, $context = NULL) use (&$previousHandler) {
+          if ($code & E_DEPRECATED) {
+              return TRUE;
+          }
+
+            return $previousHandler($code, $description, $file, $line, $context);
+        });
+      }
+
+    });
+
+    return $mockBuilder;
   }
 
 }

--- a/tests/phpunit/CRM/CiviAwards/Form/AwardPaymentTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Form/AwardPaymentTest.php
@@ -64,7 +64,7 @@ class CRM_CiviAwards_Form_AwardPaymentTest extends BaseHeadlessTest {
     $activityId = $this->createActivity('approved_complete');
     $formValues = [
       'status_id' => $this->getValueForActivityStatus('paid_complete'),
-      'target_contact_id' => 2,
+      'target_contact_id' => $this->activityContact,
       'details' => 'This is test details',
       'activity_date_time' => date('Y-m-d H:i:s'),
     ];

--- a/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
+++ b/tests/phpunit/CRM/CiviAwards/Service/AwardApplicationContactAccessTest.php
@@ -447,12 +447,20 @@ class CRM_CiviAwards_Service_AwardApplicationContactAccessTest extends BaseHeadl
    *   Award Panel Contact.
    */
   private function getAwardPanelContactObject($awardPanel, $contactId) {
-    $awardPanelContact = $this->prophesize(AwardPanelContact::class);
+    $awardPanelContact = $this->getMockBuilder(AwardPanelContact::class)
+      ->setMethods(['get'])
+      ->getMock();
+
+    $returnValueMap = [];
     foreach ($awardPanel as $awardPanel) {
-      $awardPanelContact->get($awardPanel->id, [$contactId])->willReturn(TRUE);
+      $returnValueMap[] = [
+        (string) $awardPanel->id, [$contactId], TRUE,
+      ];
     }
 
-    return $awardPanelContact->reveal();
+    $awardPanelContact->method('get')->will($this->returnValueMap($returnValueMap));
+
+    return $awardPanelContact;
   }
 
 }


### PR DESCRIPTION
## Overview
Upon changing the test container to PHP8.0, the most prominent errors were caused by the version of PHPUnit used, some of the depreciation errors are:
ReflectionType::__toString() is deprecated in PHP 7.4
ReflectionType::toArray() is deprecated in PHP 7.4

Resolving this would require using PHPUnit 8.2.3 and above, but only PHPUnit 4,5 and 6 are supported by CiviCRM as of now https://docs.civicrm.org/dev/en/latest/testing/phpunit/
https://github.com/sebastianbergmann/phpunit/issues/3728.
Since the version of PHPUnit can't be updated we suppress the errors by decorating the getMockBuilder function to ignore all E_DEPRECATED errors.