### PR TITLE
CIVIPLUS-1144: Fix typo in civiawards from ‘Award Sybtypes’ to ‘Award Subtypes' on the Manage Awards types page

### DIFF
--- a/ang/civiawards-workflow/filters/directives/workflow-list-filter-subtype.html
+++ b/ang/civiawards-workflow/filters/directives/workflow-list-filter-subtype.html
@@ -1,5 +1,5 @@
 <div ng-controller="CiviAwardWorkflowFilterController">
-  <label>{{ts('Award Sybtypes')}}</label>
+  <label>{{ts('Award Subtypes')}}</label>
   <input
     class="form-control"
     crm-ui-select="{


### PR DESCRIPTION
## Overview
Fix the Typo from ‘Award Sybtypes’ to ‘Award Subtypes' on the Manage Awards types page.

(URL: [your site]/civicrm/workflow/a?case_type_category=2&p=al#/list”

## Before
![Screenshot 2022-11-22 at 10 37 16](https://user-images.githubusercontent.com/107249752/205247703-e8ade54a-bf18-420b-af57-dd8920035d34.png)


## After
<img width="1725" alt="Screenshot 2022-12-02 at 1 46 45 PM" src="https://user-images.githubusercontent.com/107249752/205247628-33774127-34d4-4e59-b0c2-a790adbf2595.png">


