### PR TITLE
CIWEMB-435: Allow using multiple review custom groups

### DIFF
--- a/ang/civiawards-base.ang.php
+++ b/ang/civiawards-base.ang.php
@@ -46,5 +46,6 @@ return [
   'settings' => $options,
   'requires' => [
     'civicase-base',
+    'api4',
   ],
 ];

--- a/ang/civiawards.ang.php
+++ b/ang/civiawards.ang.php
@@ -29,6 +29,7 @@ return [
     0 => 'css/civiawards.min.css',
   ],
   'requires' => [
+    'api4',
     'crmUi',
     'crmUtil',
     'ngRoute',

--- a/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
@@ -18,6 +18,7 @@
     <thead>
     <tr>
       <th>Review Field Name</th>
+      <th>Field Set</th>
       <th>Enabled</th>
       <th>Data Type</th>
       <th>Field Type</th>
@@ -28,6 +29,7 @@
         ng-repeat="reviewField in model.reviewFields | filter: model.searchText"
         ng-click="model.toggleReviewField(reviewField)">
         <td>{{reviewField.label}}</td>
+        <td>{{reviewField['api.CustomGroup.getvalue']}}</td>
         <td align="center">
           <input
             ng-checked="!!model.findReviewFieldByID(reviewField.id)"

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
@@ -8,6 +8,7 @@
   <thead>
   <tr>
     <th>Review Field Name</th>
+    <th>Field Set</th>
     <th>Order</th>
     <th width="20">Required</th>
     <th>Data Type</th>
@@ -27,6 +28,7 @@
       ng-repeat="reviewField in additionalDetails.selectedReviewFields | orderBy: 'weight'"
       ng-if="additionalDetails.selectedReviewFields.length > 0">
       <td>{{getReviewFieldData(reviewField.id, 'label')}}</td>
+      <td>{{getReviewFieldData(reviewField.id, 'api.CustomGroup.getvalue')}}</td>
       <td>
         <a
           class="crm-weight-arrow" ng-if="$index > 0"

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js
@@ -213,7 +213,8 @@
         return civicaseCrmApi([['CustomField', 'get', {
           sequential: true,
           custom_group_id: { IN: applicantReviewCustomGroups },
-          options: { limit: 0 }
+          options: { limit: 0 },
+          'api.CustomGroup.getvalue': { id: '$value.custom_group_id', return: 'title' }
         }]]);
       }).then(function (customFields) {
         $scope.reviewFields = customFields[0].values;

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -22,15 +22,15 @@
    * @param {object} $sce angular Strict Contextual Escaping service.
    * @param {Function} civicaseCrmApi the CiviCRM API service.
    * @param {string} reviewsActivityTypeName the reviews activity type name.
-   * @param {string} reviewScoringFieldsGroupName the review scoring fields group name.
    * @param {Function} ts the translation function.
    * @param {Function} crmStatus crm status service
    * @param {Function} civicaseCrmUrl civicrm url service
    * @param {Function} civicaseCrmLoadForm service to load civicrm forms
+   * @param {Function} crmApi4 access to CiviCRM API v4
    */
   function civiawardsReviewsCaseTabContentController ($q, $scope, $sce,
-    civicaseCrmApi, reviewsActivityTypeName, reviewScoringFieldsGroupName, ts,
-    crmStatus, civicaseCrmUrl, civicaseCrmLoadForm) {
+    civicaseCrmApi, reviewsActivityTypeName, ts,
+    crmStatus, civicaseCrmUrl, civicaseCrmLoadForm, crmApi4) {
     var CRM_FORM_LOAD_EVENT = 'crmFormLoad';
     var CRM_FORM_SUCCESS_EVENT = 'crmFormSuccess.crmPopup crmPopupFormSuccess.crmPopup';
     var REVIEW_FORM_URL = 'civicrm/awardreview';
@@ -68,24 +68,33 @@
      * @returns {Promise} resolves after fetching the reviews.
      */
     function getReviewActivities () {
-      return civicaseCrmApi('Activity', 'get', {
-        activity_type_id: reviewsActivityTypeName,
-        case_id: $scope.caseItem.id,
-        options: { limit: 0 },
-        sequential: 1,
-        'api.OptionValue.getsingle': {
-          option_group_id: 'activity_status',
-          value: '$value.status_id'
-        },
-        'api.CustomValue.gettreevalues': {
-          entity_id: '$value.id',
-          entity_type: 'Activity',
-          'custom_group.name': reviewScoringFieldsGroupName
-        }
-      })
-        .then(function (response) {
-          return response.values;
+      return crmApi4('CustomGroup', 'get', {
+        select: ['name'],
+        join: [['OptionValue AS option_value', 'INNER', ['extends_entity_column_value', '=', 'option_value.value']]],
+        where: [['extends', '=', 'Activity'], ['option_value.option_group_id:name', '=', 'activity_type'], ['option_value.name', '=', 'Applicant Review']]
+      }).then(function (customGroups) {
+        var applicantReviewCustomGroups = customGroups.map(function (customGroup) {
+          return customGroup.name;
         });
+
+        return civicaseCrmApi('Activity', 'get', {
+          activity_type_id: reviewsActivityTypeName,
+          case_id: $scope.caseItem.id,
+          options: { limit: 0 },
+          sequential: 1,
+          'api.OptionValue.getsingle': {
+            option_group_id: 'activity_status',
+            value: '$value.status_id'
+          },
+          'api.CustomValue.gettreevalues': {
+            entity_id: '$value.id',
+            entity_type: 'Activity',
+            'custom_group.name': { IN: applicantReviewCustomGroups }
+          }
+        });
+      }).then(function (response) {
+        return response.values;
+      });
     }
 
     /**
@@ -110,9 +119,14 @@
       var sortOrder = _.sortBy(scoringFieldsSortOrder, 'weight');
 
       return _.map(angular.copy(activitiesData), function (activity) {
+        var applicantReviewFields = {};
+        activity['api.CustomValue.gettreevalues'].values.map(function (field) {
+          applicantReviewFields = Object.assign(applicantReviewFields, field.fields);
+        });
+
         activity.status_label = activity['api.OptionValue.getsingle'].label;
         activity.reviewFields = sortOrder.map(function (scoringFieldSortOrder) {
-          return _.find(activity['api.CustomValue.gettreevalues'].values[0].fields, function (field) {
+          return _.find(applicantReviewFields, function (field) {
             return field.id === scoringFieldSortOrder.id;
           });
         });

--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -120,8 +120,15 @@
 
       return _.map(angular.copy(activitiesData), function (activity) {
         var applicantReviewFields = {};
-        activity['api.CustomValue.gettreevalues'].values.map(function (field) {
-          applicantReviewFields = Object.assign(applicantReviewFields, field.fields);
+        activity['api.CustomValue.gettreevalues'].values.map(function (fieldSet) {
+          Object.keys(fieldSet.fields).forEach(function (key) {
+            var field = fieldSet.fields[key];
+            var newKey = key + field.id;
+            fieldSet.fields[newKey] = Object.assign({ id: field.id }, field);
+            delete fieldSet.fields[key];
+          });
+
+          applicantReviewFields = Object.assign(applicantReviewFields, fieldSet.fields);
         });
 
         activity.status_label = activity['api.OptionValue.getsingle'].label;

--- a/ang/civiawards/shared/constants.js
+++ b/ang/civiawards/shared/constants.js
@@ -2,6 +2,5 @@
   var module = angular.module('civiawards');
 
   module
-    .constant('reviewsActivityTypeName', 'Applicant Review')
-    .constant('reviewScoringFieldsGroupName', 'Applicant_Review');
+    .constant('reviewsActivityTypeName', 'Applicant Review');
 })(angular);

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -1,19 +1,21 @@
 (function (_) {
   describe('civiawardReviewFieldsTable', () => {
     var $rootScope, $controller, $scope, $q, civicaseCrmApi, ReviewFieldsMockData,
-      AwardAdditionalDetailsMockData, dialogService;
+      AwardAdditionalDetailsMockData, dialogService, crmApi4;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'civicase.data', 'civiawards.data', function ($provide) {
       $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
+      $provide.value('crmApi4', jasmine.createSpy('crmApi4'));
       $provide.value('dialogService', jasmine.createSpyObj('dialogService', ['open', 'close']));
     }));
 
     beforeEach(inject((_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_,
-      _ReviewFieldsMockData_, _AwardAdditionalDetailsMockData_, _dialogService_) => {
+      _ReviewFieldsMockData_, _AwardAdditionalDetailsMockData_, _dialogService_, _crmApi4_) => {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
+      crmApi4 = _crmApi4_;
       civicaseCrmApi = _civicaseCrmApi_;
       ReviewFieldsMockData = _ReviewFieldsMockData_;
       AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
@@ -21,6 +23,9 @@
 
       dialogService.dialogs = {};
       civicaseCrmApi.and.returnValue($q.resolve([
+        { values: ReviewFieldsMockData }
+      ]));
+      crmApi4.and.returnValue($q.resolve([
         { values: ReviewFieldsMockData }
       ]));
 
@@ -34,11 +39,11 @@
       });
 
       it('fetches all review fields', () => {
-        expect(civicaseCrmApi).toHaveBeenCalledWith([['CustomField', 'get', {
-          sequential: true,
-          custom_group_id: 'Applicant_Review',
-          options: { limit: 0 }
-        }]]);
+        expect(crmApi4).toHaveBeenCalledWith('CustomGroup', 'get', {
+          select: ['name'],
+          join: [['OptionValue AS option_value', 'INNER', ['extends_entity_column_value', '=', 'option_value.value']]],
+          where: [['extends', '=', 'Activity'], ['option_value.option_group_id:name', '=', 'activity_type'], ['option_value.name', '=', 'Applicant Review']]
+        });
       });
 
       it('displays all review fields', () => {


### PR DESCRIPTION
## Before

When adding "review" fields to an Award type, the fields that appear are coming from a custom group called "Applicant Review Scoring Fields" that is shipped by default with CiviAwards:

![2023-10-05 17_15_39-Custom Data _ Site-Install](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/0168a8be-b755-4b56-8c46-8143d5d49f0e)

here I've added 3 fields to this custom group:

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/340e7d0e-8b14-49ce-bc4a-c0e41772ae92)

and here you can see the above fields appear when trying to add review fields to an award type:

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/dc82470f-6073-4b7a-8f4a-ad8ab115338e)


Civiawards is hardcoded to only use the above custom group, but sometimes we have clients who have large number of review fields (e.g 200 review) that they use for various workflows and processes, and given each custom field represnts a database column in the parent custom group table, the table size will exceed the limit of MySQL which brings down the site and result in various problems.


## After

Here I am adding the ability to configure new custom groups where the fields of such groups will appear when trying to add review fields, for such custom groups to be qualified they have to be used only for "Applicant Review" activity type. The benefit of this is now clients can split their review fields into separate smaller groups, so we don't end up with single big custom group. 

Here I've added two extra custom groups were both are used for Activities of "Applicant Review" type:

![2023-10-05 17_29_05-Custom Data _ Site-Install](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/69e0e49d-5df3-4d11-be37-8acc5a0ed93b)

where the first extra group contains the following fields:

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/76e78075-bfe5-45d8-bcde-352eaaa2f468)

and the other contains this fields:

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/b6ce2a6c-1441-4dbe-b191-9977ff87de27)


Here in the award type configuration page we can see these new fields:

![2023-10-05 17_30_51-Configure Award - Gold _ Site-Install](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/1d594219-157d-414a-8e63-626195766df8)

and once added to the award type, they will appear when trying to add a review to any award of such type:

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/897ae554-0e4e-4d83-8ebb-6e7d812dd9b0)

![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/26403367-2a62-43d7-b4a6-cec0391965c7)


![image](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/6e99f48f-a671-4bd9-af9b-eaf72e6d4d05)


## Technical Details

I mostly altered the existing API calls that are hardcoded to fetch custom fields that belong to the   "Applicant Review Scoring Fields" (the machine name of this group is `Applicant_Review`) to instead fetch custom fields that belong to any custom group that extends activities of type "Applicant Review". I fetch the list of such custom groups using API v4 which unlike API v3 allows me to do a join on the option values table which allows me to able to detect such groups. Such API calls exist  in two places, the first one is inside the file `ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.js` which is responsible for the "Review" tab inside the Award type configuration page, and the other is `ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js`   which is responsible for showing the values in the award view page and the "add review" form.


## Update 1

As part of the discussion on the ticket, we decided that it would be more clear if we include the custom group name for each review field when configuring an award type, so I've added this commit to achieve that: https://github.com/compucorp/uk.co.compucorp.civiawards/pull/275/commits/35bf383222f8d741924c78fa5856467091855bcc

Here is how now the "Review fields" tab look like inside the awards type configuration page:

![2023-11-07 20_27_54-Configure Award - Gold _ Site-Install](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/00c4ea42-53c0-4d75-88ba-59a78a54c0c7)


and here after clicking on "Add review field":

![2023-11-07 20_28_56-Configure Award - Gold _ Site-Install](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/6275540/2e926796-d8a9-4842-b2ee-943fb22bacde)

