### PR TITLE
CIVIPLUS-1144: Create release 1.7.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,8 +12,8 @@
     <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.civiawards/blob/master/readme.md</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-09-07</releaseDate>
-  <version>1.6.0</version>
+  <releaseDate>2022-12-09</releaseDate>
+  <version>1.7.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.39</ver>


### PR DESCRIPTION
## Overview
Release 1.7.0 includes the following changes: 
[CIVIPLUS-1144: Fix typo in civiawards](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/264/commits/8d7ed426ce4c968c71276218f9046cfcd9b965b6)
