### PR TITLE
CIVIMMM-364: Optimize Event Listener

### DIFF
--- a/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
+++ b/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
@@ -65,12 +65,16 @@ class CRM_CiviAwards_Event_Listener_AlterCustomGroupPermission {
       return FALSE;
     }
 
+    if (!in_array($apiRequest['entity'], ['CustomGroup', 'CustomField']) || $apiRequest['action'] !== 'get') {
+      return FALSE;
+    }
+
     if (!CRM_Core_Permission::check(AwardPermission::REVIEW_FIELD_SET_PERM) ||
       (CRM_Core_Permission::check('access all custom data') && CRM_Core_Permission::check('administer CiviCRM'))) {
       return FALSE;
     }
 
-    return in_array($apiRequest['entity'], ['CustomGroup', 'CustomField']) && $apiRequest['action'] === 'get';
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR optimizes the CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php event listener by checking the api entity and action before checking for the permissions. For one particular request this does n ot bring much benefit but this was getting called a lot of time in a single page load like contact view and combined for all the calls it does bring some good impact in terms of page load.