### PR TITLE
MMB-398: Add bootstrap 5 class for case tags label

### DIFF
--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -45,7 +45,7 @@
               <span class="ssp-applicant-card__award ssp-text-large">{$caseTypeName}</span>
               <span>
                 {foreach from=$caseTags item=caseTag}
-                  <span class="label label-primary" style="background-color: {$caseTag.background_color}">{$caseTag.name}</span>
+                  <span class="badge label label-primary" style="background-color: {$caseTag.background_color}">{$caseTag.name}</span>
                 {/foreach}
             </div>
           {else}


### PR DESCRIPTION
## Overview
This PR fix the issue for case type label class on review application pages.

Scope: Point 4 from https://compucorp.atlassian.net/browse/MMB-398

This fix was for this ticket - https://compucorp.atlassian.net/browse/MMB-325 (Passed testing)

## Before

![Screenshot 2024-06-04 at 1 02 28 PM](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/131177317/d9f19e72-b16f-4a6e-88b7-60ca0f87b5a6)


## After

![Screenshot 2024-06-04 at 1 01 32 PM](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/131177317/7cd9dbec-edb6-42fa-a903-b6070402e19d)


## Technical Details
- Added `badge` class for case tag label, this will not make any impact on the old SSP pages
![Screenshot 2024-06-04 at 1 07 10 PM](https://github.com/compucorp/uk.co.compucorp.civiawards/assets/131177317/0853936c-49d8-4c18-8a7d-06d854c434a9)