### PR TITLE
RSESPRT-246: Prevent user from submitting review multiple times

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -155,3 +155,22 @@
   </div>
 </div>
 
+{literal}
+  <script type="text/javascript">
+    CRM.$(function ($) {
+      $(document).ready(function () {
+        $('form').preventDoubleSubmission();
+      });
+
+      $.fn.preventDoubleSubmission = function () {
+        CRM.$(this).on('submit', function (e) {
+          if ( $(this)[0].checkValidity() ) {
+            CRM.$.blockUI();
+          }
+        });
+
+        return this;
+      };
+    });
+  </script>
+{/literal}

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -165,7 +165,7 @@
       $.fn.preventDoubleSubmission = function () {
         CRM.$(this).on('submit', function (e) {
           if ( $(this)[0].checkValidity() ) {
-            CRM.$.blockUI();
+            $('form').block();
           }
         });
 


### PR DESCRIPTION
## Overview
This PR disables the submit button post-click so that the user is prevented from multiple click/submission as this ends up breaking the form submission.

Also, handle error when a user attempts to submit a review without an activity ID.

## Before
**User can click on award submit multiple times**

## After
**User can only click on award submit once**
![screen_recording_after](https://github.com/user-attachments/assets/49df090b-ad49-476f-8fd2-ab4083d32627)


## Before
Drupal white page error is displayed if the user attempts to submit a review without an activity ID
<img width="1298" alt="Screenshot 2024-05-31 at 12 08 37" src="https://github.com/compucorp/uk.co.compucorp.civiawards/assets/85277674/07303b95-f369-4f44-ad7b-1696abdf9c7f">


## After
Custom error message is displayed if the user attempts to submit a review without an activity ID


