### PR TITLE
COMCL-953: Move Angular Settings To Settings Class

### DIFF
--- a/CRM/CiviAwards/Settings.php
+++ b/CRM/CiviAwards/Settings.php
@@ -1,0 +1,36 @@
+<?php
+
+use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
+use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
+
+/**
+ * Get a list of settings for angular pages.
+ */
+class CRM_CiviAwards_Settings {
+
+  /**
+   * Get a list of settings for angular pages.
+   */
+  public static function getBaseSettings(): array {
+    $options = ['awardSubtypes' => 'civiawards_award_subtype'];
+
+    OptionValuesHelper::setToJsVariables($options);
+
+    return $options;
+  }
+
+  /**
+   * Get a list of settings for payment tab.
+   */
+  public static function getPaymentTabSettings(): array {
+    $options = ['payment_types' => 'budget_line_type'];
+
+    OptionValuesHelper::setToJsVariables($options);
+
+    $financeManagementSettingService = new FinanceManagementSettingService();
+    $options['instances_finance_support'] = $financeManagementSettingService->get();
+
+    return $options;
+  }
+
+}

--- a/ang/civiawards-base.ang.php
+++ b/ang/civiawards-base.ang.php
@@ -9,13 +9,7 @@
  */
 
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
-use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
 
-$options = [
-  'awardSubtypes' => 'civiawards_award_subtype',
-];
-
-OptionValuesHelper::setToJsVariables($options);
 expose_permissions();
 
 /**
@@ -43,7 +37,7 @@ function get_awards_base_js_files() {
 
 return [
   'js' => get_awards_base_js_files(),
-  'settings' => $options,
+  'settingsFactory' => ['CRM_CiviAwards_Settings', 'getBaseSettings'],
   'requires' => [
     'civicase-base',
     'api4',

--- a/ang/civiawards-payments-tab.ang.php
+++ b/ang/civiawards-payments-tab.ang.php
@@ -9,17 +9,6 @@
  */
 
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
-use CRM_CiviAwards_Service_FinanceManagementSetting as FinanceManagementSettingService;
-use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
-
-$financeManagementSettingService = new FinanceManagementSettingService();
-$options = [
-  'payment_types' => 'budget_line_type',
-];
-
-OptionValuesHelper::setToJsVariables($options);
-
-$options['instances_finance_support'] = $financeManagementSettingService->get();
 
 /**
  * Get a list of JS files.
@@ -36,7 +25,7 @@ function get_awards_payments_tab_js_files() {
 
 return [
   'js' => get_awards_payments_tab_js_files(),
-  'settings' => $options,
+  'settingsFactory' => ['CRM_CiviAwards_Settings', 'getPaymentTabSettings'],
   'requires' => [
     'civiawards-base',
   ],


### PR DESCRIPTION
## Overview
Previously all the settings needed for angular pages was being passed as plain array but to be compatible with new civicrm version the settings are being migrated to a settings class which fixes a warning on civicrm status page about unsupported settings.

## Before
![Screenshot 2024-11-27 at 20 41 24](https://github.com/user-attachments/assets/60bba554-50f8-4cd0-afad-9c528d213159)

## After
No such warnings are displayed
