### PR TITLE
MAE-969: Fix award page not loading

### DIFF
--- a/CRM/CiviAwards/Service/AwardCaseFilterPreProcess.php
+++ b/CRM/CiviAwards/Service/AwardCaseFilterPreProcess.php
@@ -16,8 +16,8 @@ class CRM_CiviAwards_Service_AwardCaseFilterPreProcess {
     $awardDetailParamName = 'case_type_id.award_detail_params';
 
     $caseTypeParams = [];
-    $managedByParam = !empty($requestParams[managedByParamName]) ?
-      $requestParams[managedByParamName] :
+    $managedByParam = !empty($requestParams['managedByParamName']) ?
+      $requestParams['managedByParamName'] :
       NULL;
     $awardDetailParams = !empty($requestParams[$awardDetailParamName]) ?
       $requestParams[$awardDetailParamName] :


### PR DESCRIPTION
## Overview
At times an Award page doesn't load, this was caused by the use of an undefined constant as a string, and this is no longer supported in PHP 8.0.

<img width="851" alt="Screenshot 2022-11-28 at 17 38 34" src="https://user-images.githubusercontent.com/85277674/204332264-fe47dc2f-95b1-4812-8971-46a7334c8f26.png">
