### PR TITLE
WHFSPRT-429: Fix new award creation

### DIFF
--- a/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
+++ b/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
@@ -124,6 +124,7 @@ class CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields implements API_Wrapper {
     $options = _civicrm_api3_get_options_from_params($apiRequest['params']);
     $returnParams = array_keys($options['return']);
     $pseudoFieldReturn = [];
+    $apiRequest['params']['pseudo_fields'] = [];
     $pseudoFields = [
       'award_manager' => ['dependency' => 'case_type_id'],
       'review_fields' => ['dependency' => 'profile_id'],


### PR DESCRIPTION
## Overview
This PR fixes creating new awards if the site has some award - Case (Awards) - custom groups and using PHP 8.
## Before
We cannot create new awards if the site has some award - Case (Awards) - custom groups and using PHP 8.

## After
We can create new awards if the site has some award - Case (Awards) - custom groups and using PHP 8.
## Technical Details
We cannot create new awards if the site has some award - Case (Awards) - custom groups.

The following appears in the docker console output:
```
TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in in_array() (line 57 of uk.co.compucorp.civiawards/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php)
> Which is this line:  
     if (!in_array('award_manager', $apiRequest['params']['pseudo_fields'])) { <-------
         return;
> Call stack:
> AwardDetailExtraFields.php:57, CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields->addAwardManagerDetails()
> AwardDetailExtraFields.php:26, CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields->toApiOutput()
> WrapperAdapter.php:72, Civi\API\Subscriber\WrapperAdapter->onApiRespond()
```
Simply, the `$apiRequest['params']['pseudo_fields']` is not defined. The `toApiOutput` get called because we are altering Civi APIs :
```php
function civiawards_civicrm_apiWrappers(&$wrappers, $apiRequest) {
  if ($apiRequest['entity'] == 'AwardDetail') {
    $wrappers[] = new CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields();
  }
  ...
```

CiviCRM calls the `fromApiInput` method first which creates the `pseudo_fields` key if the current CiviCRM request matches the criteria:
```php
 private function setRequiredReturnParameters(array &$apiRequest) {
     ...
    if (!empty($returnParams) && empty(array_intersect($returnParams, array_keys($pseudoFields)))) {
      return;
    }
    ...
      $apiRequest['params']['pseudo_fields'][] = $pseudoField;
```

If the site has some award - Case (Awards) - custom groups, the API request defined in [CustomGroupPostProcess.php#L53](https://github.com/compucorp/uk.co.compucorp.civiawards/blob/2.1.0/CRM/CiviAwards/Helper/CustomGroupPostProcess.php#L53) will hit the return statement and won't reach the `pseudo_fields` line.

The proposed solution in this commit is to set a default value for the `pseudo_fields` key.

It is worth mentioning we have this issue for two reasons :
- PHP 8: We are now using PHP 8, which throws the following warning and fatal error:
```
Warning: Undefined array key "pseudo_fields"
Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given
```
Let's compare that to PHP 7 which throws the following notice and warning:
```
Notice: Undefined index: pseudo_fields
Warning: in_array() expects parameter 2 to be array, null given
```
And the if condition will evaluate to true and will hit the return statement.

- Custom groups: The site that has some award - Case (Awards) - custom groups, will trigger the code in the method `processCaseTypeCustomGroupsOnCreate()`:
```
function civiawards_civicrm_post($op, $objectName, $objectId, &$objectRef) {
  $hooks = [
    new CRM_CiviAwards_Hook_Post_UpdateCaseTypeListForCustomGroup(),
  ];
  ...
  > UpdateCaseTypeListForCustomGroup.php:264, run()
  > ApplicantManagementAwardDetailPostProcessor.php:60, processCaseTypeCustomGroupsOnCreate()
  public function processCaseTypeCustomGroupsOnCreate(AwardDetail $awardDetail) {
    $caseTypeId = $awardDetail->case_type_id;
    $customGroups = $this->postProcessHelper->getCaseTypeCustomGroups($caseTypeId);   <------ yes we have custom groups
    if (empty($customGroups)) {
      return;
    }
    $caseTypeSubType = $this->postProcessHelper->getSubTypesForCaseType([$caseTypeId]); <------ this will get call and will lead to the bug
```
The `getSubTypesForCaseType` method defined in the file [CustomGroupPostProcess.php#L53](https://github.com/compucorp/uk.co.compucorp.civiawards/blob/2.1.0/CRM/CiviAwards/Helper/CustomGroupPostProcess.php#L53) calls civicrm_api that leads to the bug.