### PR TITLE
ESESPRT-219: Fix Contribution Creation

### DIFF
--- a/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
+++ b/CRM/CiviAwards/Event/Listener/AlterCustomGroupPermission.php
@@ -36,9 +36,13 @@ class CRM_CiviAwards_Event_Listener_AlterCustomGroupPermission {
       return;
     }
 
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest->getCheckPermissions() === FALSE) {
+      return;
+    }
+
     $reviewCustomGroupIds = self::getReviewCustomGroupIds();
     $result = $event->getResponse();
-    $apiRequest = $event->getApiRequest();
 
     foreach ($result as $customGroup) {
       $fieldName = $apiRequest['entity'] === 'CustomGroup' ? 'id' : 'custom_group_id';


### PR DESCRIPTION
## Overview
This PR fixes an issue with contribution creation for non admin users with **CiviAwards: Access review fields** permission.

## Before
Any non admin user with **CiviAwards: Access review fields** permission was not able to create a contribution.

## After
Contributions are getting created correctly for admin and non admin users.

## Technical Details
While creating the contribution in [this](https://github.com/compucorp/io.compuco.financeextras/blob/master/Civi/Financeextras/Hook/Post/UpdateContributionExchangeRate.php) hook we update the contributions exchange rate related custom fields and this is the part that was failing for non admin users.

The reason was that in [this](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/289) PR we added an event listener for allowing the  access to custom groups that are configured to be used as review fields for users with **CiviAwards: Access review fields** but in the same listener we restricted the access to any other custom group or fields due to which when we fetched the exchange rate related custom fields it fails even if we are fetching without permission enforcement.

This PR fixes the issue by respecting the checkPermissions flag on the api request and we only restrict the access if this flag is set to true.