### PR TITLE
NEUSPRT-456: Set workflow subtype field label to current instance label

### DIFF
--- a/ang/civiawards-workflow/filters/directives/workflow-list-filter-subtype.html
+++ b/ang/civiawards-workflow/filters/directives/workflow-list-filter-subtype.html
@@ -1,5 +1,5 @@
 <div ng-controller="CiviAwardWorkflowFilterController">
-  <label>{{ts('Award Subtypes')}}</label>
+  <label>{{:: ts('%1 Subtypes', { 1: currentCaseCategory.label.charAt(0).toUpperCase() + currentCaseCategory.label.slice(1) }) }}</label>
   <input
     class="form-control"
     crm-ui-select="{

--- a/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
+++ b/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.controller.js
@@ -13,12 +13,14 @@
    * @param {Function} isApplicationManagementScreen is application management screen function
    * @param {object} CaseTypeCategory case type category service
    * @param {object} civicaseCrmUrl civicrm url service
+   * @param {string} currentCaseCategory The current case type category name
    */
   function AddAwardDashboardActionButtonController ($scope, $routeParams,
     $window, canCreateOrEditAwards, isApplicationManagementScreen,
-    CaseTypeCategory, civicaseCrmUrl) {
+    CaseTypeCategory, civicaseCrmUrl, currentCaseCategory) {
     $scope.isVisible = isVisible;
     $scope.redirectToAwardsCreationScreen = redirectToAwardsCreationScreen;
+    $scope.currentCaseCategory = CaseTypeCategory.findById(currentCaseCategory);
 
     /**
      * Displays the Add Award button when on the awards dashboard and the user can create awards.

--- a/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.html
+++ b/ang/civiawards/dashboard/directives/add-award-dashboard-action-button.html
@@ -4,5 +4,5 @@
   ng-click="redirectToAwardsCreationScreen()"
   class="btn btn-primary civicase__dashboard__action-btn civicase__dashboard__action-btn--light">
   <i class="material-icons">add_circle</i>
-  {{ts('Create new award')}}
+  {{:: ts('Create new %1', { 1: currentCaseCategory.label }) }}
 </a>


### PR DESCRIPTION
## Overview
Before this PR In some instances, after creating a new ‘Application Management’ type category, the label is displayed as ‘Award’ instead of the actual category name.  

## Before
![image](https://github.com/user-attachments/assets/03bded1a-2388-443f-9748-a07cf33a46b5)


## After
![image](https://github.com/user-attachments/assets/f668f116-d311-4c88-a644-f39ebfba054f)