### PR TITLE
BTHASPRT-47: Fix Award Type Display Table

### DIFF
--- a/ang/civiawards-base/services/applicant-management-workflow.service.js
+++ b/ang/civiawards-base/services/applicant-management-workflow.service.js
@@ -178,7 +178,7 @@
                   managers: _.map(
                     awardDetails.award_manager,
                     function (managerID) {
-                      return ContactsCache.getCachedContact(managerID).display_name;
+                      return ContactsCache.getCachedContact(managerID)?.display_name ?? '';
                     }
                   )
                 }


### PR DESCRIPTION
## Overview
This PR counters an edge case when a manager for a case type has been soft deleted then the case type page does not show any record at all.

## Before
No records are displayed if any of the case type manager has been soft deleted
<img width="1792" alt="Screenshot 2025-04-15 at 4 04 50 PM" src="https://github.com/user-attachments/assets/799b45f9-b4bb-4f29-b809-1defdf675360" />


## After
All records are displayed only the manager column is empty for a case type if the manager's contact record has been soft deleted
<img width="1792" alt="Screenshot 2025-04-15 at 4 04 28 PM" src="https://github.com/user-attachments/assets/4a6a00bd-27c8-425e-8e44-6074efc7266a" />
