### PR TITLE
THFSPRT-6: Add Support For File Fields In Application Reviews

### DIFF
--- a/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
+++ b/ang/civiawards/reviews-tab/directives/reviews-case-tab-content.directive.js
@@ -90,6 +90,10 @@
             entity_id: '$value.id',
             entity_type: 'Activity',
             'custom_group.name': { IN: applicantReviewCustomGroups }
+          },
+          'api.attachment.getsingle': {
+            entity_id: '$value.id',
+            entity_table: 'civicrm_activity'
           }
         });
       }).then(function (response) {
@@ -123,6 +127,10 @@
         activity['api.CustomValue.gettreevalues'].values.map(function (fieldSet) {
           Object.keys(fieldSet.fields).forEach(function (key) {
             var field = fieldSet.fields[key];
+            if (field.html_type === 'File' && activity['api.attachment.getsingle'].id) {
+              field.value.display =
+                '<a href="' + activity['api.attachment.getsingle'].url + '" target="_blank">' + activity['api.attachment.getsingle'].name + '</a>';
+            }
             var newKey = key + field.id;
             fieldSet.fields[newKey] = Object.assign({ id: field.id }, field);
             delete fieldSet.fields[key];
@@ -140,6 +148,7 @@
 
         delete activity['api.OptionValue.getsingle'];
         delete activity['api.CustomValue.gettreevalues'];
+        delete activity['api.attachment.getsingle'];
 
         return activity;
       });

--- a/templates/CRM/CiviAwards/Form/AwardReview.tpl
+++ b/templates/CRM/CiviAwards/Form/AwardReview.tpl
@@ -92,7 +92,13 @@
           {if $isReviewFromSsp}
             <div class="ssp-form-control-description text-muted"> {$element.help_post} </div>
           {/if}
-          <div class="{$form_group_field_class}">{$form[$element.name].html}</div>
+          <div class="{$form_group_field_class}">
+            {if $form[$element.name].type === 'file' && $existingFileName && $existingFileUrl}
+              <a href="{$existingFileUrl}" target="_blank">{$existingFileName}</a>
+            {else}
+              {$form[$element.name].html}
+            {/if}
+          </div>
           <div class="clear"></div>
         </div>
       {/foreach}


### PR DESCRIPTION
## Overview
This pr adds support for file type fields in review application forms.

## Before
The support did not exist and any files uploaded through application review form were not saved.

## After
Now the files can be added to file type fields while reviewing the application and the uploaded file can be accessed as well through applicant review activity or reviews screen
<img width="1792" alt="Screenshot 2024-11-18 at 2 16 25 PM" src="https://github.com/user-attachments/assets/e1f20ed3-b018-4bb6-ae09-233546fe7e45">
