### PR TITLE
COMPCRM-70: Fix running upgraders on PHP 8 sites

### DIFF
--- a/CRM/CiviAwards/Upgrader.php
+++ b/CRM/CiviAwards/Upgrader.php
@@ -184,7 +184,7 @@ class CRM_CiviAwards_Upgrader extends CRM_CiviAwards_Upgrader_Base {
    *   The queue requires that true is returned on successful upgrade, but we
    *   use exceptions to indicate an error instead.
    */
-  public function runStepUpgrade(CRM_Queue_TaskContext $context, $step) {
+  public static function runStepUpgrade(CRM_Queue_TaskContext $context, $step) {
     $step->apply();
 
     return TRUE;


### PR DESCRIPTION
## Before
Upgrader is not working.

## After
Upgrader is working fine.

## Technical Details
The problem happens because of the migration to PHP 8:
from the PHP 8 migration notes: https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other

> The ability to call non-static methods statically has been removed. Thus [is_callable()](https://www.php.net/manual/en/function.is-callable.php) will fail when checking for a non-static method with a classname (must check with an object instance).

When the upgrader for CiviAwards runs, this function https://github.com/civicrm/civicrm-core/blob/5.51/CRM/Queue/Task.php#L94-L96 gets called with parameter `[CRM_CiviAwards_Upgrader, runStepUpgrade]` and since the function runStepUpgrade is not static it will fail.
