### PR TITLE
RCRM-22: Fix typeerror while awards creation process

### DIFF
--- a/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
+++ b/CRM/CiviAwards/Api/Wrapper/AwardDetailExtraFields.php
@@ -54,6 +54,10 @@ class CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields implements API_Wrapper {
    *   API Result details.
    */
   private function addAwardManagerDetails(array $apiRequest, array &$result) {
+    if (empty($apiRequest['params']['pseudo_fields'])) {
+      return;
+    }
+
     if (!in_array('award_manager', $apiRequest['params']['pseudo_fields'])) {
       return;
     }
@@ -73,6 +77,10 @@ class CRM_CiviAwards_Api_Wrapper_AwardDetailExtraFields implements API_Wrapper {
    *   API result.
    */
   private function addProfileFields(array $apiRequest, array &$result) {
+    if (empty($apiRequest['params']['pseudo_fields'])) {
+      return;
+    }
+
     if (!in_array('review_fields', $apiRequest['params']['pseudo_fields'])) {
       return;
     }


### PR DESCRIPTION
## Overview

This pull request fixes the issue with the Awards creation process. Previously, when attempting to create new awards, it would display an error popup and fail to create the awards.

## Before

https://github.com/compucorp/uk.co.compucorp.civiawards/assets/2689257/28898962-2cea-43b4-90cb-e6567b16fb56

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/2689257/ad02e553-1f11-427e-a8ed-4c450e88a689)

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/2689257/26e78ede-f173-4dee-b11d-5fe00bd69b3d)


## After
![awards creation after](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/2689257/1074e7b5-0427-4a3d-b214-b06a501d4163)

## Technical Details

- After upgrading PHP to version 8.0, we are encountering a TypeError when adding Awards Manager fields and profile fields to the API results. Additionally, if there are no 'pseudo_fields' present, it throws an error due to the TypeError.