### PR TITLE
RSESPRT-319: Allow Access To Review Custom Groups For Users With Review permission

### DIFF
--- a/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
+++ b/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
@@ -1,0 +1,110 @@
+<?php
+
+use Civi\API\Event\AuthorizeEvent;
+use Civi\API\Event\RespondEvent;
+use Civi\API\Event\Event;
+use Civi\Api4\Generic\Result;
+use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
+
+/**
+ * Allow custom group access to users with review permission.
+ */
+class CRM_CiviAwards_Event_Listener_AlterCustomGroupPermission {
+
+  /**
+   * Allow custom group access to users with review permission.
+   *
+   * @param Civi\API\Event\AuthorizeEvent $event
+   *   API Authorize Event Object.
+   */
+  public static function authorize(AuthorizeEvent $event) {
+    if (!self::shouldRun($event)) {
+      return;
+    }
+
+    $event->setAuthorized(TRUE);
+  }
+
+  /**
+   * Restrict to review custom groups for users with review permission.
+   *
+   * @param Civi\API\Event\RespondEvent $event
+   *   API Respond Event Object.
+   */
+  public static function respond(RespondEvent $event) {
+    if (!self::shouldRun($event)) {
+      return;
+    }
+
+    $reviewCustomGroupIds = self::getReviewCustomGroupIds();
+    $result = $event->getResponse();
+    $apiRequest = $event->getApiRequest();
+
+    foreach ($result as $customGroup) {
+      $fieldName = $apiRequest['entity'] === 'CustomGroup' ? 'id' : 'custom_group_id';
+
+      if (empty($customGroup[$fieldName]) || !in_array($customGroup[$fieldName], $reviewCustomGroupIds)) {
+        $event->setResponse(new Result());
+        break;
+      }
+    }
+  }
+
+  /**
+   * Determines if the processing will run.
+   *
+   * @param Civi\API\Event\Event $event
+   *   Api request data.
+   *
+   * @return bool
+   *   TRUE if processing should run, FALSE otherwise.
+   */
+  protected static function shouldRun(Event $event): bool {
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] != 4) {
+      return FALSE;
+    }
+
+    if (!CRM_Core_Permission::check(AwardPermission::REVIEW_FIELD_SET_PERM) ||
+      (CRM_Core_Permission::check('access all custom data') && CRM_Core_Permission::check('administer CiviCRM'))) {
+      return FALSE;
+    }
+
+    return in_array($apiRequest['entity'], ['CustomGroup', 'CustomField']) && $apiRequest['action'] === 'get';
+  }
+
+  /**
+   * Get Ids of review custom group.
+   *
+   * @return array
+   *   Ids of review custom group.
+   */
+  private static function getReviewCustomGroupIds(): array {
+    $reviewCustomGroups = [];
+    $reviewActivityType = civicrm_api3('OptionValue', 'get', [
+      'return' => ['value'],
+      'sequential' => 1,
+      'option_group_id' => 'activity_type',
+      'name' => CRM_CiviAwards_Setup_CreateApplicantReviewActivityType::APPLICANT_REVIEW,
+    ]);
+
+    if (empty($reviewActivityType['values'][0]['value'])) {
+      return $reviewCustomGroups;
+    }
+
+    $reviewActivityTypeId = $reviewActivityType['values'][0]['value'];
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'return' => ['id'],
+      'sequential' => 1,
+      'extends' => 'Activity',
+      'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $reviewActivityTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+    ]);
+
+    if (!empty($result['values'])) {
+      $reviewCustomGroups = array_column($result['values'], 'id');
+    }
+
+    return $reviewCustomGroups;
+  }
+
+}

--- a/CRM/CiviAwards/Event/Listener/AlterOptionValuePermission.php
+++ b/CRM/CiviAwards/Event/Listener/AlterOptionValuePermission.php
@@ -5,12 +5,12 @@ use Civi\Api4\Generic\AbstractAction;
 use CRM_CiviAwards_Hook_AlterAPIPermissions_Award as AwardPermission;
 
 /**
- * Award filter while fetching cases.
+ * Allow option value access to users with review permission.
  */
-class CRM_CiviAwards_Event_Listener_AlterPermission {
+class CRM_CiviAwards_Event_Listener_AlterOptionValuePermission {
 
   /**
-   * Fetches cases by the given award filters.
+   * Allow option value access to users with review permission.
    *
    * @param \Civi\API\Event\AuthorizeEvent $event
    *   API Prepare Event Object.

--- a/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-field-selection.html
@@ -29,7 +29,7 @@
         ng-repeat="reviewField in model.reviewFields | filter: model.searchText"
         ng-click="model.toggleReviewField(reviewField)">
         <td>{{reviewField.label}}</td>
-        <td>{{reviewField['api.CustomGroup.getvalue']}}</td>
+        <td>{{reviewField['custom_group_title']}}</td>
         <td align="center">
           <input
             ng-checked="!!model.findReviewFieldByID(reviewField.id)"

--- a/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
+++ b/ang/civiawards/award-creation/directives/review-fields/review-fields-table.directive.html
@@ -28,7 +28,7 @@
       ng-repeat="reviewField in additionalDetails.selectedReviewFields | orderBy: 'weight'"
       ng-if="additionalDetails.selectedReviewFields.length > 0">
       <td>{{getReviewFieldData(reviewField.id, 'label')}}</td>
-      <td>{{getReviewFieldData(reviewField.id, 'api.CustomGroup.getvalue')}}</td>
+      <td>{{getReviewFieldData(reviewField.id, 'custom_group_title')}}</td>
       <td>
         <a
           class="crm-weight-arrow" ng-if="$index > 0"

--- a/ang/test/civiawards/award-creation/directives/award.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/award.directive.spec.js
@@ -310,7 +310,7 @@
               end_date: AwardAdditionalDetailsMockData.end_date,
               award_subtype: AwardAdditionalDetailsMockData.award_subtype,
               award_manager: ['2', '1'],
-              review_fields: [{ id: '19', required: '0', weight: 1 }],
+              review_fields: [{ id: 19, required: '0', weight: 1 }],
               is_template: true
             });
           });

--- a/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
+++ b/ang/test/civiawards/award-creation/directives/review-fields/review-fields-table.directive.spec.js
@@ -1,33 +1,26 @@
 (function (_) {
   describe('civiawardReviewFieldsTable', () => {
-    var $rootScope, $controller, $scope, $q, civicaseCrmApi, ReviewFieldsMockData,
+    var $rootScope, $controller, $scope, $q, ReviewFieldsMockData,
       AwardAdditionalDetailsMockData, dialogService, crmApi4;
 
     beforeEach(module('civiawards.templates', 'civiawards', 'civicase.data', 'civiawards.data', function ($provide) {
-      $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
       $provide.value('crmApi4', jasmine.createSpy('crmApi4'));
       $provide.value('dialogService', jasmine.createSpyObj('dialogService', ['open', 'close']));
     }));
 
-    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_,
+    beforeEach(inject((_$q_, _$controller_, _$rootScope_,
       _ReviewFieldsMockData_, _AwardAdditionalDetailsMockData_, _dialogService_, _crmApi4_) => {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
       crmApi4 = _crmApi4_;
-      civicaseCrmApi = _civicaseCrmApi_;
       ReviewFieldsMockData = _ReviewFieldsMockData_;
       AwardAdditionalDetailsMockData = _AwardAdditionalDetailsMockData_.get();
       $scope = $rootScope.$new();
 
       dialogService.dialogs = {};
-      civicaseCrmApi.and.returnValue($q.resolve([
-        { values: ReviewFieldsMockData }
-      ]));
-      crmApi4.and.returnValue($q.resolve([
-        { values: ReviewFieldsMockData }
-      ]));
+      crmApi4.and.returnValue($q.resolve(ReviewFieldsMockData));
 
       $scope.$digest();
     }));
@@ -129,15 +122,15 @@
 
       it('displays the already saved review fields', () => {
         expect($scope.additionalDetails.selectedReviewFields).toEqual([{
-          id: '19',
+          id: 19,
           required: true,
           weight: 1
         }, {
-          id: '20',
+          id: 20,
           required: false,
           weight: 2
         }, {
-          id: '45',
+          id: 45,
           required: false,
           weight: 3
         }]);

--- a/ang/test/mocks/data/award-additional-details.data.js
+++ b/ang/test/mocks/data/award-additional-details.data.js
@@ -11,15 +11,15 @@
       award_manager: ['2', '1'],
       is_template: true,
       review_fields: [{
-        id: '19',
+        id: 19,
         weight: 1,
         required: '1'
       }, {
-        id: '20',
+        id: 20,
         weight: 2,
         required: '0'
       }, {
-        id: '45',
+        id: 45,
         weight: 3,
         required: '0'
       }]

--- a/ang/test/mocks/data/review-fields.data.js
+++ b/ang/test/mocks/data/review-fields.data.js
@@ -3,7 +3,7 @@
 
   module.constant('ReviewFieldsMockData', [
     {
-      id: '19',
+      id: 19,
       custom_group_id: '8',
       name: 'Goals_Scored',
       label: 'Goals Scored',
@@ -18,7 +18,7 @@
       column_name: 'goals_scored_19',
       in_selector: '0'
     }, {
-      id: '20',
+      id: 20,
       custom_group_id: '8',
       name: 'Number_of_Dribbles_per_game',
       label: 'Number of Dribbles per game',
@@ -33,7 +33,7 @@
       column_name: 'number_of_dribbles_per_game_20',
       in_selector: '0'
     }, {
-      id: '45',
+      id: 45,
       custom_group_id: '9',
       name: 'Age',
       label: 'Age',

--- a/civiawards.php
+++ b/civiawards.php
@@ -23,7 +23,19 @@ function civiawards_civicrm_config(&$config) {
 
   Civi::dispatcher()->addListener(
     'civi.api.authorize',
-    ['CRM_CiviAwards_Event_Listener_AlterPermission', 'authorize'],
+    ['CRM_CiviAwards_Event_Listener_AlterOptionValuePermission', 'authorize'],
+    10
+  );
+
+  Civi::dispatcher()->addListener(
+    'civi.api.authorize',
+    ['CRM_CiviAwards_Event_Listener_AlterCustomGroupPermission', 'authorize'],
+    10
+  );
+
+  Civi::dispatcher()->addListener(
+    'civi.api.respond',
+    ['CRM_CiviAwards_Event_Listener_AlterCustomGroupPermission', 'respond'],
     10
   );
 }


### PR DESCRIPTION
## Overview
Allow users with award review permission to access custom groups that are configured to be used as review fields.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/a45460c4-a8f3-4a35-8979-39454c494399)


## After
![screen_recording_after](https://github.com/user-attachments/assets/b6855a7f-9fd9-4f87-81b5-4d7b16c861e6)
